### PR TITLE
Incident report / location tab navigation should be based on urls instead of events

### DIFF
--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -15,13 +15,13 @@ Template.userEvent.helpers
   isEditing: ->
     return Template.instance().editState.get()
   locationView: ->
-    currentRoute = Router.current().route.getName()
-    return currentRoute is "event-locations" or currentRoute is "user-event"
+    viewParam = Router.current().getParams()._view
+    return typeof viewParam is "undefined" or viewParam is "locations"
   incidentView: ->
-    return Router.current().route.getName() is "event-incidents"
+    return Router.current().getParams()._view is "incidents"
   view: ->
-    currentRoute = Router.current().route.getName()
-    if currentRoute is "event-incidents"
+    currentView = Router.current().getParams()._view
+    if currentView is "incidents"
       return "incidentReports"
     return "locationList"
   templateData: ->

--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -14,6 +14,18 @@ Template.userEvent.onRendered ->
 Template.userEvent.helpers
   isEditing: ->
     return Template.instance().editState.get()
+  locationView: ->
+    currentRoute = Router.current().route.getName()
+    return currentRoute is "event-locations" or currentRoute is "user-event"
+  incidentView: ->
+    return Router.current().route.getName() is "event-incidents"
+  view: ->
+    currentRoute = Router.current().route.getName()
+    if currentRoute is "event-incidents"
+      return "incidentReports"
+    return "locationList"
+  templateData: ->
+    return Template.instance().data
 
 Template.userEvent.events
   "click .edit-link, click #cancel-edit": (event, template) ->
@@ -39,9 +51,6 @@ Template.userEvent.events
         if not error
           template.editState.set(false)
       )
-  "click a[data-toggle='tab']": (e, template) ->
-    template.$(".reactive-table tr").removeClass("details-open")
-    template.$(".reactive-table tr.tr-details").remove()
 
 Template.createEvent.events
   "submit #add-event": (e) ->

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -91,36 +91,8 @@ Router.route "/contact-us",
 Router.route "/user-events",
   name: 'user-events'
 
-Router.route "/user-event/:_id",
+Router.route "/user-event/:_id/:_view?",
   name: 'user-event'
-  waitOn: ->
-    [
-      Meteor.subscribe "userEvent", @params._id
-      Meteor.subscribe "eventArticles", @params._id
-      Meteor.subscribe "eventIncidents", @params._id
-    ]
-  data: ->
-    userEvent: UserEvents().findOne({'_id': @params._id})
-    articles: Articles().find({'userEventId': @params._id}, {sort: {publishDate: -1}}).fetch()
-    incidents: Incidents().find({'userEventId': @params._id}, {sort: {date: -1}}).fetch()
-
-Router.route "/event-locations/:_id",
-  name: "event-locations"
-  template: "userEvent"
-  waitOn: ->
-    [
-      Meteor.subscribe "userEvent", @params._id
-      Meteor.subscribe "eventArticles", @params._id
-      Meteor.subscribe "eventIncidents", @params._id
-    ]
-  data: ->
-    userEvent: UserEvents().findOne({'_id': @params._id})
-    articles: Articles().find({'userEventId': @params._id}, {sort: {publishDate: -1}}).fetch()
-    incidents: Incidents().find({'userEventId': @params._id}, {sort: {date: -1}}).fetch()
-
-Router.route "/event-incidents/:_id",
-  name: "event-incidents"
-  template: "userEvent"
   waitOn: ->
     [
       Meteor.subscribe "userEvent", @params._id

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -103,3 +103,31 @@ Router.route "/user-event/:_id",
     userEvent: UserEvents().findOne({'_id': @params._id})
     articles: Articles().find({'userEventId': @params._id}, {sort: {publishDate: -1}}).fetch()
     incidents: Incidents().find({'userEventId': @params._id}, {sort: {date: -1}}).fetch()
+
+Router.route "/event-locations/:_id",
+  name: "event-locations"
+  template: "userEvent"
+  waitOn: ->
+    [
+      Meteor.subscribe "userEvent", @params._id
+      Meteor.subscribe "eventArticles", @params._id
+      Meteor.subscribe "eventIncidents", @params._id
+    ]
+  data: ->
+    userEvent: UserEvents().findOne({'_id': @params._id})
+    articles: Articles().find({'userEventId': @params._id}, {sort: {publishDate: -1}}).fetch()
+    incidents: Incidents().find({'userEventId': @params._id}, {sort: {date: -1}}).fetch()
+
+Router.route "/event-incidents/:_id",
+  name: "event-incidents"
+  template: "userEvent"
+  waitOn: ->
+    [
+      Meteor.subscribe "userEvent", @params._id
+      Meteor.subscribe "eventArticles", @params._id
+      Meteor.subscribe "eventIncidents", @params._id
+    ]
+  data: ->
+    userEvent: UserEvents().findOne({'_id': @params._id})
+    articles: Articles().find({'userEventId': @params._id}, {sort: {publishDate: -1}}).fetch()
+    incidents: Incidents().find({'userEventId': @params._id}, {sort: {date: -1}}).fetch()

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -66,16 +66,14 @@ template(name="userEvent")
       if incidents.length
         .row
           ul.nav.nav-tabs(role="tablist")
-            li.active(role="presentation")
-              a.location-tab(href="#locationTab" aria-control="location tab" role="tab" data-toggle="tab") Locations
-            li(role="presentation")
-              a.incident-tab(href="#incidentTab" aria-control="incident report tab" role="tab" data-toggle="tab") Incident Reports
+            li(class="{{#if locationView}}active{{/if}}" role="presentation")
+              a(href="{{pathFor route='event-locations' _id=userEvent._id}}") Locations
+            li(class="{{#if incidentView}}active{{/if}}" role="presentation")
+              a(href="{{pathFor route='event-incidents' _id=userEvent._id}}") Incident Reports
 
         .tab-content
-          #locationTab.tab-pane.active(role="tabpanel")
-            +locationList
-          #incidentTab.tab-pane(role="tabpanel")
-            +incidentReports
+          .tab-pane.active(role="tabpanel")
+            +Template.dynamic template=view data=templateData
       else
         .row
           +addIncidentReport

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -67,9 +67,9 @@ template(name="userEvent")
         .row
           ul.nav.nav-tabs(role="tablist")
             li(class="{{#if locationView}}active{{/if}}" role="presentation")
-              a(href="{{pathFor route='event-locations' _id=userEvent._id}}") Locations
+              a(href="{{pathFor route='user-event' _id=userEvent._id _view='locations'}}") Locations
             li(class="{{#if incidentView}}active{{/if}}" role="presentation")
-              a(href="{{pathFor route='event-incidents' _id=userEvent._id}}") Incident Reports
+              a(href="{{pathFor route='user-event' _id=userEvent._id _view='incidents'}}") Incident Reports
 
         .tab-content
           .tab-pane.active(role="tabpanel")


### PR DESCRIPTION
The initial event page load still uses the same route and url. Clicking the tabs will change between 2 new routes I added. It's annoying how the page jumps to the top after clicking a tab but I'm not sure of how to keep that from happening.