### PR TITLE
Entering a location search term should close expanded rows

### DIFF
--- a/client/controllers/locationList.coffee
+++ b/client/controllers/locationList.coffee
@@ -59,6 +59,10 @@ Template.locationList.helpers
     }
 
 Template.locationList.events
+  "keyup .reactive-table-input": (event, template) ->
+    if event.target.value.length
+      template.$("tr").removeClass("details-open")
+      template.$("tr.tr-details").remove()
   "click #event-locations-table th": (event, template) ->
     template.$("tr").removeClass("details-open")
     template.$("tr.tr-details").remove()


### PR DESCRIPTION
I added a keyup event handler to the location filter that removes detail rows when a search term is entered.