### PR TITLE
Add button for adding non-suggested incident reports on incident report suggestion modal

### DIFF
--- a/client/controllers/suggestedIncidents.coffee
+++ b/client/controllers/suggestedIncidents.coffee
@@ -163,3 +163,10 @@ Template.suggestedIncidentsModal.events
         toastr.error err.reason
       else
         Modal.hide(template)
+  "click #non-suggested-incident": (event, template) ->
+    Modal.show("incidentModal", {
+      articles: [template.data.article]
+      userEventId: template.data.userEventId
+      add: true
+      incident: {url: [template.data.article.url]}
+    })

--- a/client/views/suggestedIncidentsModal.jade
+++ b/client/views/suggestedIncidentsModal.jade
@@ -15,4 +15,5 @@ template(name="suggestedIncidentsModal")
               p.annotated-content=annotatedContent
         .modal-footer
           button.btn.btn-default(type="button" data-dismiss="modal") Close
+          button.btn.btn-default#non-suggested-incident(type="button") Add New Incident
           button.btn.btn-primary#add-suggestions(type="button") Add Confirmed Suggestions


### PR DESCRIPTION
The new button is in the modal footer and simply opens the new incident form modal.