### PR TITLE
Admins can delete EIDR C events

### DIFF
--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -17,8 +17,14 @@ Template.userEvent.helpers
     return Template.instance().editState.get()
 
 Template.userEvent.events
-  "click #edit, click #cancel-edit": (event, template) ->
+  "click .edit-link, click #cancel-edit": (event, template) ->
     template.editState.set(not template.editState.get())
+  "click .delete-link": (event, template) ->
+    if confirm("Are you sure you want to delete this event?")
+      Meteor.call("deleteUserEvent", @_id, (error, result) ->
+        if not error
+          Router.go('user-events')
+      )
   "submit #editEvent": (event, template) ->
     event.preventDefault()
     valid = event.target.eventName.checkValidity()
@@ -44,10 +50,10 @@ Template.createEvent.events
       return
     newEvent = e.target.eventName.value
     summary = e.target.eventSummary.value
-    
+
     $new = $("#location-select2")
     locations = []
-    
+
     for option in $new.select2("data")
       locations.push({
         geonameId: option.item.geonameId,
@@ -58,7 +64,7 @@ Template.createEvent.events
         longitude: option.item.lng,
         subdivision: option.item.adminName1
       })
-    
+
     Meteor.call("addUserEvent", newEvent, summary, locations, (error, result) ->
       if result
         Router.go('user-event', {_id: result})

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -84,7 +84,7 @@ Router.route "/create-event",
 
 Router.route "/contact-us",
   name: 'contact-us'
-  
+
 Router.route "/user-events",
   name: 'user-events'
 

--- a/client/stylesheets/header.import.styl
+++ b/client/stylesheets/header.import.styl
@@ -37,7 +37,7 @@
 .navbar-nav .open .dropdown-menu
   background-color secondary-light
 
-.dropdown-menu
+.navbar-nav .dropdown-menu
   > li > a
     padding 20px
 

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -8,10 +8,10 @@ template(name="userEvent")
               with userEvent
                 form#editEvent.form-horizontal
                   .form-group
-                    .col-sm-2.space-btm-1
-                      button#save-edit.btn.btn-primary.btn-block(type='submit') Save
                     .col-sm-2
                       button#cancel-edit.btn.btn-default.btn-block(type='button') Cancel
+                    .col-sm-2.space-btm-1
+                      button#save-edit.btn.btn-primary.btn-block(type='submit') Save
                   .form-group
                     .col-sm-12
                       input.form-control.input-lg(type='text', name='eventName', value='{{eventName}}', placeholder="Event name", required)
@@ -20,26 +20,35 @@ template(name="userEvent")
                       textarea.form-control(name="eventSummary", placeholder="Event summary", rows="15") {{summary}}
             else
               with userEvent
+                if isInRole "admin"
+                  .row
+                    .col-sm-2.space-btm-2
+                      .dropdown
+                        button.btn.btn-default.dropdown-toggle(type="button" data-toggle="dropdown")
+                          | Admin Options
+                          span.caret
+                        ul.dropdown-menu
+                          li
+                            a.edit-link(href="#") Edit
+                          li
+                            a.delete-link(href="#") Delete
                 .row
-                  .col-sm-2.col-md-push-10
-                    if isInRole "admin"
-                      button#edit.btn.btn-default.btn-lg.btn-block Edit
-                  .col-sm-10.col-md-pull-2.space-btm-2
+                  .col-sm-10
                     h1 {{eventName}}
-                    .col-sm-2.space-btm-1
-                      button.btn.btn-default.btn-block(type="button" data-target="#shareLink" data-toggle="collapse")
-                        i.fa.fa-share
-                        | Share
-                  #shareLink.row.collapse
-                    .col-sm-12.shareLink
-                      .panel.panel-default
-                        .panel-body
-                          p Share this event by copying the direct link to this page below.
-                          .input-group
-                            input#eventLink.form-control(type="text" readonly value="{{urlFor 'user-event'}}")
-                            span.input-group-btn
-                              button#copyLink.btn.btn-default(type="button" data-clipboard-target="#eventLink")
-                                i.fa.fa-clipboard
+                  .col-sm-2.space-btm-1
+                    button.btn.btn-default.btn-block(type="button" data-target="#shareLink" data-toggle="collapse")
+                      i.fa.fa-share
+                      | Share
+                #shareLink.row.collapse
+                  .col-sm-12.shareLink
+                    .panel.panel-default
+                      .panel-body
+                        p Share this event by copying the direct link to this page below.
+                        .input-group
+                          input#eventLink.form-control(type="text" readonly value="{{urlFor 'user-event'}}")
+                          span.input-group-btn
+                            button#copyLink.btn.btn-default(type="button" data-clipboard-target="#eventLink")
+                              i.fa.fa-clipboard
                 .row
                   .col-sm-10.space-btm-2
                     h5 Created by {{createdByUserName}} on {{creationDate}}
@@ -54,7 +63,7 @@ template(name="userEvent")
                   .col-md-12
                     +summary
 
-  .container.tables
+  .container
     .row
       .col-lg-6
         +locationList

--- a/collections/userEvents.coffee
+++ b/collections/userEvents.coffee
@@ -8,7 +8,7 @@ if Meteor.isServer
 
   Meteor.publish "userEvent", (eidID) ->
     UserEvents.find({_id: eidID})
-  
+
   Meteor.publish "userEvents", () ->
     UserEvents.find()
 
@@ -25,7 +25,7 @@ Meteor.methods
       trimmedName = name.trim()
       user = Meteor.user()
       now = new Date()
-      
+
       if trimmedName.length isnt 0
         UserEvents.insert({
           eventName: trimmedName,
@@ -40,7 +40,7 @@ Meteor.methods
           if result
             Meteor.call("addEventLocations", result, locations)
         )
-  
+
   updateUserEvent: (id, name, summary) ->
     if Roles.userIsInRole(Meteor.userId(), ['admin'])
       user = Meteor.user()
@@ -51,7 +51,10 @@ Meteor.methods
         lastModifiedByUserId: user._id,
         lastModifiedByUserName: user.profile.name
       }})
-  
+  deleteUserEvent: (id) ->
+    if Roles.userIsInRole(Meteor.userId(), ['admin'])
+      UserEvents.remove(id)
+
   updateUserEventLastModified: (id) ->
     user = Meteor.user()
     if user


### PR DESCRIPTION
I combined the edit and delete options into a dropdown menu under a button that says "Admin Options". I don't like that the dropdown menu covers the event name when it's open, maybe we can find somewhere else to put the button. I'm not sure what the reason for an event being deleted would be so I didn't really see a need to do a soft delete at this point in time.