### PR TITLE
add feature to suggest user events based on title of promed post

### DIFF
--- a/client/controllers/curatorEvents.coffee
+++ b/client/controllers/curatorEvents.coffee
@@ -16,7 +16,6 @@ Template.curatorEvents.onCreated ->
     ).map((article)->
       [article.userEventId, article]
     ))
-  Template.curatorEvents.associatedEventIdsToArticles = @associatedEventIdsToArticles
 
 Template.curatorEvents.onRendered ->
   @$('#curatorEventsFilter input').attr 'placeholder', 'Search events'
@@ -33,6 +32,12 @@ Template.curatorEvents.helpers
       _id:
         $in: _.keys(Template.instance().associatedEventIdsToArticles.get())
     )
+
+  associatedEventIdsToArticles: ->
+    Template.instance().associatedEventIdsToArticles
+
+  title: ->
+    Template.instance().data.title
 
   associated: () ->
     articleId = Template.instance().data._id

--- a/client/controllers/curatorEvents.coffee
+++ b/client/controllers/curatorEvents.coffee
@@ -16,6 +16,7 @@ Template.curatorEvents.onCreated ->
     ).map((article)->
       [article.userEventId, article]
     ))
+  Template.curatorEvents.associatedEventIdsToArticles = @associatedEventIdsToArticles
 
 Template.curatorEvents.onRendered ->
   @$('#curatorEventsFilter input').attr 'placeholder', 'Search events'

--- a/client/controllers/curatorSuggestedEvents.coffee
+++ b/client/controllers/curatorSuggestedEvents.coffee
@@ -8,6 +8,7 @@ UserEvents = require '/imports/collections/userEvents.coffee'
 #
 #   The table is reactively updated by an autorun that listens to changes
 #   on the Template.currentEvents reactive var `associatedEventIdsToArticles`.
+#   Note: this reactive var is passed to this template throught jade.
 ###
 
 Template.suggestedEvents.onCreated ->
@@ -51,6 +52,7 @@ Template.suggestedEvents.onCreated ->
   # TODO: this is domain specific to ProMed. If other feeds are added, we would
   # need to do some conditional logic `if feed.isPromed then remove first token`.
   search = if tokens.length > 1 then tokens.slice(1, tokens.length).join(' ') else ''
+
   # call the server-side meteor method to perform full-text search sorted by score
   Meteor.call 'searchUserEvents', search, (err, res) =>
     if err
@@ -62,8 +64,8 @@ Template.suggestedEvents.onCreated ->
   # reactively compute changes to associatedEventIdsToArticles object and
   # update the suggested events
   @autorun =>
-    if Template.curatorEvents.associatedEventIdsToArticles
-      associated = Template.curatorEvents.associatedEventIdsToArticles.get()
+    if @data.associatedEventIdsToArticles
+      associated = @data.associatedEventIdsToArticles.get()
       @updateSuggestedEvents(associated)
 
 Template.suggestedEvents.helpers

--- a/client/controllers/curatorSuggestedEvents.coffee
+++ b/client/controllers/curatorSuggestedEvents.coffee
@@ -1,0 +1,98 @@
+UserEvents = require '/imports/collections/userEvents.coffee'
+
+###
+# Template.suggestedEvents - creates a reactive table to be display as part of
+#   the curatorInbox -> curatorEvents views.  The table is populated by a
+#   remove server-side meteor method that performs a full-text search on the
+#   UserEvents collection. The result is sorted by highest score.
+#
+#   The table is reactively updated by an autorun that listens to changes
+#   on the Template.currentEvents reactive var `associatedEventIdsToArticles`.
+###
+
+Template.suggestedEvents.onCreated ->
+  @isOpen = new ReactiveVar(true)
+  @events = new ReactiveVar([])
+  @initialEvents = []
+
+  # sets the suggestedEvents table fields
+  @eventFields = [
+    {
+      key: 'score'
+      label: ''
+      sortOrder: 1
+      sortDirection: 'descending'
+      hidden: true
+    },
+    {
+      key: 'eventName'
+      label: ''
+      tmpl: Template.curatorEventSearchRow
+    }
+  ]
+
+  ###
+  # updateSuggestedEvents - takes the result of a reactive computation and
+  #   updates the suggested events array by computing the difference.
+  #
+  # @param {object} associated, the object's keys contains the userEventId of
+  #   associated UserEvents
+  ###
+  @updateSuggestedEvents = (associated) =>
+    suggestedUserEventIds = _.pluck(@initialEvents, '_id')
+    associatedUserEventIds = Object.keys(associated)
+    diff = _.difference(suggestedUserEventIds, associatedUserEventIds)
+    events = _.filter(@initialEvents, (e) -> diff.indexOf(e._id) >= 0)
+    @events.set(events)
+
+  # strip punctuation and create tokens
+  tokens = if @data.title then @data.title.replace(/[~`!@#$%^&*(){}\[\];:"'<,.>?\/\\|_+=-]/g, '').split(' ') else []
+  # remove the first token from the search string (PRO/AH/EDR> without the special chars)
+  # TODO: this is domain specific to ProMed. If other feeds are added, we would
+  # need to do some conditional logic `if feed.isPromed then remove first token`.
+  search = if tokens.length > 1 then tokens.slice(1, tokens.length).join(' ') else ''
+  # call the server-side meteor method to perform full-text search sorted by score
+  Meteor.call 'searchUserEvents', search, (err, res) =>
+    if err
+      return
+    # set the initialEvents to the result and update the reactive array
+    @initialEvents = res
+    @events.set(res)
+
+  # reactively compute changes to associatedEventIdsToArticles object and
+  # update the suggested events
+  @autorun =>
+    if Template.curatorEvents.associatedEventIdsToArticles
+      associated = Template.curatorEvents.associatedEventIdsToArticles.get()
+      @updateSuggestedEvents(associated)
+
+Template.suggestedEvents.helpers
+  # controls the visiblity of the suggested-events-table and toggles the chevron
+  isOpen: ->
+    Template.instance().isOpen.get()
+  # the reactive array that populates the reactive-`table
+  events: ->
+    Template.instance().events.get()
+  # settings for the reactive-table
+  settings: ->
+    fields = Template.instance().eventFields
+    return {
+      id: 'suggested-events-table'
+      noDataTmpl: Template.noCuratorEvents
+      fields: fields
+      showRowCount: false
+      showFilter: false
+      showColumnToggles: false
+      showNavigationRowsPerPage: false
+      currentPage: 1
+      rowsPerPage: 5
+      class: "table table-hover col-sm-12"
+    }
+
+Template.suggestedEvents.events
+  # event handler to toggle the reactive var isOpen
+  'click .curator-collapse': (event, template) ->
+    if template.isOpen.get()
+      template.isOpen.set false
+    else
+      template.isOpen.set true

--- a/client/controllers/curatorSuggestedEvents.coffee
+++ b/client/controllers/curatorSuggestedEvents.coffee
@@ -86,6 +86,7 @@ Template.suggestedEvents.helpers
       showFilter: false
       showColumnToggles: false
       showNavigationRowsPerPage: false
+      showNavigation: 'never'
       currentPage: 1
       rowsPerPage: 5
       class: "table table-hover col-sm-12"

--- a/client/views/curatorEvents.jade
+++ b/client/views/curatorEvents.jade
@@ -14,7 +14,7 @@ template(name="curatorEvents")
       p.no-events.muted-text Currently no associated events
 
   .suggested-events.curator-events
-    +suggestedEvents
+    +suggestedEvents title=title associatedEventIdsToArticles=associatedEventIdsToArticles
 
   .all-events.curator-events
     .curator-events-header

--- a/client/views/curatorEvents.jade
+++ b/client/views/curatorEvents.jade
@@ -13,6 +13,9 @@ template(name="curatorEvents")
     else
       p.no-events.muted-text Currently no associated events
 
+  .suggested-events.curator-events
+    +suggestedEvents
+
   .all-events.curator-events
     .curator-events-header
       h4 All Events

--- a/client/views/curatorSuggestedEvents.jade
+++ b/client/views/curatorSuggestedEvents.jade
@@ -1,0 +1,11 @@
+template(name='suggestedEvents')
+  .curator-events-header.curator-collapse
+    h4
+      | Suggested Events
+    .curator-events-collapse
+      if isOpen
+        i.fa.fa-lg.fa-chevron-circle-down
+      else
+        i.fa.fa-lg.fa-chevron-circle-left
+  if isOpen
+    +reactiveTable collection=events settings=settings class='table curator-events-table'}

--- a/client/views/curatorSuggestedEvents.jade
+++ b/client/views/curatorSuggestedEvents.jade
@@ -8,4 +8,4 @@ template(name='suggestedEvents')
       else
         i.fa.fa-lg.fa-chevron-circle-left
   if isOpen
-    +reactiveTable collection=events settings=settings class='table curator-events-table'}
+    +reactiveTable collection=events settings=settings class='table curator-events-table'

--- a/imports/collections/userEvents.coffee
+++ b/imports/collections/userEvents.coffee
@@ -1,2 +1,15 @@
 UserEvents = new Mongo.Collection "userEvents"
+
+###
+  ensures that a $text index is created on the eventName and summary
+###
+ensureIndexes = () ->
+  UserEvents.rawCollection().createIndex {eventName: 'text', summary: 'text'}, (error) ->
+    if error
+      console.warn '[UserEvents.createIndex]: ', error
+
+if Meteor.isServer
+  Meteor.startup ->
+    ensureIndexes()
+
 module.exports = UserEvents

--- a/imports/stylesheets/curator.import.styl
+++ b/imports/stylesheets/curator.import.styl
@@ -220,7 +220,13 @@
     .tr-incidents-wrapper
       padding 0
 
+.curator-collapse
+  cursor pointer
+.curator-events-collapse
+  margin-left auto
+
 #associated-events
+#suggested-events-table
 #curator-events-table
   margin-left 15px
   tr

--- a/methods/userEvents.coffee
+++ b/methods/userEvents.coffee
@@ -61,3 +61,8 @@ Meteor.methods
         $unset:
           lastIncidentDate: ""
       })
+
+if Meteor.isServer
+    Meteor.methods
+      searchUserEvents: (search) ->
+        UserEvents.find({$text: {$search: search}}, {fields: {score: {$meta: 'textScore'}}, sort: {score: {$meta: 'textScore'}}}).fetch()

--- a/methods/userEvents.coffee
+++ b/methods/userEvents.coffee
@@ -61,8 +61,3 @@ Meteor.methods
         $unset:
           lastIncidentDate: ""
       })
-
-if Meteor.isServer
-    Meteor.methods
-      searchUserEvents: (search) ->
-        UserEvents.find({$text: {$search: search}}, {fields: {score: {$meta: 'textScore'}}, sort: {score: {$meta: 'textScore'}}}).fetch()

--- a/server/interfaces.coffee
+++ b/server/interfaces.coffee
@@ -52,3 +52,13 @@ Meteor.methods
       response.data
     else
       throw new Meteor.Error 500, "Unable to reach the API"
+
+  ###
+  # searchUserEvents - perform a full-text search on `eventName` and `summary`,
+  #   sorted by matching score.
+  #
+  # @param {string} search, the text to search for matches
+  # @returns {array} userEvents, an array of userEvents
+  ###
+  searchUserEvents: (search) ->
+    UserEvents.find({$text: {$search: search}}, {fields: {score: {$meta: 'textScore'}}, sort: {score: {$meta: 'textScore'}}}).fetch()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/132240647

- $text index on UserEvent `eventName` and `summary`
- server-side meteor method to perform the $text $search sorted by score
- reactive table that displays the suggested events 
- updates reactively based on associatedEventIdsToArticles object

Steps:
1. Visit Curators -> Inbox
2. Note: collapsible 'Suggested Events' table, matches that do not exist in 'Associated Events' will be displayed
3. Click on the `+` icon to add an event to the 'Associated Events' section
4. Click on the `-` icon to remove and event from the 'Associated Events' section
5. Note: the table updates reactively