### PR TITLE
create initial user record upon server startup

### DIFF
--- a/server/accounts.coffee
+++ b/server/accounts.coffee
@@ -1,3 +1,15 @@
 Accounts.emailTemplates.siteName = "EIDR-Connect"
-
 Accounts.emailTemplates.from = "EIDR-C <no-reply@eha.io>"
+
+Meteor.startup ->
+  unless Meteor.users.find().count()
+    userData = Meteor.settings.private.initial_user
+    if userData
+      console.log "[ Creating initial user with email #{userData.email} … ]"
+      Accounts.createUser userData
+      newUserRecord = Meteor.users.findOne('emails.address': userData.email)
+      if newUserRecord
+        Roles.addUsersToRoles(newUserRecord._id, ['admin'])
+    else
+      console.warn '[ Meteor.settings.private.initial_user object \
+                          is required to create the initial user record ]'

--- a/server/accounts.coffee
+++ b/server/accounts.coffee
@@ -5,7 +5,8 @@ Meteor.startup ->
   unless Meteor.users.find().count()
     userData = Meteor.settings.private.initial_user
     if userData
-      console.log "[ Creating initial user with email #{userData.email} … ]"
+      userData.profile = { name: 'Admin' }
+      console.log "[ Creating initial user with email #{userData.email} ]"
       Accounts.createUser userData
       newUserRecord = Meteor.users.findOne('emails.address': userData.email)
       if newUserRecord


### PR DESCRIPTION
Creates initial admin user record based on this sample information provided via settings.json:
```
  "private": {
    "initial_user": {
      "email": "tech@ecohealthalliance.org",
      "password": "bottledwhiskeyisnogoodifitsonlynoon"
    }
  }
```
