### PR TITLE
Save associated articles for each location

### DIFF
--- a/client/controllers/article.coffee
+++ b/client/controllers/article.coffee
@@ -1,4 +1,4 @@
 Template.article.events
   "click .delete-article": (e) ->
-    if window.confirm("Delete article?")
-      grid.Articles.remove(@_id)
+    if window.confirm("Are you sure you want to delete this article?\nAll locations mentioned only in this article will be deleted as well.")
+      Meteor.call("removeEventArticle", @_id)

--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -22,7 +22,7 @@ Template.articles.events
     scrapeLocations = e.target.scrapeLocations.checked
 
     if article.length isnt 0
-      Meteor.call("addEventArticle", @userEvent._id, article, e.target.publishDate.value, (error, result) ->
+      Meteor.call("addEventArticle", templateInstance.data.userEvent._id, article, e.target.publishDate.value, (error, result) ->
         if not error
           e.target.article.value = ""
           e.target.publishDate.value = ""
@@ -32,7 +32,7 @@ Template.articles.events
             articleLocations = []
             existingLocations = []
 
-            for loc in @locations
+            for loc in templateInstance.data.locations
               existingLocations.push(loc.geonameId.toString())
 
             Modal.show("loadingModal")
@@ -47,3 +47,22 @@ Template.articles.events
               Modal.show("locationModal", {userEventId:templateInstance.data.userEvent._id, suggestedLocations: articleLocations, articleUrl: article})
             )
       )
+
+Template.articleSelect2.onRendered ->
+  templateData = Template.instance().data
+  
+  $(document).ready(() ->
+    $input = $("#" + templateData.selectId)
+    
+    $input.select2({
+      placeholder: "Select at least one article"
+      multiple: true
+    })
+    
+    if templateData.selected
+      $input.val(templateData.selected).trigger("change")
+    #$(".select2-container").css("width", "100%")
+  )
+
+Template.articleSelect2.onDestroyed ->
+  $("#" + Template.instance().data.selectId).select2("destroy")

--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -20,30 +20,30 @@ Template.articles.events
       return
     article = e.target.article.value.trim()
     scrapeLocations = e.target.scrapeLocations.checked
-    
+
     if article.length isnt 0
       Meteor.call("addEventArticle", @userEvent._id, article, e.target.publishDate.value, (error, result) ->
         if not error
           e.target.article.value = ""
           e.target.publishDate.value = ""
           e.target.scrapeLocations.checked = false
-          
+
           if scrapeLocations
             articleLocations = []
             existingLocations = []
-            
+
             for loc in @locations
               existingLocations.push(loc.geonameId.toString())
-            
+
             Modal.show("loadingModal")
-            
+
             Meteor.call("getArticleLocations", article, (error, result) ->
               if result and result.length
                 for loc in result
                   if existingLocations.indexOf(loc.geonameId) is -1
                     articleLocations.push(loc)
-              
+
               Modal.hide()
-              Modal.show("locationModal", {userEventId:templateInstance.data.userEvent._id, suggestedLocations: articleLocations})
+              Modal.show("locationModal", {userEventId:templateInstance.data.userEvent._id, suggestedLocations: articleLocations, articleUrl: article})
             )
       )

--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -24,6 +24,7 @@ Template.articles.events
     if article.length isnt 0
       Meteor.call("addEventArticle", templateInstance.data.userEvent._id, article, e.target.publishDate.value, (error, result) ->
         if not error
+          articleId = result
           e.target.article.value = ""
           e.target.publishDate.value = ""
           e.target.scrapeLocations.checked = false
@@ -44,7 +45,11 @@ Template.articles.events
                     articleLocations.push(loc)
 
               Modal.hide()
-              Modal.show("locationModal", {userEventId:templateInstance.data.userEvent._id, suggestedLocations: articleLocations, articleUrl: article})
+              Modal.show("locationModal", {
+                userEventId:templateInstance.data.userEvent._id,
+                suggestedLocations: articleLocations,
+                article: {articleId: articleId, url: article}
+              })
             )
       )
 
@@ -55,13 +60,12 @@ Template.articleSelect2.onRendered ->
     $input = $("#" + templateData.selectId)
     
     $input.select2({
-      placeholder: "Select at least one article"
       multiple: true
     })
     
     if templateData.selected
       $input.val(templateData.selected).trigger("change")
-    #$(".select2-container").css("width", "100%")
+    $(".select2-container").css("width", "100%")
   )
 
 Template.articleSelect2.onDestroyed ->

--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -50,7 +50,7 @@ Template.createEvent.events
       return
     newEvent = e.target.eventName.value
     summary = e.target.eventSummary.value
-
+    
     Meteor.call("addUserEvent", newEvent, summary, (error, result) ->
       if result
         Router.go('user-event', {_id: result})

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -99,4 +99,4 @@ Router.route "/user-event/:_id",
   data: ->
     userEvent: UserEvents().findOne({'_id': @params._id})
     articles: Articles().find({'userEventId': @params._id}, {sort: {publishDate: -1}}).fetch()
-    locations: Geolocations().find({'userEventId': @params._id}).fetch()
+    locations: Geolocations().find({'userEventId': @params._id}, {sort: {displayName: 1}}).fetch()

--- a/client/views/createEvent.jade
+++ b/client/views/createEvent.jade
@@ -4,7 +4,7 @@ template(name="createEvent")
       .row
         .col-md-12
           h1 Create Emergence Event
- 
+
           form#add-event.form-horizontal(novalidate)
             .form-group
               label.control-label.col-sm-2 Event Name

--- a/client/views/locationSelect2.jade
+++ b/client/views/locationSelect2.jade
@@ -1,2 +1,0 @@
-template(name="locationSelect2")
-  select#location-select2.form-control.select2(name='location')

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -88,10 +88,7 @@ template(name="locationList")
               select#location-select2.form-control.select2(name='location')
           .form-group
             .col-md-12
-              select#article-select2.form-control.select2(name='locationArticle')
-                option(value="")
-                each articles
-                  option(value="{{_id}}") {{url}}
+              +articleSelect2 selectId="article-select2" articles=articles
           .form-group
             .col-lg-4.col-lg-offset-8.col-md-12
               button#add-location.btn.btn-primary.btn-block(type="button") Add Location
@@ -121,6 +118,21 @@ template(name="location")
             label.col-md-3 Added On
             .col-md-9
               p {{addedDate}}
+          .row
+            label.col-md-3 Sources
+            .col-md-7
+              if isEditingSources
+                +articleSelect2 selectId=articleSelectId articles=allArticles selected=selectedArticles
+              else
+                each sourceArticles
+                  p
+                    a(href="{{url}}") {{url}}
+            .col-md-2
+              if isEditingSources
+                button.save-edit-sources.btn.btn-default(type="button") Save
+                button.cancel-edit-sources.btn.btn-default(type="button") Cancel
+              else
+                button.edit-sources.btn.btn-default(type="button") Edit Sources
       .col-sm-2.col-xs-6
         if currentUser
           button.btn.btn-danger.btn-sm.btn-block.remove-location(type="button") Delete
@@ -202,3 +214,8 @@ template(name="loadingModal")
           p
             i.fa.fa-circle-o-notch.fa-spin
             | Processing article
+
+template(name="articleSelect2")
+  select.article-select2.form-control.select2(id="{{selectId}}" multiple)
+    each articles
+      option(value="{{url}}") {{url}}

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -66,9 +66,9 @@ template(name="userEvent")
   .container
     .row
       .col-lg-6
-        +locationList
-      .col-lg-6
         +articles
+      .col-lg-6
+        +locationList
 
 template(name="summary")
   if userEvent.summary
@@ -82,16 +82,19 @@ template(name="locationList")
       h3 Locations
     if currentUser
       .panel-body.comments-container
-        .form-horizontal.comment-form
-          .form-group
-            .col-md-12
-              select#location-select2.form-control.select2(name='location')
-          .form-group
-            .col-md-12
-              +articleSelect2 selectId="article-select2" articles=articles
-          .form-group
-            .col-lg-4.col-lg-offset-8.col-md-12
-              button#add-location.btn.btn-primary.btn-block(type="button") Add Location
+        if articles.length
+          .form-horizontal.comment-form
+            .form-group
+              label.col-lg-3.control-label Location
+              .col-lg-9
+                select#location-select2.form-control.select2(name='location')
+            .form-group
+              label.col-lg-3.control-label Source Articles
+              .col-lg-9
+                +articleSelect2 selectId="article-select2" articles=articles
+            .form-group
+              .col-lg-4.col-lg-offset-8.col-md-12
+                button#add-location.btn.btn-primary.btn-block(type="button") Add Location
     if locations.length
       ul.list-group
         each locations
@@ -104,38 +107,42 @@ template(name="location")
     .row
       .col-sm-10.space-btm-2
         a(role="button" href="#{{_id}}" data-toggle="collapse") {{formatLocation(this)}}
-        .collapse(id="{{_id}}").space-top-2
-          .row
-            label.col-md-3 Geonames Link
-            .col-md-9
-              p
-                a(href="{{url}}") {{displayName}}
-          .row
-            label.col-md-3 Added By
-            .col-md-9
-              p {{addedByUserName}}
-          .row
-            label.col-md-3 Added On
-            .col-md-9
-              p {{addedDate}}
-          .row
-            label.col-md-3 Sources
-            .col-md-7
-              if isEditingSources
-                +articleSelect2 selectId=articleSelectId articles=allArticles selected=selectedArticles
-              else
-                each sourceArticles
-                  p
-                    a(href="{{url}}") {{url}}
-            .col-md-2
-              if isEditingSources
-                button.save-edit-sources.btn.btn-default(type="button") Save
-                button.cancel-edit-sources.btn.btn-default(type="button") Cancel
-              else
-                button.edit-sources.btn.btn-default(type="button") Edit Sources
       .col-sm-2.col-xs-6
         if currentUser
           button.btn.btn-danger.btn-sm.btn-block.remove-location(type="button") Delete
+    .collapse(id="{{_id}}").space-top-2
+      .row
+        label.col-md-3 Geonames Link
+        .col-md-9
+          p
+            a(href="{{url}}") {{displayName}}
+      .row
+        label.col-md-3 Added By
+        .col-md-9
+          p {{addedByUserName}}
+      .row
+        label.col-md-3 Added On
+        .col-md-9
+          p {{addedDate}}
+      .row
+        label.col-md-3 Sources
+        .col-md-9
+          if isEditingSources
+            +articleSelect2 selectId=articleSelectId articles=allArticles selected=selectedArticles
+          else
+            each sourceArticles
+              p
+                a(href="{{url}}") {{url}}
+      if currentUser
+        .row.space-top-2
+          if isEditingSources
+            .col-sm-3.col-xs-6.col-md-offset-3
+              button.cancel-edit-sources.btn.btn-default.btn-block(type="button") Cancel
+            .col-sm-3.col-xs-6
+               button.save-edit-sources.btn.btn-primary.btn-block(type="button") Save
+          else
+            .col-sm-3.col-xs-6.col-md-offset-3
+              button.edit-sources.btn.btn-default.btn-block(type="button") Edit Sources
 
 template(name="articles")
   .panel.panel-default
@@ -177,9 +184,9 @@ template(name="article")
         if publishDate
           p
             small {{publishDate}}
-      .col-md-2
+      .col-sm-2.col-xs-6
         if currentUser
-          button.btn.btn-danger.btn-sm.btn-block.delete-article("article-id"=_id) Delete
+          button.btn.btn-danger.btn-sm.btn-block.delete-article Delete
 
 template(name="locationModal")
   .modal.fade(role="dialog")
@@ -218,4 +225,4 @@ template(name="loadingModal")
 template(name="articleSelect2")
   select.article-select2.form-control.select2(id="{{selectId}}" multiple)
     each articles
-      option(value="{{url}}") {{url}}
+      option(value="{{_id}}") {{url}}

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -85,10 +85,16 @@ template(name="locationList")
         .form-horizontal.comment-form
           .form-group
             .col-md-12
-              +locationSelect2
+              select#location-select2.form-control.select2(name='location')
+          .form-group
+            .col-md-12
+              select#article-select2.form-control.select2(name='locationArticle')
+                option(value="")
+                each articles
+                  option(value="{{_id}}") {{url}}
           .form-group
             .col-lg-4.col-lg-offset-8.col-md-12
-              button#add-locations.btn.btn-primary.btn-block(type="button") Add Locations
+              button#add-location.btn.btn-primary.btn-block(type="button") Add Location
     if locations.length
       ul.list-group
         each locations

--- a/collections/articles.coffee
+++ b/collections/articles.coffee
@@ -38,6 +38,14 @@ Meteor.methods
           # months are 0 indexed, so subtract 1 when creating the date
           insertArticle.publishDate = new Date(dateSplit[2], dateSplit[0] - 1, dateSplit[1])
         
-        Articles.insert(insertArticle)
+        newId = Articles.insert(insertArticle)
         
         Meteor.call("updateUserEventLastModified", eventId)
+        
+        return newId
+  removeEventArticle: (id) ->
+    if Meteor.user()
+      removed = Articles.findOne(id)
+      Articles.remove(id)
+      Meteor.call("removeOrphanedLocations", removed.userEventId, id)
+      Meteor.call("updateUserEventLastModified", removed.userEventId)

--- a/collections/geolocations.coffee
+++ b/collections/geolocations.coffee
@@ -12,11 +12,18 @@ if Meteor.isServer
 Meteor.methods
   generateGeonamesUrl: (geonameId) ->
     return "http://www.geonames.org/" + geonameId
-  addEventLocations: (eventId, locations) ->
+  addEventLocations: (eventId, articles, locations) ->
     if Meteor.user()
       existingLocations = []
+      sources = []
+      
       for loc in Geolocations.find({userEventId: eventId}).fetch()
         existingLocations.push(loc.geonameId)
+      
+      for article in articles
+        sources.push({
+          url: article
+        })
 
       for location in locations
         if existingLocations.indexOf(location.geonameId.toString()) is -1
@@ -34,6 +41,7 @@ Meteor.methods
             addedByUserId: user._id,
             addedByUserName: user.profile.name,
             addedDate: new Date()
+            sourceArticles: sources
           }
           Geolocations.insert(geolocation)
 

--- a/collections/geolocations.coffee
+++ b/collections/geolocations.coffee
@@ -17,7 +17,7 @@ Meteor.methods
       existingLocations = []
       for loc in Geolocations.find({userEventId: eventId}).fetch()
         existingLocations.push(loc.geonameId)
-      
+
       for location in locations
         if existingLocations.indexOf(location.geonameId.toString()) is -1
           user = Meteor.user()
@@ -36,7 +36,7 @@ Meteor.methods
             addedDate: new Date()
           }
           Geolocations.insert(geolocation)
-          
+
           Meteor.call("updateUserEventLastModified", eventId)
     else
         throw new Meteor.Error(403, "Not authorized")

--- a/collections/userEvents.coffee
+++ b/collections/userEvents.coffee
@@ -37,7 +37,7 @@ Meteor.methods
           lastModifiedByUserId: user._id,
           lastModifiedByUserName: user.profile.name
         })
-
+  
   updateUserEvent: (id, name, summary) ->
     if Roles.userIsInRole(Meteor.userId(), ['admin'])
       user = Meteor.user()


### PR DESCRIPTION
Since a source article must be chosen when adding a location, I hid the location form when no articles have been added to the event yet and took away the ability to add multiple locations at once on that form. The sources are listed in the expandable location details section and can be edited there as well. When an article is removed, it's references are also removed from all locations for that event. If a location has only the removed article as its source, the location is deleted as well.