### PR TITLE
Change case counts to incident reports

### DIFF
--- a/client/controllers/count.coffee
+++ b/client/controllers/count.coffee
@@ -1,4 +1,4 @@
 Template.count.events
   "click .delete-count": (e) ->
-    if window.confirm("Are you sure you want to delete this count?")
+    if window.confirm("Are you sure you want to delete this incident report?")
       Meteor.call("removeEventCount", @_id)

--- a/client/controllers/counts.coffee
+++ b/client/controllers/counts.coffee
@@ -6,6 +6,9 @@ formatLocation = (name, sub, country) ->
     text += ", " + country
   return text
 
+Template.counts.onCreated ->
+  @incidentType = new ReactiveVar("")
+
 Template.counts.onRendered ->
   $(document).ready(() ->
     $(".datePicker").datetimepicker({
@@ -18,9 +21,18 @@ Template.counts.onRendered ->
     })
   )
 
+Template.counts.helpers
+  showCountForm: ->
+    type = Template.instance().incidentType.get()
+    return type is "cases" or type is "deaths"
+  showOtherForm: ->
+    return Template.instance().incidentType.get() is "other"
+
 Template.counts.events
+  "change select[name='incidentType']": (e, template) ->
+    template.incidentType.set($(e.target).val())
   "submit #add-count": (e, templateInstance) ->
-    event.preventDefault()
+    e.preventDefault()
     $articleSelect = templateInstance.$(e.target.countArticles)
     validURL = e.target.countArticles.checkValidity()
     unless validURL
@@ -31,9 +43,17 @@ Template.counts.events
       toastr.error('Please provide a valid date.')
       e.target.publishDate.focus()
       return
-    unless e.target.cases.checkValidity() || e.target.deaths.checkValidity()
-      toastr.error('Please provide a valid case or death count.')
-      e.target.cases.focus()
+    unless e.target.incidentType.checkValidity()
+      toastr.error('Please select an incident type.')
+      e.target.incidentType.focus()
+      return
+    if e.target.count and e.target.count.checkValidity() is false
+      toastr.error('Please provide a valid count.')
+      e.target.count.focus()
+      return
+    if e.target.other and e.target.other.value.trim().length is 0
+      toastr.error('Please specify the incident type.')
+      e.target.other.focus()
       return
 
     article = ""
@@ -55,16 +75,17 @@ Template.counts.events
         longitude: option.item.lng,
       })
 
-    if article.length isnt 0
-      Meteor.call("addEventCount", templateInstance.data.userEvent._id, article, allLocations, e.target.cases.value, e.target.deaths.value, e.target.date.value, (error, result) ->
-        if not error
-          countId = result
-          $articleSelect.select2('val', '')
-          e.target.date.value = ""
-          e.target.cases.value = ""
-          e.target.deaths.value = ""
-          templateInstance.$("#count-location-select2").select2('val', '')
-          toastr.success("Count added to event.")
-        else
-          toastr.error(error.reason)
-      )
+    incidentCount = if e.target.count then e.target.count.value.trim() else e.target.other.value.trim()
+
+    Meteor.call("addEventCount", templateInstance.data.userEvent._id, article, allLocations, e.target.incidentType.value, incidentCount, e.target.date.value, (error, result) ->
+      if not error
+        countId = result
+        $articleSelect.select2('val', '')
+        e.target.date.value = ""
+        e.target.incidentType.value = ""
+        templateInstance.incidentType.set("")
+        templateInstance.$("#count-location-select2").select2('val', '')
+        toastr.success("Incident report added to event.")
+      else
+        toastr.error(error.reason)
+    )

--- a/client/controllers/incidentReport.coffee
+++ b/client/controllers/incidentReport.coffee
@@ -1,4 +1,4 @@
-Template.count.events
+Template.incidentReport.events
   "click .delete-count": (e) ->
     if window.confirm("Are you sure you want to delete this incident report?")
       Meteor.call("removeEventCount", @_id)

--- a/client/controllers/incidentReports.coffee
+++ b/client/controllers/incidentReports.coffee
@@ -6,10 +6,10 @@ formatLocation = (name, sub, country) ->
     text += ", " + country
   return text
 
-Template.counts.onCreated ->
+Template.incidentReports.onCreated ->
   @incidentType = new ReactiveVar("")
 
-Template.counts.onRendered ->
+Template.incidentReports.onRendered ->
   $(document).ready(() ->
     $(".datePicker").datetimepicker({
       format: "M/D/YYYY",
@@ -21,14 +21,14 @@ Template.counts.onRendered ->
     })
   )
 
-Template.counts.helpers
+Template.incidentReports.helpers
   showCountForm: ->
     type = Template.instance().incidentType.get()
     return type is "cases" or type is "deaths"
   showOtherForm: ->
     return Template.instance().incidentType.get() is "other"
 
-Template.counts.events
+Template.incidentReports.events
   "change select[name='incidentType']": (e, template) ->
     template.incidentType.set($(e.target).val())
   "submit #add-count": (e, templateInstance) ->
@@ -77,7 +77,7 @@ Template.counts.events
 
     incidentCount = if e.target.count then e.target.count.value.trim() else e.target.other.value.trim()
 
-    Meteor.call("addEventCount", templateInstance.data.userEvent._id, article, allLocations, e.target.incidentType.value, incidentCount, e.target.date.value, (error, result) ->
+    Meteor.call("addIncidentReport", templateInstance.data.userEvent._id, article, allLocations, e.target.incidentType.value, incidentCount, e.target.date.value, (error, result) ->
       if not error
         countId = result
         $articleSelect.select2('val', '')

--- a/client/views/incidentReports.jade
+++ b/client/views/incidentReports.jade
@@ -1,0 +1,82 @@
+template(name="incidentReports")
+  .panel.panel-default
+    .panel-heading
+      h3 Incident Reports
+    .panel-body.comments-container
+      if currentUser
+        .comment-form
+          form#add-count.form-horizontal(novalidate)
+            .form-group
+              label.col-lg-3.control-label Article URL
+              .col-lg-9
+                +articleSelect2 selectId="countArticles" articles=articles
+            .form-group
+              label.col-lg-3.control-label Date
+              .col-lg-9
+                input.form-control.datePicker(type="text" name="date" data-DateTimePicker)
+            .form-group
+              label.col-lg-3.control-label Location
+              .col-lg-9
+                +locationSelect2 selectId="count-location-select2" multiple="true"
+            .form-group
+              label.col-lg-3.control-label Incident Type
+              .col-lg-9
+                select.form-control(name="incidentType" required)
+                  option(value="")
+                  option(value="cases") Case Count
+                  option(value="deaths") Death Count
+                  option(value="other") Other
+            .form-group
+              if showCountForm
+                label.col-lg-3.control-label Count
+                .col-lg-9
+                  input.form-control(name="count" type="number" min="0" required)
+              if showOtherForm
+                label.col-lg-3.control-label Specify Other
+                .col-lg-9
+                  input.form-control(name="other" type="text" required)
+            .form-group
+              .col-lg-4.col-lg-offset-8.col-sm-12
+                button.btn.btn-primary.btn-block(type="submit") Add Report
+    if counts.length
+      ul.list-group
+        each counts
+          +incidentReport
+    else
+      p No incident reports are associated with this event.
+
+template(name="incidentReport")
+  li.list-group-item
+    .form-horizontal
+      .row
+        .col-sm-10
+          each val in url
+            p
+              a.ref-link(href="{{val}}" target="_blank") {{val}}
+          if date
+            p
+              small {{date}}
+        .col-sm-2.col-xs-6
+          if currentUser
+            button.btn.btn-danger.btn-sm.btn-block.delete-count Delete
+      .row
+        .col-sm-2.control-label Location:
+        .col-sm-10
+          p.form-control-static
+            if locations.length
+              each locations
+                | {{name}}, {{displayName}}, {{countryName}}
+            else
+              | No location specified.
+      .row
+        if cases
+          +incidentDetails label="Cases" value=cases
+        if deaths
+          +incidentDetails label="Deaths" value=deaths
+        if specify
+          +incidentDetails label="Other" value=specify
+
+template(name="incidentDetails")
+  .col-sm-2.control-label {{label}}:
+  .col-sm-10
+    p.form-control-static {{value}}

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -259,7 +259,7 @@ template(name="articleSelect2")
 template(name="counts")
   .panel.panel-default
     .panel-heading
-      h3 Case/Death Counts
+      h3 Incident Reports
     .panel-body.comments-container
       if currentUser
         .comment-form
@@ -277,48 +277,64 @@ template(name="counts")
               .col-lg-9
                 +locationSelect2 selectId="count-location-select2" multiple="true"
             .form-group
-              label.col-lg-3.control-label Cases
+              label.col-lg-3.control-label Incident Type
               .col-lg-9
-                input.form-control.new-cases(name="cases" required type="number")
+                select.form-control(name="incidentType" required)
+                  option(value="")
+                  option(value="cases") Case Count
+                  option(value="deaths") Death Count
+                  option(value="other") Other
             .form-group
-              label.col-lg-3.control-label Deaths
-              .col-lg-9
-                input.form-control.new-deaths(name="deaths" required type="number")
+              if showCountForm
+                label.col-lg-3.control-label Count
+                .col-lg-9
+                  input.form-control(name="count" type="number" min="0" required)
+              if showOtherForm
+                label.col-lg-3.control-label Specify Other
+                .col-lg-9
+                  input.form-control(name="other" type="text" required)
             .form-group
               .col-lg-4.col-lg-offset-8.col-sm-12
-                button.btn.btn-primary.btn-block(type="submit") Add Count
+                button.btn.btn-primary.btn-block(type="submit") Add Report
     if counts.length
       ul.list-group
         each counts
           +count
     else
-      p No case/death counts are associated with this event.
+      p No incident reports are associated with this event.
 
 template(name="count")
   li.list-group-item
-    .row
-      .col-sm-10
-        each val in url
-          p
-            a.ref-link(href="{{val}}" target="_blank") {{val}}
-        if date
-          p
-            small {{date}}
-      .col-sm-2.col-xs-6
-        if currentUser
-          button.btn.btn-danger.btn-sm.btn-block.delete-count Delete
-    .row
-      .col-sm-2.text-right Locations:
-      if locations.length
+    .form-horizontal
+      .row
         .col-sm-10
-          each locations
-            p {{name}}, {{displayName}}, {{countryName}}
-      else
-        | No locations specified.
-    .row
-      if cases
-        .col-sm-2.text-right Cases:
-        .col-sm-2.text-left {{cases}}
-      if deaths
-        .col-sm-2.text-right Deaths:
-        .col-sm-2.text-left {{deaths}}
+          each val in url
+            p
+              a.ref-link(href="{{val}}" target="_blank") {{val}}
+          if date
+            p
+              small {{date}}
+        .col-sm-2.col-xs-6
+          if currentUser
+            button.btn.btn-danger.btn-sm.btn-block.delete-count Delete
+      .row
+        .col-sm-2.control-label Location:
+        .col-sm-10
+          p.form-control-static
+            if locations.length
+              each locations
+                {{name}}, {{displayName}}, {{countryName}}
+            else
+              | No location specified.
+      .row
+        if cases
+          +incident label="Cases" value=cases
+        if deaths
+          +incident label="Deaths" value=deaths
+        if specify
+          +incident label="Other" value=specify
+
+template(name="incident")
+  .col-sm-2.control-label {{label}}:
+  .col-sm-10
+    p.form-control-static {{value}}

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -71,7 +71,7 @@ template(name="userEvent")
         +locationList
     .row
       .col-lg-6
-        +counts
+        +incidentReports
 
 template(name="summary")
   if userEvent.summary
@@ -255,86 +255,3 @@ template(name="articleSelect2")
       option(value="")
     each articles
       option(value="{{_id}}") {{url}}
-
-template(name="counts")
-  .panel.panel-default
-    .panel-heading
-      h3 Incident Reports
-    .panel-body.comments-container
-      if currentUser
-        .comment-form
-          form#add-count.form-horizontal(novalidate)
-            .form-group
-              label.col-lg-3.control-label Article URL
-              .col-lg-9
-                +articleSelect2 selectId="countArticles" articles=articles
-            .form-group
-              label.col-lg-3.control-label Date
-              .col-lg-9
-                input.form-control.datePicker(type="text" name="date" data-DateTimePicker)
-            .form-group
-              label.col-lg-3.control-label Location
-              .col-lg-9
-                +locationSelect2 selectId="count-location-select2" multiple="true"
-            .form-group
-              label.col-lg-3.control-label Incident Type
-              .col-lg-9
-                select.form-control(name="incidentType" required)
-                  option(value="")
-                  option(value="cases") Case Count
-                  option(value="deaths") Death Count
-                  option(value="other") Other
-            .form-group
-              if showCountForm
-                label.col-lg-3.control-label Count
-                .col-lg-9
-                  input.form-control(name="count" type="number" min="0" required)
-              if showOtherForm
-                label.col-lg-3.control-label Specify Other
-                .col-lg-9
-                  input.form-control(name="other" type="text" required)
-            .form-group
-              .col-lg-4.col-lg-offset-8.col-sm-12
-                button.btn.btn-primary.btn-block(type="submit") Add Report
-    if counts.length
-      ul.list-group
-        each counts
-          +count
-    else
-      p No incident reports are associated with this event.
-
-template(name="count")
-  li.list-group-item
-    .form-horizontal
-      .row
-        .col-sm-10
-          each val in url
-            p
-              a.ref-link(href="{{val}}" target="_blank") {{val}}
-          if date
-            p
-              small {{date}}
-        .col-sm-2.col-xs-6
-          if currentUser
-            button.btn.btn-danger.btn-sm.btn-block.delete-count Delete
-      .row
-        .col-sm-2.control-label Location:
-        .col-sm-10
-          p.form-control-static
-            if locations.length
-              each locations
-                {{name}}, {{displayName}}, {{countryName}}
-            else
-              | No location specified.
-      .row
-        if cases
-          +incident label="Cases" value=cases
-        if deaths
-          +incident label="Deaths" value=deaths
-        if specify
-          +incident label="Other" value=specify
-
-template(name="incident")
-  .col-sm-2.control-label {{label}}:
-  .col-sm-10
-    p.form-control-static {{value}}

--- a/collections/counts.coffee
+++ b/collections/counts.coffee
@@ -20,7 +20,7 @@ if Meteor.isServer
       return Roles.userIsInRole(Meteor.userId(), ['admin'])
 
 Meteor.methods
-  addEventCount: (eventId, url, locations, type, count, date) ->
+  addIncidentReport: (eventId, url, locations, type, value, date) ->
     if url.length
       insertCount = {
         url: [url],
@@ -42,9 +42,9 @@ Meteor.methods
         insertCount.date = new Date(dateSplit[2], dateSplit[0] - 1, dateSplit[1])
 
       switch type
-        when "cases" then insertCount.cases = count
-        when "deaths" then insertCount.deaths = count
-        else insertCount.specify = count
+        when "cases" then insertCount.cases = value
+        when "deaths" then insertCount.deaths = value
+        else insertCount.specify = value
       newId = Counts.insert(insertCount)
       Meteor.call("updateUserEventLastModified", eventId)
       return newId

--- a/collections/counts.coffee
+++ b/collections/counts.coffee
@@ -20,7 +20,7 @@ if Meteor.isServer
       return Roles.userIsInRole(Meteor.userId(), ['admin'])
 
 Meteor.methods
-  addEventCount: (eventId, url, locations, cases, deaths, date) ->
+  addEventCount: (eventId, url, locations, type, count, date) ->
     if url.length
       insertCount = {
         url: [url],
@@ -41,8 +41,10 @@ Meteor.methods
         # months are 0 indexed, so subtract 1 when creating the date
         insertCount.date = new Date(dateSplit[2], dateSplit[0] - 1, dateSplit[1])
 
-      insertCount.cases = cases
-      insertCount.deaths = deaths
+      switch type
+        when "cases" then insertCount.cases = count
+        when "deaths" then insertCount.deaths = count
+        else insertCount.specify = count
       newId = Counts.insert(insertCount)
       Meteor.call("updateUserEventLastModified", eventId)
       return newId


### PR DESCRIPTION
I added a field for selecting the incident type, which toggles the following form element between a number input and a text input. In order to avoid database changes, I kept the case count, death count, and other specification values as separate document properties in the collection rather than having type and value fields.