### PR TITLE
Create audit trail for event locations

### DIFF
--- a/client/controllers/geolocations.coffee
+++ b/client/controllers/geolocations.coffee
@@ -32,7 +32,7 @@ Template.locationSelect2.onRendered ->
     $(".select2-container").css("width", "100%")
   )
 
-Template.locationList.helpers
+Template.location.helpers
   formatLocation: (location) ->
     return formatLocation(location.displayName, location.subdivision, location.countryName)
 

--- a/client/stylesheets/globals.import.styl
+++ b/client/stylesheets/globals.import.styl
@@ -122,6 +122,9 @@ table tr:last-child
   h3
     margin 0
 
+.panel > p
+  padding 15px
+
 .default-fullWidth
   background ll-gray
 

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -46,31 +46,44 @@ template(name="locationList")
   .panel.panel-default
     .panel-heading
       h3 Locations
-    .panel-body
-      if locations.length
-        if currentUser
-          .form-horizontal
-            each locations
-              .form-group
-                .col-sm-12
-                  button.btn.btn-danger.btn-sm.remove-location(type="button")
-                    i.fa.fa-times
-                  a(href="{{url}}") {{formatLocation(this)}}
-        else
-          ul
-            each locations
-              li.location-list
-                a(href="{{url}}") {{formatLocation(this)}}
-      else
-        p No locations are associated with this event.
-      if currentUser
-        .form-horizontal
+    if currentUser
+      .panel-body.comments-container
+        .form-horizontal.comment-form
           .form-group
             .col-md-12
               +locationSelect2
           .form-group
             .col-lg-4.col-lg-offset-8.col-md-12
               button#add-locations.btn.btn-primary.btn-block(type="button") Add Locations
+    if locations.length
+      ul.list-group
+        each locations
+          li.list-group-item
+            .row
+              .col-md-10
+                +location
+              .col-md-2
+                if currentUser
+                  button.btn.btn-danger.btn-sm.remove-location(type="button") Delete
+    else
+      p No locations are associated with this event.
+
+template(name="location")
+  a(role="button" href="#{{_id}}" data-toggle="collapse") {{formatLocation(this)}}
+  .collapse(id="{{_id}}").space-top-2
+    .row
+      label.col-md-3 Geonames Link
+      .col-md-9
+        p
+          a(href="{{url}}") {{formatLocation(this)}}
+    .row
+      label.col-md-3 Added By
+      .col-md-9
+        p {{addedByUserName}}
+    .row
+      label.col-md-3 Added On
+      .col-md-9
+        p {{addedDate}}
 
 template(name="articles")
   .panel.panel-default
@@ -105,7 +118,7 @@ template(name="article")
         a.ref-link(href="{{url}}" target="_blank") {{url}}
       .col-md-2
         if currentUser
-          button.btn.btn-default.btn-sm.delete-article("article-id" = _id) Delete
+          button.btn.btn-danger.btn-sm.delete-article("article-id" = _id) Delete
 
 template(name="locationModal")
   .modal.fade(role="dialog")

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -58,32 +58,32 @@ template(name="locationList")
     if locations.length
       ul.list-group
         each locations
-          li.list-group-item
-            .row
-              .col-md-10
-                +location
-              .col-md-2
-                if currentUser
-                  button.btn.btn-danger.btn-sm.remove-location(type="button") Delete
+          +location
     else
       p No locations are associated with this event.
 
 template(name="location")
-  a(role="button" href="#{{_id}}" data-toggle="collapse") {{formatLocation(this)}}
-  .collapse(id="{{_id}}").space-top-2
+  li.list-group-item
     .row
-      label.col-md-3 Geonames Link
-      .col-md-9
-        p
-          a(href="{{url}}") {{formatLocation(this)}}
-    .row
-      label.col-md-3 Added By
-      .col-md-9
-        p {{addedByUserName}}
-    .row
-      label.col-md-3 Added On
-      .col-md-9
-        p {{addedDate}}
+      .col-sm-10.space-btm-2
+        a(role="button" href="#{{_id}}" data-toggle="collapse") {{formatLocation(this)}}
+        .collapse(id="{{_id}}").space-top-2
+          .row
+            label.col-md-3 Geonames Link
+            .col-md-9
+              p
+                a(href="{{url}}") {{displayName}}
+          .row
+            label.col-md-3 Added By
+            .col-md-9
+              p {{addedByUserName}}
+          .row
+            label.col-md-3 Added On
+            .col-md-9
+              p {{addedDate}}
+      .col-sm-2.col-xs-6
+        if currentUser
+          button.btn.btn-danger.btn-sm.btn-block.remove-location(type="button") Delete
 
 template(name="articles")
   .panel.panel-default
@@ -114,11 +114,11 @@ template(name="articles")
 template(name="article")
   li.list-group-item
     .row
-      .col-md-10
+      .col-sm-10
         a.ref-link(href="{{url}}" target="_blank") {{url}}
-      .col-md-2
+      .col-sm-2.col-xs-6
         if currentUser
-          button.btn.btn-danger.btn-sm.delete-article("article-id" = _id) Delete
+          button.btn.btn-danger.btn-sm.btn-block.delete-article("article-id" = _id) Delete
 
 template(name="locationModal")
   .modal.fade(role="dialog")

--- a/collections/geolocations.coffee
+++ b/collections/geolocations.coffee
@@ -20,6 +20,7 @@ Meteor.methods
       
       for location in locations
         if existingLocations.indexOf(location.geonameId.toString()) is -1
+          user = Meteor.user()
           geolocation = {
             userEventId: eventId,
             geonameId: location.geonameId,
@@ -29,7 +30,10 @@ Meteor.methods
             countryName: location.countryName,
             latitude: location.latitude,
             longitude: location.longitude,
-            url: Meteor.call("generateGeonamesUrl", location.geonameId)
+            url: Meteor.call("generateGeonamesUrl", location.geonameId),
+            addedByUserId: user._id,
+            addedByUserName: user.profile.name,
+            addedDate: new Date()
           }
           Geolocations.insert(geolocation)
     else


### PR DESCRIPTION
I restyled the location section so the layout matches the articles section. Now each location link expands a details section that contains the geonames link, the user who added it, and the date it was added. The delete button still looks weird on extra small view ports though. But I didn't want to make it fill all 12 columns because that looked even more cluttered.

I keep using styling from the comments stylesheet for these sections. I think at some point it should be renamed/rewritten to describe event sections without the naming being specific to comments.