### PR TITLE
prevent clicks from going through the legend container

### DIFF
--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -35,7 +35,9 @@ Template.articles.events
 
     if article.length isnt 0
       Meteor.call("addEventArticle", templateInstance.data.userEvent._id, article, e.target.publishDate.value, e.target.publishDateTZ.value, (error, result) ->
-        if not error
+        if error
+          toastr.error error.reason
+        else
           articleId = result
           e.target.article.value = ""
           e.target.publishDate.value = ""
@@ -86,10 +88,10 @@ Template.articleSelect2.helpers
     Meteor.defer ->
       $input = templateInstance.$("#" + templateData.selectId)
       options = {}
-      
+
       if templateData.multiple
         options.multiple = true
-      
+
       $input.select2(options)
 
       if templateData.selected


### PR DESCRIPTION
This PR prevents the clicks on the legend widget from going through to the map.
Also adds a warning toast when the user attempts to add an article which is already in the database.