### PR TITLE
Add species and confirm status to incident report expanded table rows, and when travel related is not true, leave it blank instead of showing an X

### DIFF
--- a/client/controllers/incidentReport.coffee
+++ b/client/controllers/incidentReport.coffee
@@ -1,8 +1,4 @@
 Template.incidentReport.helpers
-  travelIcon: ->
-    if @travelRelated
-      return "fa-check"
-    return "fa-times"
   formatDate: (date) ->
     return moment(date).format("MMM D, YYYY")
 

--- a/client/views/incidentReports.jade
+++ b/client/views/incidentReports.jade
@@ -38,17 +38,14 @@ template(name="incidentReport")
               p.form-control-static {{formatLocation(this)}}
           else
             p.form-control-static No location specified.
-      if species
-        .row
-          .col-sm-2.control-label Species:
-          .col-sm-10
-            p.form-control-static
-              em {{species}}
-      if status
-        .row
-          .col-sm-2.control-label Status:
-          .col-sm-10
-            p.form-control-static {{status}}
+      .row
+        .col-sm-2.control-label Species:
+        .col-sm-10
+          p.form-control-static {{species}}
+      .row
+        .col-sm-2.control-label Status:
+        .col-sm-10
+          p.form-control-static {{status}}
       .row
         if cases
           +incidentDetails label="Cases" value=cases
@@ -59,8 +56,9 @@ template(name="incidentReport")
       .row
         .col-sm-2.control-label Travel Related:
         .col-sm-10
-          p.form-control-static
-            i.fa.fa-lg(class="{{travelIcon}}")
+          if travelRelated
+            p.form-control-static
+              i.fa.fa-lg.fa-check
 
 template(name="incidentDetails")
   .col-sm-2.control-label {{label}}:


### PR DESCRIPTION
The status and species fields were already being displayed in the incident details but only if they had values, so I took away the if that kept them from being shown when they were blank. And if the incident isn't travel related, the travel related field is blank rather than containing X.