### PR TITLE
EIDR-C article pub dates can be edited

### DIFF
--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -25,11 +25,16 @@ Template.articles.helpers
           return ""
       }
     ]
-    if Meteor.user()
+    if Roles.userIsInRole(Meteor.userId(), ['admin'])
       fields.push({
         key: "delete"
         label: ""
         cellClass: "remove-row"
+      })
+      fields.push({
+        key: "Edit"
+        label: ""
+        cellClass: "edit-row"
       })
     fields.push({
       key: "expand"
@@ -75,6 +80,10 @@ Template.articles.events
       else if window.confirm("Are you sure you want to delete this event source?")
         currentOpen.remove()
         Meteor.call("removeEventSource", @_id)
+    else if $target.closest(".edit-row").length
+      modalData = @
+      modalData.edit = true
+      Modal.show("sourceModal", modalData)
     else if not $parentRow.hasClass("tr-details")
       closeRow = $parentRow.hasClass("details-open")
       ###

--- a/client/controllers/sourceModal.coffee
+++ b/client/controllers/sourceModal.coffee
@@ -1,6 +1,10 @@
+convertDate = require "/imports/convertDate.coffee"
+
 Template.sourceModal.onCreated ->
   @tzIsSpecified = false
   @proMEDRegEx = /promedmail\.org\/post\/(\d+)/ig
+  if @data.publishDate
+    @timezoneFixedPublishDate = convertDate(@data.publishDate, "local", UTCOffsets[@data.publishDateTZ])
 
 Template.sourceModal.helpers
   timezones: ->
@@ -8,22 +12,43 @@ Template.sourceModal.helpers
     defaultTimezone = if moment().isDST() then 'EDT' else 'EST'
     for tzKey, tzOffset of UTCOffsets
       timezones.push({name: tzKey, offset: tzOffset})
-      if tzKey is defaultTimezone
+      if @publishDateTZ
+        if @publishDateTZ is tzKey
+          timezones[timezones.length-1].selected = true
+      else if tzKey is defaultTimezone
         timezones[timezones.length-1].selected = true
     timezones
   initDatePicker: ->
     templateInstance = Template.instance()
+    pickerOptions = {
+      format: 'M/D/YYYY'
+      inline: true
+      useCurrent: false
+    }
+    if templateInstance.timezoneFixedPublishDate
+      pickerOptions.defaultDate = moment(
+        year: templateInstance.timezoneFixedPublishDate.year()
+        month: templateInstance.timezoneFixedPublishDate.month()
+        date: templateInstance.timezoneFixedPublishDate.date()
+      )
+
     Meteor.defer ->
-      templateInstance.$(".datePicker").datetimepicker
-        format: 'M/D/YYYY'
-        inline: true
-        useCurrent: false
+      templateInstance.$(".datePicker").datetimepicker pickerOptions
   initTimePicker: ->
     templateInstance = Template.instance()
+    fixed = templateInstance.timezoneFixedPublishDate
+    pickerOptions = {
+      format: 'h:mm A'
+      useCurrent: false
+    }
+    if templateInstance.timezoneFixedPublishDate
+      pickerOptions.defaultDate = templateInstance.timezoneFixedPublishDate
     Meteor.defer ->
-      templateInstance.$(".timePicker").datetimepicker
-        format: 'hh:mm A'
-        useCurrent: false
+      $picker = templateInstance.$(".timePicker").datetimepicker pickerOptions
+  saveButtonClass: ->
+    if @edit
+      return "save-edit-modal"
+    return "save-modal"
 
 Template.sourceModal.events
   "click .save-modal": (e, templateInstance) ->
@@ -34,13 +59,12 @@ Template.sourceModal.events
     timePicker = templateInstance.$('#publishTime').data("DateTimePicker")
     date = datePicker.date()
     time = timePicker.date()
-    dateString = ""
 
     unless validURL
       toastr.error('Please enter an article.')
       form.article.focus()
       return
-    if !date and time
+    if !date and form.publishTime.value.length
       toastr.error('Please select a date.')
       return
     unless form.publishDateTZ.checkValidity()
@@ -48,17 +72,22 @@ Template.sourceModal.events
       form.publishDateTZ.focus()
       return
 
-    if date
-      dateString = date.format("M/D/YYYY")
-      if time
-        dateString += time.format(" hh:mm A")
-
     source = {
       userEventId: templateInstance.data.userEventId
       url: article
-      publishDate: dateString
       publishDateTZ: form.publishDateTZ.value
     }
+
+    if date
+      selectedDate = moment(
+        year: date.year()
+        month: date.month()
+        date: date.date()
+      )
+      if form.publishTime.value.length
+        selectedDate.set({hour: time.get("hour"), minute: time.get("minute")})
+        selectedDate = convertDate(selectedDate, UTCOffsets[source.publishDateTZ], "local")
+      source.publishDate = selectedDate.toDate()
 
     enhance = form.enhance.checked
     Meteor.call("addEventSource", source, (error, articleId) ->
@@ -79,6 +108,42 @@ Template.sourceModal.events
               _id: articleId
               url: article
           })
+    )
+
+  "click .save-edit-modal": (e, templateInstance) ->
+    form = templateInstance.$("form")[0]
+    datePicker = templateInstance.$('#publishDate').data("DateTimePicker")
+    timePicker = templateInstance.$('#publishTime').data("DateTimePicker")
+    date = datePicker.date()
+    time = timePicker.date()
+
+    if !date and form.publishTime.value.length
+      toastr.error('Please select a date.')
+      return
+    unless form.publishDateTZ.checkValidity()
+      toastr.error('Please select a time zone.')
+      form.publishDateTZ.focus()
+      return
+
+    source = @
+    source.publishDateTZ = form.publishDateTZ.value
+    
+    if date
+      selectedDate = moment(
+        year: date.year()
+        month: date.month()
+        date: date.date()
+      )
+      if form.publishTime.value.length
+        selectedDate.set({hour: time.get("hour"), minute: time.get("minute")})
+        selectedDate = convertDate(selectedDate, UTCOffsets[source.publishDateTZ], "local")
+      source.publishDate = selectedDate.toDate()
+
+    Meteor.call("updateEventSource", source, (error, result) ->
+      if error
+        toastr.error error.reason
+      else
+        Modal.hide(templateInstance)
     )
 
   "change #publishDateTZ": (e, templateInstance) ->

--- a/client/views/sourceModal.jade
+++ b/client/views/sourceModal.jade
@@ -3,13 +3,20 @@ template(name="sourceModal")
     .modal-dialog
       .modal-content
         .modal-header
-          h4.modal-title Add Event Source
+          h4.modal-title
+            if edit
+              | Edit Event Source
+            else
+              | Add Event Source
         .modal-body
           form#add-source.form-horizontal(novalidate)
             .form-group
               .col-md-12
                 label.control-label Article URL
-                input#article.form-control.new-article(type="url" name="article" required)
+                if edit
+                  p.form-control-static {{url}}
+                else
+                  input#article.form-control.new-article(type="url" name="article" required)
             .form-group
               .col-md-12
                 label.control-label Publication Date
@@ -19,7 +26,7 @@ template(name="sourceModal")
                 .input-group
                   span.input-group-addon
                     i.fa.fa-clock-o
-                  input#publishTime.timePicker.form-control(type="text" placeholder="Time" init="{{initTimePicker}}")
+                  input#publishTime.timePicker.form-control(type="text" name="publishTime" placeholder="Time" init="{{initTimePicker}}")
               .col-md-6
                 .input-group
                   span.input-group-addon
@@ -27,12 +34,13 @@ template(name="sourceModal")
                   select#publishDateTZ.form-control(name="publishDateTZ")
                     each timezones
                       option(value=name selected=selected) {{name}} (GMT{{offset}})
-            .form-group
-              .col-lg-12
-                .checkbox
-                  label
-                    input(type="checkbox" value="1" name="enhance" checked)
-                    | Suggest incident reports
+            unless edit
+              .form-group
+                .col-lg-12
+                  .checkbox
+                    label
+                      input(type="checkbox" value="1" name="enhance" checked)
+                      | Suggest incident reports
         .modal-footer
           button.btn.btn-default(type="button" data-dismiss="modal") Close
-          button.btn.btn-primary.save-modal(type="button") Save
+          button.btn.btn-primary(type="button" class=saveButtonClass) Save

--- a/imports/convertDate.coffee
+++ b/imports/convertDate.coffee
@@ -1,0 +1,17 @@
+convertDate = (convertDate, currentOffset, targetOffset) ->
+  converted = moment(convertDate)
+  currentMinuteOffset = converted.utcOffset()
+  if currentOffset isnt "local"
+    offset = parseInt(currentOffset)
+    currentMinuteOffset = (parseInt(offset / 100) * 60) + (offset % 100)
+  targetMinuteOffset = converted.utcOffset()
+  if targetOffset isnt "local"
+    offset = parseInt(targetOffset)
+    targetMinuteOffset = (parseInt(offset / 100) * 60) + (offset % 100)
+  # Convert back to GMT
+  converted.add(currentMinuteOffset * -1, "minutes")
+  # Convert to target offset
+  converted.add(targetMinuteOffset, "minutes")
+  return converted
+
+module.exports = convertDate


### PR DESCRIPTION
Since the database stores the publication date in the local machine's timezone, we need to convert it to the target timezone when showing it on the edit form. I tried to use moment timezone to handle this conversion but it messed up the date time picker plugin, which relies on moment.  I also noticed that if a time isn't selected when saving, the edit form will show the time as 12:00 AM the next time it's opened. Maybe the date and time should be stored separately in the database.