### PR TITLE
adds filter capability to the plot and cumultive filter button

### DIFF
--- a/client/controllers/incidentReports.coffee
+++ b/client/controllers/incidentReports.coffee
@@ -74,6 +74,7 @@ Template.incidentReports.onRendered ->
       if incident
         return incident
     )
+
     # we have an existing plot, update plot with new data array
     if @plot instanceof ScatterPlot
       @updatePlot(incidents)
@@ -165,6 +166,22 @@ Template.incidentReports.helpers
     }
 
 Template.incidentReports.events
+  "click #scatterPlot-toggleCumulative": (event, template) ->
+    $target = $(event.currentTarget)
+    $icon = $target.find('i.fa')
+    if $target.hasClass('active')
+      $target.removeClass('active')
+      $icon.removeClass('fa-check-circle').addClass('fa-circle-o')
+      template.plot.removeFilter('cumulative')
+      template.updatePlot()
+    else
+      $target.addClass('active')
+      $icon.removeClass('fa-circle-o').addClass('fa-check-circle')
+      template.plot.addFilter 'cumulative', (d) ->
+        if d.meta.cumulative
+          return d
+      template.updatePlot()
+
   "click #scatterPlot-resetZoom": (event, template) ->
     template.plot.resetZoom()
   "click #event-incidents-table th": (event, template) ->

--- a/client/views/incidentReports.jade
+++ b/client/views/incidentReports.jade
@@ -9,7 +9,10 @@ template(name="incidentReports")
     .col-md-6
       .row
         div#scatterPlot-toolbar
-          a#scatterPlot-resetZoom.btn.btn-xs.btn-default
+          a#scatterPlot-toggleCumulative.btn.btn-xs.btn-default.scatterPlot-toolbar-button
+            i.fa.fa-circle-o
+            | Toggle Cumulative
+          a#scatterPlot-resetZoom.btn.btn-xs.btn-default.scatterPlot-toolbar-button
             i.fa.fa-refresh
             | Reset Zoom
       .row

--- a/imports/charts/Plot.coffee
+++ b/imports/charts/Plot.coffee
@@ -22,7 +22,7 @@ class Plot
   constructor: (options) ->
     @options = options
     @drawn = false
-    @filters = {}
+    @filters = options.filters || {}
     @
 
   ###

--- a/imports/charts/ScatterPlot.coffee
+++ b/imports/charts/ScatterPlot.coffee
@@ -87,18 +87,7 @@ class ScatterPlot extends Plot
 
     # filter the data is withing the current domain of the axes (necessary
     # when zoom is enabled)
-    filtered = _.filter(@data, (d) =>
-      x1 = @axes.xScale.domain()[0]
-      if x1 instanceof Date
-        x1 = x1.getTime()
-      x2 = @axes.xScale.domain()[1]
-      if x2 instanceof Date
-        x2 = x2.getTime()
-      y1 = @axes.yScale.domain()[0]
-      y2 = @axes.yScale.domain()[1]
-      if ((d.x >= x1 && d.x <= x2) && (d.y >= y1 && d.y <= y2))
-        return d
-    )
+    filtered = @applyFilters()
 
     @markers.selectAll('.marker').data(filtered).enter().append('rect')
       # if the scale is large enough (e.g. the scale is two years and the span

--- a/imports/stylesheets/scatterPlot.import.styl
+++ b/imports/stylesheets/scatterPlot.import.styl
@@ -4,7 +4,7 @@
   margin-right 15px
   float right
 
-#scatterPlot-resetZoom
+.scatterPlot-toolbar-button
   padding-top 2px
   padding-bottom 2px
   font-size 12px
@@ -48,17 +48,6 @@
 
 .grid path
   stroke-width 0
-
-.resetZoomBtn
-  fill #345e7e
-  opacity .9
-  cursor pointer
-  border-radius 8px
-
-.resetZoomText
-  font-size 10px
-  pointer-events none
-  fill #ccc
 
 .zoomOverlay
   pointer-events all


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/132223713

This feature added an API to add/remove filters to the base plot. This allows the plot instance to apply these filters on each draw, including the default filter for the current axes domain. This simplifies a lot of complexity that may otherwise occur in the controller code trying to synchronize data state between each plot update. 

In the following example, the filtering method is given a name and method to execute. Note: the method will be bound to the plot instance.

```
addFilter('cumulative', (d) ->
  // do something with a data element
```

```
removeFilter('cumulative')
```

![image](https://cloud.githubusercontent.com/assets/12954045/19560004/91dd562a-96a0-11e6-95ca-7db589381be7.png)
