### PR TITLE
Event details edit modal

### DIFF
--- a/client/controllers/editEventModal.coffee
+++ b/client/controllers/editEventModal.coffee
@@ -1,0 +1,51 @@
+Template.editEventDetailsModal.onCreated ->
+  @confirmingDeletion = new ReactiveVar false
+
+Template.editEventDetailsModal.onRendered ->
+  instance = @
+  @$('#edit-event-modal').on 'show.bs.modal', (event) ->
+    instance.confirmingDeletion.set false
+    fieldToEdit = $(event.relatedTarget).data('editing')
+    # Wait for the the modal to open
+    # then focus input based on which edit button the user clicks
+    Meteor.setTimeout () ->
+      field = switch fieldToEdit
+        when 'disease' then 'input[name=eventDisease]'
+        when 'summary' then 'textarea'
+        else 'input:first'
+      instance.$(field).focus()
+    , 500
+
+Template.editEventDetailsModal.helpers
+  confirmingDeletion: ->
+    Template.instance().confirmingDeletion.get()
+
+Template.editEventDetailsModal.events
+  'submit #editEvent': (event, template) ->
+    event.preventDefault()
+    valid = event.target.eventName.checkValidity()
+    unless valid
+      toastr.error('Please provide a new name')
+      event.target.eventName.focus()
+      return
+    updatedName = event.target.eventName.value.trim()
+    updatedSummary = event.target.eventSummary.value.trim()
+    disease = event.target.eventDisease.value.trim()
+    if updatedName.length isnt 0
+      Meteor.call 'updateUserEvent', @_id, updatedName, updatedSummary, disease, (error, result) ->
+        if not error
+          $('#edit-event-modal').modal 'hide'
+
+  'click .delete-event': (event, instance) ->
+    instance.confirmingDeletion.set true
+
+  'click .back-to-editing': (event, instance) ->
+    instance.confirmingDeletion.set false
+
+  'click .delete-event-confirmation': (event, instance) ->
+    Meteor.call 'deleteUserEvent', @_id, (error, result) ->
+      if not error
+        instance.$('#edit-event-modal').modal('hide')
+        $('.modal-backdrop').remove()
+        $('body').removeClass 'modal-open'
+        Router.go 'user-events'

--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -40,12 +40,13 @@ Template.userEvent.events
     toastr.success("Event link copied.")
   "click .edit-link, click #cancel-edit": (event, template) ->
     template.editState.set(not template.editState.get())
-  "click .delete-link": (event, template) ->
-    if confirm("Are you sure you want to delete this event?")
-      Meteor.call("deleteUserEvent", @_id, (error, result) ->
-        if not error
-          Router.go('user-events')
-      )
+  "click .delete-event": (event, template) ->
+    console.log 'delete'
+    # Meteor.call("deleteUserEvent", @_id, (error, result) ->
+    #   if not error
+    #     Router.go('user-events')
+
+    # )
   "submit #editEvent": (event, template) ->
     event.preventDefault()
     valid = event.target.eventName.checkValidity()

--- a/client/controllers/userEvent.coffee
+++ b/client/controllers/userEvent.coffee
@@ -40,28 +40,6 @@ Template.userEvent.events
     toastr.success("Event link copied.")
   "click .edit-link, click #cancel-edit": (event, template) ->
     template.editState.set(not template.editState.get())
-  "click .delete-event": (event, template) ->
-    console.log 'delete'
-    # Meteor.call("deleteUserEvent", @_id, (error, result) ->
-    #   if not error
-    #     Router.go('user-events')
-
-    # )
-  "submit #editEvent": (event, template) ->
-    event.preventDefault()
-    valid = event.target.eventName.checkValidity()
-    unless valid
-      toastr.error('Please provide a new name')
-      event.target.eventName.focus()
-      return
-    updatedName = event.target.eventName.value.trim()
-    updatedSummary = event.target.eventSummary.value.trim()
-    disease = event.target.eventDisease.value.trim()
-    if updatedName.length isnt 0
-      Meteor.call("updateUserEvent", @_id, updatedName, updatedSummary, disease, (error, result) ->
-        if not error
-          template.editState.set(false)
-      )
 
 Template.createEvent.events
   "submit #add-event": (e) ->

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -3,31 +3,10 @@ template(name="userEvent")
     .row
       .event-head
         .basic-info
-          if isEditing
-            with userEvent
-              form#editEvent.form-horizontal
-                .form-group
-                  .col-md-12
-                    label.control-label Event Name
-                    input.form-control(type='text' name='eventName' value='{{eventName}}' required)
-                .form-group
-                  .col-md-12
-                    label.control-label Event Disease
-                    input.form-control(type="text" name="eventDisease" value="{{disease}}")
-                .form-group
-                  .col-md-12
-                    label.control-label Event Summary
-                    textarea.form-control(name="eventSummary" rows="15") {{summary}}
-                .form-group
-                  .col-sm-2
-                    button#cancel-edit.btn.btn-default.btn-block(type='button') Cancel
-                  .col-sm-2.space-btm-1
-                    button#save-edit.btn.btn-primary.btn-block(type='submit') Save
-          else
-            with userEvent
-              .row
-                .col-md-12
-                  +summary
+          with userEvent
+            .row
+              .col-md-12
+                +summary
 
       if incidents.length
         .row
@@ -49,52 +28,43 @@ template(name="userEvent")
           +articles
 
 template(name="summary")
-  .row
-    .col-md-6
-      .eventName.eventNameSummary {{eventName}}
+  .row.event-summary
+    .col-md-6.event-details
+      h1.event-name= eventName
+      if isInRole "admin"
+        i.fa.fa-edit.edit-event-details(data-toggle="modal" data-target="#edit-event-modal")
       p
         if disease
-          .diseaseName {{disease}}
+          .disease-name= disease
         else
           | No disease available.
-      p.abstract.eventSummary
+      p.abstract.event-summary
         if summary
-          | {{summary}}
+          | #{summary}
         else
           | No summary available.
     .col-md-6
       .col-sm-4.col-sm-offset-8.space-btm-1.space-top-1
-        if isInRole "admin"
-          .dropdown
-            button.btn.btn-default.btn-block.dropdown-toggle(type="button" data-toggle="dropdown" style="white-space: normal;")
-              | Admin Options
-              span.caret
-            ul.dropdown-menu
-              li
-                a.edit-link(href="#") Edit
-              li
-                a.delete-link(href="#") Delete
       table#countTable.col-md-12
         tr.col-md-12
-          td.col-md-6.countCell.countCellLeft.text-center
-            .col-md-12.countCellValue
-              {{caseCount}}
-            .col-md-12.countCellTitle INCIDENT REPORTS
-          td.col-md-6.countCell.text-center
-            .col-md-12.countCellValue
-              {{articleCount}}
-            .col-md-12.countCellTitle SOURCES
-        tr.col-md-12.countTableDetail
-          td.col-md-5.gi Created By:
-            b{{createdByUserName}}
-            |on {{formatDate creationDate}}
-          td.col-md-5.gi.giCellCenter Last Modified By:
-            b{{lastModifiedByUserName}}
-            |on {{formatDate lastModifiedDate}}
+          td.col-md-6.count-cell.count-cell-left.text-center
+            .col-md-12.count-cell-value= caseCount
+            .col-md-12.count-cell-title Incident Reports
+          td.col-md-6.count-cell.text-center
+            .col-md-12.count-cell-value= articleCount
+            .col-md-12.count-cell-title Sources
+        tr.col-md-12.count-table-detail
+          td.col-md-5.gi
+            span Created:
+            | {{formatDate creationDate}} by #{createdByUserName}
+          td.col-md-5.gi.gi-cell-center
+            span Last Modified:
+            | {{formatDate lastModifiedDate}} by #{lastModifiedByUserName}
           td.col-md-2.gi
             button.copy-link.btn.btn-xs.btn-default(type="button" data-clipboard-text="{{urlFor 'user-event'}}")
               i.fa.fa-share-alt
               | Copy Event Link
+  +editEventDetailsModal
 
 
 
@@ -133,14 +103,37 @@ template(name="location")
           ul
             each sources
              li
-                a(href="{{this}}") {{this}}
+                a(href=this)= this
                   i.fa.fa-external-link
       .form-group
         .col-md-12
           i.fa.fa-globe
-          a(href="http://www.geonames.org/{{id}}") {{name}}
+          a(href="http://www.geonames.org/{{id}}")= name
             i.fa.fa-external-link
       .form-group
         .col-md-12
           i.fa.fa-info-circle
           em Added on {{formatDate addedDate}}
+
+template(name="editEventDetailsModal")
+  #edit-event-modal.modal.fade(role="dialog")
+    .modal-dialog
+      .modal-content
+        form#editEvent
+          .modal-header
+            h4.modal-title Edit Event Details
+          .modal-body.clearfix
+            .form-group
+              label Event Name
+              input.form-control(type='text' name='eventName' value=eventName required)
+            .form-group
+              label Event Disease
+              input.form-control(type="text" name="eventDisease" value=disease)
+            .form-group
+              label Event Summary
+              textarea.form-control(name="eventSummary" rows="15")= summary
+
+          .modal-footer
+            button.btn.btn-danger.delete-event.pull-left(type="button") Delete Event
+            button.btn.btn-default(type="button" data-dismiss="modal") Close
+            button.btn.btn-success.btn-wide.save-modal(type="button") Save

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -30,19 +30,33 @@ template(name="userEvent")
 template(name="summary")
   .row.event-summary
     .col-md-6.event-details
-      h1.event-name= eventName
-      if isInRole "admin"
-        i.fa.fa-edit.edit-event-details(data-toggle="modal" data-target="#edit-event-modal")
-      p
+      .event-name-wrap
+        h1.event-name= eventName
+        if isInRole "admin"
+          i.fa.fa-edit.edit-event-details(
+            data-toggle="modal"
+            data-target="#edit-event-modal"
+            data-editing='name')
+      p.disease-name
         if disease
-          .disease-name= disease
+          span= disease
         else
-          | No disease available.
-      p.abstract.event-summary
+          span.not-available No disease available.
+          if isInRole "admin"
+            i.fa.fa-plus-circle.edit-event-details(
+              data-toggle="modal"
+              data-target="#edit-event-modal"
+              data-editing='disease')
+      p.abstract.summary(class="{{#unless summary}} shift-up {{/unless}}")
         if summary
-          | #{summary}
+          span= summary
         else
-          | No summary available.
+          span.not-available No summary available.
+          if isInRole "admin"
+            i.fa.fa-plus-circle.edit-event-details(
+              data-toggle="modal"
+              data-target="#edit-event-modal"
+              data-editing='summary')
     .col-md-6
       .col-sm-4.col-sm-offset-8.space-btm-1.space-top-1
       table#countTable.col-md-12
@@ -123,17 +137,29 @@ template(name="editEventDetailsModal")
           .modal-header
             h4.modal-title Edit Event Details
           .modal-body.clearfix
-            .form-group
-              label Event Name
-              input.form-control(type='text' name='eventName' value=eventName required)
-            .form-group
-              label Event Disease
-              input.form-control(type="text" name="eventDisease" value=disease)
-            .form-group
-              label Event Summary
-              textarea.form-control(name="eventSummary" rows="15")= summary
+            unless confirmingDeletion
+              .form-group
+                label Event Name
+                input.form-control(type='text' name='eventName' value=eventName required)
+              .form-group
+                label Event Disease
+                input.form-control(type="text" name="eventDisease" value=disease)
+              .form-group
+                label Event Summary
+                textarea.form-control(name="eventSummary" rows="15")= summary
+            else
+              .delete-confirmation
+                i.fa.fa-trash-o
+                p Are you sure you want to delete this event?
+                p= eventName
+                .main-action
+                  button.btn.btn-danger.btn-wide.delete-event-confirmation(type="button") Delete Event
+                .other-actions
+                  button.btn.btn-default.btn-sm.back-to-editing(type="button") Edit Event
+                  button.btn.btn-default.btn-sm(type="button" data-dismiss="modal") Cancel
 
-          .modal-footer
-            button.btn.btn-danger.delete-event.pull-left(type="button") Delete Event
-            button.btn.btn-default(type="button" data-dismiss="modal") Close
-            button.btn.btn-success.btn-wide.save-modal(type="button") Save
+          unless confirmingDeletion
+            .modal-footer
+              button.btn.btn-danger.delete-event.pull-left(type="button") Delete Event
+              button.btn.btn-default(type="button" data-dismiss="modal") Cancel
+              button.btn.btn-success.btn-wide.save-modal(type="submit") Save

--- a/client/views/userEvent.jade
+++ b/client/views/userEvent.jade
@@ -134,6 +134,7 @@ template(name="editEventDetailsModal")
     .modal-dialog
       .modal-content
         form#editEvent
+          .close-modal(data-dismiss="modal" aria-label="Close")
           .modal-header
             h4.modal-title Edit Event Details
           .modal-body.clearfix

--- a/imports/stylesheets/_main.styl
+++ b/imports/stylesheets/_main.styl
@@ -7,6 +7,8 @@
 
 @import 'buttons.import'
 @import 'fonts.import'
+@import 'modals.import'
+@import 'forms.import'
 @import 'globals.import'
 
 @import 'header.import'

--- a/imports/stylesheets/buttons.import.styl
+++ b/imports/stylesheets/buttons.import.styl
@@ -21,10 +21,10 @@ $btn-types = {
     bg-hover: darken($success-btn-color, 25%)
   }
   '.btn-danger': {
-    text: $primary
+    text: $primary-dark
     text-hover: white
     border: darken($delete, 30%)
-    bg: lighten($delete, 50%)
+    bg: lighten($delete, 60%)
     bg-hover: darken($delete, 10%)
   }
   '.btn-warning': {
@@ -109,7 +109,7 @@ $buttons()
   padding-top .25em
   padding-bottom .25em
   text-transform none
-  font-size 1em
+  font-size .95em
 
 @media(max-width: $mobile-break)
   .btn-featured

--- a/imports/stylesheets/buttons.import.styl
+++ b/imports/stylesheets/buttons.import.styl
@@ -3,8 +3,8 @@ $warning-btn-color = lighten($warning, 50%)
 
 $btn-types = {
   '.btn-default': {
-    text: $primary
-    border: $border-btn
+    text: $m-gray
+    border: lighten($m-gray, 50%)
     bg: white
     bg-hover: $l-gray
   },
@@ -73,8 +73,8 @@ $buttons()
 .btn
   padding-top .5em
   padding-bottom .5em
-  padding-left 1em
-  padding-right 1em
+  padding-left 1.25em
+  padding-right 1.25em
   font-size 1em
   font-weight 300
   letter-spacing .03em
@@ -93,6 +93,10 @@ $buttons()
 .btn-action
 .btn-shouting
   text-transform uppercase
+
+.btn-wide
+  padding-left 2em
+  padding-right 2em
 
 .btn-featured
   padding 1em 5em

--- a/imports/stylesheets/event.import.styl
+++ b/imports/stylesheets/event.import.styl
@@ -13,17 +13,20 @@
   padding-bottom 20px
 
 .event-details
-  margin-top 25px
+  margin 25px 0 35px 0
+
+.event-name-wrap
+  display flex
+  align-items flex-start
+  margin-bottom .25em
 
 .event-name
-  margin-top 0
-  font-size 2.5em
+  margin 0
+  font-size 2.25em
   color $highlight
   font-weight 600
-  display inline-block
 
 .edit-event-details
-  vertical-align top
   margin-left 10px
   cursor pointer
   font-size 1.25em
@@ -32,16 +35,45 @@
     color $primary
 
 .disease-name
-  font-size 20px
-  color #345e7e
-  padding-bottom 10px
+  span
+    font-size 1.5em
+    color $primary
+    &.not-available
+      font-size 1em
 
-.event-summary
-  padding-bottom 25px
+.summary
+  line-height 1.75em
+
+.summary
+.disease-name
+  .not-available
+    color $m-gray
+    font-style italic
+  .fa
+    font-size 95%
+  &.shift-up
+    margin-top -10px
+
+.delete-confirmation
+  text-align center
+  padding-top 2em
+  padding-bottom 3.5em
+  p
+    &:first-of-type
+      margin .5em 0 .2em 0
+      font-size 125%
+    &:last-of-type
+      font-style italic
+      margin-bottom 2em
+  i
+    color lighten($delete, 20%)
+    font-size 5em
+  .other-actions
+    margin-top 1em
+    .btn:first-of-type
+      margin-right .5em
 
 .event-head
-  h1
-    margin-bottom 20px
   .minor
     font-size 20px
   h2

--- a/imports/stylesheets/event.import.styl
+++ b/imports/stylesheets/event.import.styl
@@ -12,20 +12,31 @@
   background $secondary-light
   padding-bottom 20px
 
-.eventName
-  padding-top 15px
-  padding-bottom 10px
+.event-details
+  margin-top 25px
 
-.eventNameSummary
-  font-size 36px
+.event-name
+  margin-top 0
+  font-size 2.5em
   color $highlight
+  font-weight 600
+  display inline-block
 
-.diseaseName
+.edit-event-details
+  vertical-align top
+  margin-left 10px
+  cursor pointer
+  font-size 1.25em
+  color $m-gray
+  &:hover
+    color $primary
+
+.disease-name
   font-size 20px
   color #345e7e
   padding-bottom 10px
 
-.eventSummary
+.event-summary
   padding-bottom 25px
 
 .event-head

--- a/imports/stylesheets/events.import.styl
+++ b/imports/stylesheets/events.import.styl
@@ -141,39 +141,41 @@
   width 100%
   height 600px
 
-.modal-body
-  padding 10px 20px 2px 20px
-
-.modal-header
-  padding 5px 5px 5px 20px
-  .close
-    padding 5px 5px 5px 5px
-
-.countCell
+.count-cell
   height 100px
-  border-bottom 1px solid #f7b297
+  border-bottom 1px solid $secondary
   font-size 36px
 
-.countCellLeft
-  border-right 1px solid #f7b297
+.count-cell-left
+  border-right 1px solid $secondary
 
-.countCellValue
-  color #345e7e
+.count-cell-value
+  color $primary
   font-weight bold
 
-.countCellTitle
-  color #345e7e
-  font-size 18px
+.count-cell-title
+  color $primary
+  font-size .6em
+  font-weight 300
   margin-bottom 20px
+  text-transform uppercase
 
-td.col-md-4.countCell.text-center
+td.col-md-4.count-cell.text-center
   float left
 
-.giCellCenter
-  border-left 1px solid #f7b297
+.gi-cell-center
+  border-left 1px solid $secondary
 
 .gi
   padding 10px
-  font-style italic
-  font-size 12px
-  color #808080
+  font-size .75em
+  color $m-gray
+  font-weight 300
+  span
+    font-weight 400
+
+.copy-link
+  font-size 1.1em
+  font-weight 400
+  padding-top .25em
+  padding-bottom .25em

--- a/imports/stylesheets/forms.import.styl
+++ b/imports/stylesheets/forms.import.styl
@@ -1,0 +1,3 @@
+form
+  label
+    margin-bottom .25em

--- a/imports/stylesheets/modals.import.styl
+++ b/imports/stylesheets/modals.import.styl
@@ -29,3 +29,17 @@ $modal-border-radius = 4px
 .modal-footer
   padding-top 1.25em
   padding-bottom 2em
+
+.close-modal
+  position absolute
+  right 1em
+  top .75em
+  cursor pointer
+  color $m-gray
+  padding .25em
+  &:hover
+    color $secondary-dark
+  &::before
+    font-family FontAwesome
+    content '\f057'
+    font-size 1.65em

--- a/imports/stylesheets/modals.import.styl
+++ b/imports/stylesheets/modals.import.styl
@@ -1,0 +1,31 @@
+$modal-border-radius = 4px
+
+.modal-content
+  border-radius $modal-border-radius
+
+.modal-body
+  padding 10px 20px
+
+.modal-header
+  padding 0
+  border-top-left-radius $modal-border-radius
+  border-top-right-radius $modal-border-radius
+  overflow hidden
+  background $ll-gray
+  .close
+    padding 5px
+
+.modal-title
+  padding .35em .75em .4em .75em
+  text-transform uppercase
+  font-weight 300
+  font-size 2em
+  color $primary
+
+.modal-header
+.modal-footer
+  border-color lighten($l-gray, 10%)
+
+.modal-footer
+  padding-top 1.25em
+  padding-bottom 2em

--- a/imports/stylesheets/variables.import.styl
+++ b/imports/stylesheets/variables.import.styl
@@ -1,9 +1,11 @@
 $primary = #345E7E
 $primary-light = #EAEEF2
 $primary-l-light = lighten($primary, 90%)
+$primary-dark = darken($primary, 30%)
 $secondary = #F7B297
 $secondary-light = #FAF0EC
 $secondary-l-light = lighten($secondary, 90%)
+$secondary-dark = darken($secondary, 30%)
 $highlight = #F07382
 
 $selected = $secondary-light


### PR DESCRIPTION
Moves the edit event UI elements into a modal and changes the _admin options_ dropdown to a simple button near the title.

Event selection now is accomplished via a button in the modal. The alert confirmation is replaced with a secondary modal 'page' which asks the user for confirmation.

When there is no disease or summary, the user sees button which opens modal and the appropriate input field is focused.

Cleans up some jade/css - specifically switching from camelCase classnames to hyphenated and avoiding using the double curly brackets to reference properties.

PT Story: https://www.pivotaltracker.com/story/show/130376327