### PR TITLE
bugfix - debounce plot.update; the plot will determine if it should show/hide the no data warning

### DIFF
--- a/client/controllers/incidentReports.coffee
+++ b/client/controllers/incidentReports.coffee
@@ -30,70 +30,54 @@ Template.incidentReports.onCreated ->
   # therefore we will setup a reactive cursor to use with the plot as an
   # instance variable.
   @incidents = Incidents.find({userEventId: @data.userEvent._id}, {sort: {date: -1}})
-  Meteor.defer =>
-    # format the data
-    @autorun =>
-      # anytime the incidents cursur changes, refetch the data and format
-      data = _.chain(@incidents.fetch())
-        .map((incident) ->
-          RectMarker.createFromIncident(incident)
-        ).filter((m) ->
-          if typeof m != 'undefined'
-            return m
-        ).value()
 
-      # we have an existing plot, update plot with new data array
-      if @plot instanceof ScatterPlot
-        @plot.update(data)
-        return
+Template.incidentReports.onRendered ->
+  @plot = new ScatterPlot({
+    containerID: 'scatterPlot',
+    svgContainerClass: 'scatterPlot-container',
+    height: $('#event-incidents-table').parent().height(),
+    axes: {
+      # show grid lines
+      grid: true,
+      x: {
+        title: 'Time',
+        type: 'datetime',
+      },
+      y: {
+        title: 'Incidents',
+        type: 'numeric',
+      }
+    },
+    tooltip: {
+      opacity: .8
+      # function to render the tooltip
+      template: (marker) ->
+        marker.moment = moment # template reference for momentjs
+        marker.type = marker.meta.type
+        if marker.y != 1
+          marker.type = "#{marker.type}s"
+        # underscore compiled template
+        tmpl = _.template(tooltipTmpl)
+        # render the template from
+        tmpl(marker)
+    },
+    zoom: true,
+  })
+  # deboune how many consecutive calls to update the plot during reactive changes
+  @updatePlot = _.debounce(_.bind(@plot.update, @plot), 300)
 
-      # build the plot
-      @plot = new ScatterPlot({
-        containerID: 'scatterPlot',
-        svgContainerClass: 'scatterPlot-container',
-        height: $('#event-incidents-table').parent().height(),
-        axes: {
-          # show grid lines
-          grid: true,
-          x: {
-            title: 'Time',
-            type: 'datetime',
-            minMax: [
-              Axes.minDatetime(_.pluck(data, 'x')),
-              Axes.maxDatetime(_.pluck(data, 'w')),
-            ],
-          },
-          y: {
-            title: 'Incidents',
-            type: 'numeric',
-            minMax: [
-              0,
-              Axes.maxNumeric(_.pluck(data, 'y')),
-            ]
-          }
-        },
-        tooltip: {
-          opacity: .8
-          # function to render the tooltip
-          template: (marker) ->
-            marker.moment = moment # template reference for momentjs
-            marker.type = marker.meta.type
-            if marker.y != 1
-              marker.type = "#{marker.type}s"
-            # underscore compiled template
-            tmpl = _.template(tooltipTmpl)
-            # render the template from
-            tmpl(marker)
-        },
-        zoom: true,
-      })
-
-      if data.length <= 0
-        @plot.showWarn('Not enough data.')
-        return
-
-      @plot.draw(data)
-
+  @autorun =>
+    # anytime the incidents cursur changes, refetch the data and format
+    incidents = @incidents.fetch().map((incident) =>
+      return RectMarker.createFromIncident(incident)
+    ).filter((incident) =>
+      if incident
+        return incident
+    )
+    # we have an existing plot, update plot with new data array
+    if @plot instanceof ScatterPlot
+      @updatePlot(incidents)
+      return
 
 Template.incidentReports.helpers
   getSettings: ->
@@ -182,7 +166,7 @@ Template.incidentReports.helpers
 
 Template.incidentReports.events
   "click #scatterPlot-resetZoom": (event, template) ->
-    template.plot.zoom.reset()
+    template.plot.resetZoom()
   "click #event-incidents-table th": (event, template) ->
     template.$("tr").removeClass("details-open")
     template.$("tr.tr-details").remove()

--- a/imports/charts/Axes.coffee
+++ b/imports/charts/Axes.coffee
@@ -44,7 +44,11 @@ class Axes
   constructor: (plot, options) ->
     @plot = plot
     @options = options
-    @axesOpts = options.axes || {x: {title: 'x', type: 'numeric', minMax: [0,100]}, y: {title: 'y', type: 'numeric', minMax: [0, 100]}, grid: true}
+    @axesOpts = options.axes || {x: {title: 'x', type: 'numeric', minMax: [0, 0]}, y: {title: 'y', type: 'numeric', minMax: [0, 0]}, grid: true}
+    if typeof @axesOpts.x.minMax == 'undefined'
+      @axesOpts.x.minMax = [0, 0]
+    if typeof @axesOpts.y.minMax == 'undefined'
+      @axesOpts.y.minMax = [0, 0]
     @init()
 
   ###
@@ -147,14 +151,16 @@ class Axes
     if @axesOpts.x.type == 'datetime'
       xMin = Axes.minDatetime(_.pluck(data, 'x'))
       # check for 'width' property on the x-axis
-      if data.hasOwnProperty('w')
+      w = _.pluck(data, 'w')
+      if w.length > 0
         xMax = Axes.maxDatetime(_.pluck(data, 'w'))
       else
         xMax = Axes.maxDatetime(_.pluck(data, 'x'))
     else
       xMin = 0
       # check for 'width' property on the x-axis
-      if data.hasOwnProperty('w')
+      w = _.pluck(data, 'w')
+      if w.length > 0
         xMax = Axes.maxNumeric(_.pluck(data, 'w'))
       else
         xMax = Axes.maxNumeric(_.pluck(data, 'x'))

--- a/imports/charts/Plot.coffee
+++ b/imports/charts/Plot.coffee
@@ -21,6 +21,7 @@ class Plot
   ###
   constructor: (options) ->
     @options = options
+    @drawn = false
     @
 
   ###
@@ -78,6 +79,7 @@ class Plot
       @root = d3.select("\##{@options.containerID}").append('svg')
         .attr('width', @viewBoxWidth)
         .attr('height', @viewBoxHeight)
+    @root.style('opacity', 0)
 
     # the container of the plot
     @container = @root.append('g')
@@ -101,8 +103,27 @@ class Plot
     @markers = @container.append('g')
       .attr('class', 'scatterPlot-markers')
       .attr('transform', "translate(#{@margins.left}, 0)")
+
     # return
     @
+
+  ###
+  # draw - draws the markers on the plot
+  #
+  # @note this will automatically show/hide a warning message if the data
+  # is empty. Do not call super() to override this behavior.
+  #
+  # @param {array} data, an array of {object} for each marker
+  ###
+  draw: (data) ->
+    if !@drawn
+      @drawn = true
+      @root.transition().style('opacity', 1)
+    if typeof data != 'undefined'
+      if data.length <= 0
+        @showWarn()
+        return
+    @removeWarn()
 
   ###
   # getWidth
@@ -128,12 +149,29 @@ class Plot
   # @return {object} this
   ###
   showWarn: (m) ->
-    mSize = m.split('').length;
-    @warn = @root.append('g')
+    if typeof m == 'undefined'
+      m = 'No data to display'
+    if @warn
+      @removeWarn()
+    @warn = @container.append('g')
+      .style('opacity', 0)
       .attr('class', 'scatterPlot-warn')
-      .attr('transform', "translate(#{@getWidth() / 2 - mSize}, #{@getHeight() / 2})")
-    @warn.append('text')
+    text = @warn.append('text')
+      .attr('text-anchor', 'middle')
+      .attr('x', @width / 2)
+      .attr('y', @getHeight() / 2)
       .text(m)
+    @warn.transition().style('opacity', 1)
+    @
+
+  ###
+  # removeWarn - removes the warning message from the plot
+  #
+  # @return {object} this
+  ###
+  removeWarn: () ->
+    if @warn
+      @warn.remove()
     @
 
   ###

--- a/imports/charts/ScatterPlot.coffee
+++ b/imports/charts/ScatterPlot.coffee
@@ -81,6 +81,7 @@ class ScatterPlot extends Plot
   # @returns {object} this
   ###
   draw: (data) ->
+    super(data)
     if data
       @data = data
 
@@ -147,7 +148,7 @@ class ScatterPlot extends Plot
     if data
       @data = data
     super(data)
-    @redraw()
+    @redraw(data)
     @
 
   ###
@@ -155,8 +156,8 @@ class ScatterPlot extends Plot
   #
   # @returns {object} this
   ###
-  redraw: () ->
-    @clear().draw()
+  redraw: (draw) ->
+    @clear().draw(draw)
     @
 
   ###
@@ -192,7 +193,10 @@ class ScatterPlot extends Plot
   # resetZoom - resets the zoom of the axes
   ###
   resetZoom: () ->
-    @axes.resetZoom()
+    if !@data || @data.length <= 0
+      return
+    if @zoom
+      @zoom.reset()
 
 
 module.exports = ScatterPlot

--- a/imports/stylesheets/scatterPlot.import.styl
+++ b/imports/stylesheets/scatterPlot.import.styl
@@ -27,6 +27,9 @@
 
 .scatterPlot-warn
   fill orangered
+  font-size 1.5em
+  font-weight 200
+  text-transform uppercase
 
 .scatterPlot-tooltip
   position absolute


### PR DESCRIPTION
bugfix - https://www.pivotaltracker.com/story/show/132659361

- The plot will determine if it should show/hide the no data warning.
- improved styling
- improved center positioning 
- added transition on the opacity of the showWarn message
- misc bugfix to disable resetZoom if data is not at least one or zoom is disabled
- added transition on the opacity to the first drawing of the plot

Steps A:
1. goto the Event Map
2. click on a marker
3. click on a link to /user-event/:id
4. confirm that the warning does not appear

Steps B:
1. goto the Tracked Events
2. sort by Article Count ascending
3. click on an event to /user-event/:id
4. confirm that the warning appears for an event without data