### PR TITLE
Fix styling and text-sive of buttons

### DIFF
--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -6,7 +6,7 @@ Template.userEvent.onCreated ->
 
 Template.userEvent.onRendered ->
   $(document).ready ->
-    board = new Clipboard("#copyLink")
+    board = new Clipboard(".copy-link")
     $(document.body).on("focus", "#eventLink", ->
       $(this).select()
     )
@@ -36,7 +36,7 @@ Template.userEvent.helpers
     return Template.instance().data
 
 Template.userEvent.events
-  "click #copyLink": (event, template) ->
+  "click .copy-link": (event, template) ->
     toastr.success("Event link copied.")
   "click .edit-link, click #cancel-edit": (event, template) ->
     template.editState.set(not template.editState.get())

--- a/client/views/articles.jade
+++ b/client/views/articles.jade
@@ -18,7 +18,7 @@ template(name="articles")
             p There are no articles currently associated with this event.
           .col-lg-4.col-sm-12
             +sourceModalButton
-            button.btn.secondary-btn.btn-block.open-source-form(type="button")
+            button.btn.btn-primary.btn-block.open-source-form(type="button")
               i.fa.fa-plus-circle
               | Add Source
       .col-md-6.event-sources-detail
@@ -71,6 +71,6 @@ template(name="articleSelect2")
 
 template(name="sourceModalButton")
   if isInRole "admin"
-    button.btn.secondary-btn.btn-block.open-source-form(type="button")
+    button.btn.btn-primary.btn-block.open-source-form(type="button")
       i.fa.fa-plus-circle
       | Add Source

--- a/client/views/createAccount.jade
+++ b/client/views/createAccount.jade
@@ -22,4 +22,4 @@ template(name="createAccount")
                     | Grant Admin Rights
             .row
               .col-sm-3.col-sm-offset-7
-                button.btn.btn-primary.btn-lg.btn-block(type='submit') Add User
+                button.btn.btn-primary.btn-block.btn-spacious.btn-action(type='submit') Add User

--- a/client/views/incidentReports.jade
+++ b/client/views/incidentReports.jade
@@ -11,8 +11,8 @@ template(name="addIncidentReport")
   if currentUser
     .tab-form
       .row
-        .col-md-6.col-md-offset-3.col-sm-12
-          button.btn.secondary-btn.btn-block.open-incident-form(type="button")
+        .col-md-6.col-sm-12
+          button.btn.btn-primary.open-incident-form(type="button")
             i.fa.fa-plus-circle
             | Add Incident Report
 
@@ -80,7 +80,7 @@ template(name="incidentModal")
           else
             +incidentForm
         .modal-footer
-          button.btn.secondary-btn(type="button" data-dismiss="modal") Close
+          button.btn.btn-default(type="button" data-dismiss="modal") Close
           if add
-            button.btn.main-btn.save-modal-duplicate(type="button") Save then Duplicate
-          button.btn.main-btn.save-modal(type="button") Save
+            button.btn.btn-primary.save-modal-duplicate(type="button") Save then Duplicate
+          button.btn.btn-primary.save-modal(type="button") Save

--- a/client/views/sourceModal.jade
+++ b/client/views/sourceModal.jade
@@ -34,5 +34,5 @@ template(name="sourceModal")
                     input(type="checkbox" value="1" name="enhance" checked)
                     | Suggest incident reports
         .modal-footer
-          button.btn.secondary-btn(type="button" data-dismiss="modal") Close
-          button.btn.main-btn.save-modal(type="button") Save
+          button.btn.btn-default(type="button" data-dismiss="modal") Close
+          button.btn.btn-primary.save-modal(type="button") Save

--- a/client/views/splash.jade
+++ b/client/views/splash.jade
@@ -9,4 +9,4 @@ template(name="splash")
           | EID events can be compared and individual emergence events can be explored in depth.
     .row
       .col-md-4.col-md-offset-4
-        a.btn.btn-primary.btn-block(href="{{pathFor 'user-events'}}", role="button") View Tracked Events
+        a.btn.btn-primary.btn-block.btn-action.btn-spacious(href="{{pathFor 'user-events'}}", role="button") View Tracked Events

--- a/client/views/suggestedIncidentModal.jade
+++ b/client/views/suggestedIncidentModal.jade
@@ -7,5 +7,5 @@ template(name="suggestedIncidentModal")
         .modal-body
           +incidentForm
         .modal-footer
-          button.btn.secondary-btn.reject(type="button" data-dismiss="modal") Reject
-          button.btn.main-btn.save-modal(type="button") Confirm
+          button.btn.btn-default.reject(type="button" data-dismiss="modal") Reject
+          button.btn.btn-primary.save-modal(type="button") Confirm

--- a/client/views/suggestedIncidentsModal.jade
+++ b/client/views/suggestedIncidentsModal.jade
@@ -15,4 +15,4 @@ template(name="suggestedIncidentsModal")
               p.annotated-content=annotatedContent
         .modal-footer
           button.btn.btn-default(type="button" data-dismiss="modal") Close
-          button.btn.main-btn#add-suggestions(type="button") Add Confirmed Suggestions
+          button.btn.btn-primary#add-suggestions(type="button") Add Confirmed Suggestions

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -20,9 +20,9 @@ template(name="userEvent")
                     textarea.form-control(name="eventSummary" rows="15") {{summary}}
                 .form-group
                   .col-sm-2
-                    button#cancel-edit.btn.secondary-btn.btn-block(type='button') Cancel
+                    button#cancel-edit.btn.btn-default.btn-block(type='button') Cancel
                   .col-sm-2.space-btm-1
-                    button#save-edit.btn.main-btn.btn-block(type='submit') Save
+                    button#save-edit.btn.btn-primary.btn-block(type='submit') Save
           else
             with userEvent
               .row
@@ -66,7 +66,7 @@ template(name="summary")
       .col-sm-4.col-sm-offset-8.space-btm-1.space-top-1
         if isInRole "admin"
           .dropdown
-            button.btn.secondary-btn.btn-block.dropdown-toggle(type="button" data-toggle="dropdown" style="white-space: normal;")
+            button.btn.btn-default.btn-block.dropdown-toggle(type="button" data-toggle="dropdown" style="white-space: normal;")
               | Admin Options
               span.caret
             ul.dropdown-menu
@@ -92,7 +92,7 @@ template(name="summary")
             b{{lastModifiedByUserName}}
             |on {{formatDate lastModifiedDate}}
           td.col-md-2.gi
-            button#copyLink.btn.btn-xs.btn-default(type="button" data-clipboard-text="{{urlFor 'user-event'}}")
+            button.copy-link.btn.btn-xs.btn-default(type="button" data-clipboard-text="{{urlFor 'user-event'}}")
               i.fa.fa-share-alt
               | Copy Event Link
 

--- a/imports/stylesheets/buttons.import.styl
+++ b/imports/stylesheets/buttons.import.styl
@@ -1,43 +1,44 @@
+$success-btn-color = desaturate(lighten($positive, 45%), 20%)
+$warning-btn-color = lighten($warning, 50%)
+
 $btn-types = {
   '.btn-default': {
-    text-color: $primary
-    color: $l-gray
+    text: $primary
     border: $border-btn
-    bg: $ll-gray
+    bg: white
     bg-hover: $l-gray
   },
   '.btn-primary': {
-    text-color: $primary
-    color: darken($l-gray, 50%)
+    text: $primary
     border: $border-btn
     bg: $primary-light
-    bg-hover: $secondary
+    bg-hover: lighten($secondary, 10%)
   },
   '.btn-success': {
-    text-color: $primary
-    color: darken($l-gray, 50%)
-    border: $border-btn
-    bg: $positive
-    bg-hover: $secondary
+    text: $primary
+    border: darken($positive, 30%)
+    bg: $success-btn-color
+    bg-hover: darken($success-btn-color, 25%)
   }
   '.btn-danger': {
-    text-color: $primary
-    text-color-hover: white
-    color: $delete,
-    bg: lighten($delete, 90%)
+    text: $primary
+    text-hover: white
+    border: darken($delete, 30%)
+    bg: lighten($delete, 50%)
+    bg-hover: darken($delete, 10%)
   }
   '.btn-warning': {
-    text-color: $primary
-    color: $warning,
-    bg: lighten($warning, 90%)
+    text: $primary
+    border: darken($warning, 30%)
+    bg: $warning-btn-color
+    bg-hover: darken($warning-btn-color, 25%)
   }
 }
 
 $buttons()
   for $btn-type, $btn-type-props  in $btn-types
-    $text = $btn-type-props.text-color
-    $text-hover = $btn-type-props.text-color-hover or $text
-    $color = $btn-type-props.color
+    $text = $btn-type-props.text
+    $text-hover = $btn-type-props.text-hover or $text
     $bg = $btn-type-props.bg
     $bg-hover = $btn-type-props.bg-hover or lighten($bg, 40%)
     $border = $btn-type-props.border or $border-btn
@@ -50,7 +51,7 @@ $buttons()
         color $text-hover
         border-color darken($bg-hover, 20%)
       &:focus
-        border-color darken($color, 20%)
+        border-color darken($border, 20%)
         background saturate(darken($bg, 10%), 20%)
         color $text
       &:focus
@@ -67,13 +68,31 @@ $buttons()
           background $bg
           border-color lighten($border, 10%)
 
+$buttons()
+
 .btn
-  padding-top .75em
-  padding-bottom .75em
-  text-transform uppercase
-  font-size 1.25em
+  padding-top .5em
+  padding-bottom .5em
+  padding-left 1em
+  padding-right 1em
+  font-size 1em
   font-weight 300
   letter-spacing .03em
+
+.btn-delete
+  @extend .btn-danger
+
+.btn-confirm
+  @extend .btn-success
+
+.btn-spacious
+  padding-top .75em
+  padding-bottom .75em
+  font-size 1.25em
+
+.btn-action
+.btn-shouting
+  text-transform uppercase
 
 .btn-featured
   padding 1em 5em
@@ -91,5 +110,3 @@ $buttons()
 @media(max-width: $mobile-break)
   .btn-featured
     width 100%
-
-$buttons()

--- a/imports/stylesheets/events.import.styl
+++ b/imports/stylesheets/events.import.styl
@@ -26,7 +26,6 @@
       left 15px
 
 .reactive-table-columns-dropdown .dropdown-toggle
-  font-size 0
   &::before,
   &::after
     vAlign()
@@ -34,10 +33,8 @@
     @extend .font-awesome
     content '\f0db'
     padding-right 5px
-    font-size 16px
-  &::after
-    content 'Variables'
-    font-size 14px
+    line-height 0
+    margin-top -3px
 
 .dropdown-toggle-nav
   font-size 0
@@ -180,6 +177,3 @@ td.col-md-4.countCell.text-center
   font-style italic
   font-size 12px
   color #808080
-
-#copyLink
-  color #345e7e


### PR DESCRIPTION
Fixes up the customized set of bootstrap button classes.
Adds `.btn-delete` as alias for the `.btn-danger` and `.btn-confirm` for the `.btn-success`
Adds a few classes for more control over the styling of buttons:
`.btn-spacious` increases padding and font-size
`.btn-action` uppercases text (alias: `.shouting`)

Also removes `.main-btn` and `.secondary-btn` as the styles for those classes were removed at some point. Now we should use bootstraps btn syntax.

https://www.pivotaltracker.com/story/show/130077331