### PR TITLE
adds feature to display incident information when map markers are shown

### DIFF
--- a/client/controllers/eventMap.coffee
+++ b/client/controllers/eventMap.coffee
@@ -60,9 +60,9 @@ Template.eventMap.onRendered ->
       # Remove events that have no locations to plot on the map
       filteredEvents = []
       for event in allEvents
-        incidentLocations = Incidents.find({userEventId: event._id, locations: {$ne: null}}, {fields: {locations: 1}}).fetch()
-        if incidentLocations.length
-          event.incidents = incidentLocations
+        incidents = Incidents.find({userEventId: event._id, locations: {$ne: null}}, {sort: {date: -1}}).fetch()
+        if incidents.length
+          event.incidents = incidents
           filteredEvents.push event
 
       if filteredEvents.length
@@ -71,7 +71,7 @@ Template.eventMap.onRendered ->
           rgbColor = chroma(colorScale[templateEvents.length]).rgb()
           templateEvents.push
             _id: event._id
-            name: event.eventName
+            eventName: event.eventName
             date: event.creationDate
             lastIncidentDate: event.lastIncidentDate
             rgbColor: rgbColor
@@ -96,7 +96,6 @@ Template.eventMap.onRendered ->
       MapHelpers.addMarkersToMap map, instance, selecedMapLocations
     else
       MapHelpers.addMarkersToMap map, instance, instance.filteredMapLocations
-
 
 Template.eventMap.helpers
   getQuery: ->
@@ -128,6 +127,27 @@ Template.eventMap.events
   "click .event-list-prev:not('.disabled')": (event, template) ->
     paginate template, 1
 
+
+
 Template.markerPopup.helpers
-  getEvents: ->
+  getEvents: () ->
     Template.instance().data.events
+  getCount: (incidents, type) ->
+    instance = Template.instance()
+    byLocation = _.filter(incidents, (incident) ->
+      if incident.locations[0].name == instance.data.location
+        return incident
+    )
+    if type == 'incidents'
+      return byLocation.length
+    byType = _.chain(byLocation).pluck(type).filter((incident) ->
+      if typeof incident != 'undefined'
+        return incident
+    ).value()
+    if byType.length <= 0
+      return 0
+    count = _.reduce(byType, (s, n) -> s += n)
+    if isNaN(count)
+      return 0
+    else
+      return count.toLocaleString()

--- a/client/controllers/mapFilters.coffee
+++ b/client/controllers/mapFilters.coffee
@@ -96,9 +96,11 @@ Template.mapFilters.events
     if selectedEvents.findOne(id: id)
       selectedEvents.remove id: id
     else
+      event = _.find(instance.data.templateEvents.get(), (e) -> e._id == id)
       selectedEvents.insert
         id: id
         rgbColor: @rgbColor
+        eventName: event.eventName
         incidents: @incidents
         selected: true
 

--- a/client/views/eventMap.jade
+++ b/client/views/eventMap.jade
@@ -12,7 +12,20 @@ template(name="eventMap")
 template(name="markerPopup")
   h4 {{location}}
   each getEvents
-    p
-      svg.marker-color-spot(height="10" width="10")
-        circle(fill="rgb({{mapColorRGB}})" r="5" cx="5" cy="5")
-      a(href="{{pathFor 'user-event' _id=id}}") {{name}}
+    div.row.popup-row
+      div.col-md-1
+        svg.marker-color-spot(height="10" width="10")
+          circle(fill="rgb({{mapColorRGB}})" r="5" cx="5" cy="5")
+      div.col-md-10
+        a(href="{{pathFor 'user-event' _id=id}}") {{eventName}}
+    div.row.popup-row
+      div.popup-incidents-text
+        div.col-md-4
+          span.popup-incidents-label Cases:
+          span {{getCount incidents 'cases'}}
+        div.col-md-4
+          span.popup-incidents-label Deaths:
+          span {{getCount incidents 'deaths'}}
+        div.col-md-4
+          span.popup-incidents-label Incidents:
+          span {{getCount incidents 'incidents'}}

--- a/client/views/mapFilters.jade
+++ b/client/views/mapFilters.jade
@@ -10,7 +10,7 @@ template(name="mapFilters")
     ul.map-event-list.list-group
       each getEvents
         li.map-event-list--item.list-group-item(class="{{#if selected}} selected {{/if}}")
-          span.name=name
+          span.name=eventName
           span.date Last Incident Date: {{formatDate lastIncidentDate}}
           .circle(style="background-color:rgb(#{rgbColor})")
       else

--- a/imports/stylesheets/eventMap.import.styl
+++ b/imports/stylesheets/eventMap.import.styl
@@ -155,3 +155,16 @@
         padding-right 4em
     &:last-of-type
       margin 0
+
+.popup-row
+  padding-left 5px
+  padding-right 5px
+  line-height 1.5em
+  width 325px
+
+.popup-incidents-text
+  font-size 0.75em
+  color #808080
+
+.popup-incidents-label
+  font-weight bold

--- a/imports/ui/mapMarkers.coffee
+++ b/imports/ui/mapMarkers.coffee
@@ -42,7 +42,7 @@ module.exports =
         if latLng not in uniqueEventLocations
           if not mapLocations[latLng]
             mapLocations[latLng] = {name: location.name, events: []}
-          mapLocations[latLng].events.push({id: event._id, name: event.eventName, mapColorRGB: rgbColor})
+          mapLocations[latLng].events.push({id: event._id, eventName: event.eventName, incidents: event.incidents, mapColorRGB: rgbColor})
           uniqueEventLocations.push(latLng)
 
   addMarkersToMap: (map, instance, mapLocations) ->

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -15,6 +15,8 @@ Meteor.publish "mapIncidents", () ->
       "dateRange.end": 1
       "dateRange.cumulative": 1
       locations: 1
+      cases: 1
+      deaths: 1
   })
 
 # User Events


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/130518645

Steps: 
1. Click on the 'Event Map'
2. Click on a marker
3. Notice popup dialog contains counters about incident information

![image](https://cloud.githubusercontent.com/assets/12954045/19476620/19ae7cf4-9508-11e6-8e0d-8e7ce0a33fec.png)


Note: clicking on a URL within the marker popup will route the the /user-event/:id but the ScatterPlot shows 'Not enough data'.  This bug is tracked in pivotal as https://www.pivotaltracker.com/story/show/132659361
