### PR TITLE
adds feature to clean urls

### DIFF
--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -1,6 +1,9 @@
 Incidents = require '/imports/collections/incidentReports.coffee'
 Articles = require '/imports/collections/articles.coffee'
 
+import {formatUrl} from '/imports/utils.coffee'
+
+
 Template.articles.onCreated ->
   @selectedSourceId = new ReactiveVar null
 
@@ -70,6 +73,8 @@ Template.articles.helpers
         locations[location.id] = location.name
     )
     _.flatten locations
+  formatUrl: (url) ->
+    formatUrl(url)
 
 Template.articles.events
   "click .reactive-table tbody tr": (event, template) ->

--- a/client/controllers/curatorEvents.coffee
+++ b/client/controllers/curatorEvents.coffee
@@ -91,7 +91,7 @@ Template.curatorEvents.events
       Blaze.renderWithData(Template.curatorEventIncidents, this, $tr[0])
   "click .associate-event": (event, template) ->
     Meteor.call('addEventSource', {
-      url: "http://www.promedmail.org/post/" + template.data.selectedSourceId.get(),
+      url: "promedmail.org/post/" + template.data.selectedSourceId.get(),
       userEventId: @_id
       publishDate: template.data.publishDate
       publishDateTZ: "EST"

--- a/client/controllers/incidentReport.coffee
+++ b/client/controllers/incidentReport.coffee
@@ -1,3 +1,9 @@
+import { formatUrl } from '/imports/utils.coffee'
+
+Template.incidentReport.helpers
+  formatUrl: (url) ->
+    formatUrl(url)
+
 Template.addIncidentReport.events
   "click .open-incident-form": (event, template) ->
     Modal.show("incidentModal", {articles: template.data.articles, userEventId: template.data.userEvent._id, add: true})

--- a/client/controllers/incidentReports.coffee
+++ b/client/controllers/incidentReports.coffee
@@ -20,6 +20,9 @@ tooltipTmpl = """
   </div>
 """
 
+import { formatUrl } from '/imports/utils.coffee'
+
+
 Template.incidentReports.onDestroyed ->
   if @plot
     @plot.destroy()
@@ -92,6 +95,8 @@ Template.incidentReports.onRendered ->
       return
 
 Template.incidentReports.helpers
+  formatUrl: (url) ->
+    formatUrl(url)
   getSettings: ->
     fields = [
       {
@@ -192,7 +197,6 @@ Template.incidentReports.events
       template.plot.removeFilter('notCumulative')
       template.plot.addFilter('cumulative', template.filters.cumulative)
       template.updatePlot()
-
   "click #scatterPlot-resetZoom": (event, template) ->
     template.plot.resetZoom()
   "click #event-incidents-table th": (event, template) ->

--- a/client/controllers/sourceModal.coffee
+++ b/client/controllers/sourceModal.coffee
@@ -1,13 +1,15 @@
 convertDate = require "/imports/convertDate.coffee"
-utils = require '/imports/utils.coffee'
 Articles = require '/imports/collections/articles.coffee'
+
+import {UTCOffsets, cleanUrl} from '/imports/utils.coffee'
+
 
 Template.sourceModal.onCreated ->
   @tzIsSpecified = false
   @proMEDRegEx = /promedmail\.org\/post\/(\d+)/ig
   if @data.publishDate
     @timezoneFixedPublishDate = convertDate(@data.publishDate, "local",
-                                              utils.UTCOffsets[@data.publishDateTZ])
+                                              UTCOffsets[@data.publishDateTZ])
   @suggestedArticles = new Mongo.Collection(null)
   Meteor.call 'queryForSuggestedArticles', @data.userEventId, (error, result) =>
     if result
@@ -41,7 +43,7 @@ Template.sourceModal.helpers
   timezones: ->
     timezones = []
     defaultTimezone = if moment().isDST() then 'EDT' else 'EST'
-    for tzKey, tzOffset of utils.UTCOffsets
+    for tzKey, tzOffset of UTCOffsets
       timezones.push({name: tzKey, offset: tzOffset})
       if @publishDateTZ
         if @publishDateTZ is tzKey
@@ -86,7 +88,7 @@ Template.sourceModal.events
 
     source = {
       userEventId: templateInstance.data.userEventId
-      url: article
+      url: cleanUrl(article)
       publishDateTZ: form.publishDateTZ.value
     }
 
@@ -99,7 +101,7 @@ Template.sourceModal.events
       if form.publishTime.value.length
         selectedDate.set({hour: time.get("hour"), minute: time.get("minute")})
         selectedDate = convertDate(selectedDate,
-                                    utils.UTCOffsets[source.publishDateTZ], "local")
+                                    UTCOffsets[source.publishDateTZ], "local")
       source.publishDate = selectedDate.toDate()
 
     enhance = form.enhance.checked
@@ -148,7 +150,7 @@ Template.sourceModal.events
       if form.publishTime.value.length
         selectedDate.set({hour: time.get("hour"), minute: time.get("minute")})
         selectedDate = convertDate(selectedDate,
-                                    utils.UTCOffsets[source.publishDateTZ], "local")
+                                    UTCOffsets[source.publishDateTZ], "local")
       source.publishDate = selectedDate.toDate()
 
     Meteor.call("updateEventSource", source, (error, result) ->

--- a/client/controllers/sourceModal.coffee
+++ b/client/controllers/sourceModal.coffee
@@ -175,7 +175,7 @@ Template.sourceModal.events
           daylightSavings = daylightSavings and moment.utc(
             date.year() + "-11-01") >= date
           tz = if daylightSavings then "EDT" else "EST"
-          date = date.utcOffset(utils.UTCOffsets[tz])
+          date = date.utcOffset(UTCOffsets[tz])
           templateInstance.$("#publishDateTZ").val(tz)
           templateInstance.$('#publishDate').data("DateTimePicker").date(date)
           templateInstance.$('#publishTime').data("DateTimePicker").date(date)

--- a/client/controllers/suggestedIncidents.coffee
+++ b/client/controllers/suggestedIncidents.coffee
@@ -201,7 +201,7 @@ Template.suggestedIncidentsModal.events
     content = Template.instance().content.get()
     displayCharacters = 150
     [start, end] = incident.countAnnotation.textOffsets[0]
-    
+
     startingIndex = Math.min(incident.locationTerritory?.territoryStart or start,
       incident.dateTerritory?.territoryStart or start)
     precedingText = content.slice(startingIndex, start)

--- a/client/views/articles.jade
+++ b/client/views/articles.jade
@@ -23,7 +23,7 @@ template(name="articles")
               | Add Source
       .col-md-6.event-sources-detail
         if selectedSource
-          h2= selectedSource.url
+          h2= formatUrl(selectedSource.url)
           .row.event-source-info
             .col-lg-1
               a.ref-link(href="{{selectedSource.url}}" target="_blank" rel="noopener noreferrer")

--- a/client/views/incidentReports.jade
+++ b/client/views/incidentReports.jade
@@ -35,7 +35,7 @@ template(name="incidentReport")
         .col-sm-10
           each val in url
             p.form-control-static
-              a.ref-link(href="{{val}}" target="_blank") {{val}}
+              a.ref-link(href="{{formatUrl(val)}}" target="_blank") {{formatUrl(val)}}
       if dateRange
         .row
           .col-sm-2.control-label Date:

--- a/imports/utils.coffee
+++ b/imports/utils.coffee
@@ -1,4 +1,35 @@
-module.exports.incidentReportFormToIncident = (form)->
+###
+# cleanUrl - takes an existing url and removes the last match of the applied
+#   regular expressions.
+#
+# @param {string} existingUrl, the url to be cleaned
+# @param {array} [regexps], (optional) an array of compiled regular expressions
+# @returns {string} cleanedUrl, an url that has been cleaned
+###
+export cleanUrl = (existingUrl, regexps) ->
+  regexps = regexps || [new RegExp('^(https?:\/\/)', 'i'), new RegExp('^(www\.)', 'i')]
+  cleanedUrl = existingUrl
+  regexps.forEach (r) ->
+    found = false
+    match = cleanedUrl.match(r)
+    if match && match.length > 0
+      cleanedUrl = cleanedUrl.replace(match[match.length-1], '')
+  return cleanedUrl
+
+###
+# formatUrl - takes an cleaned url and adds 'http' so that a browser can open
+#
+# @param {string} existingUrl, the url to be formatted
+# @returns {string} formattedUrl, an url that has 'http' added
+###
+export formatUrl = (existingUrl) ->
+  regexp = new RegExp('^(https?:\/\/)', 'i')
+  if regexp.test existingUrl
+    return existingUrl
+  else
+    return 'http://' + existingUrl
+
+export incidentReportFormToIncident = (form)->
   $form = $(form)
   $articleSelect = $(form.articleSource)
   if $form.find("#singleDate").hasClass("active")
@@ -60,7 +91,7 @@ module.exports.incidentReportFormToIncident = (form)->
     incident.locations.push(item)
   return incident
 
-module.exports.UTCOffsets =
+export UTCOffsets =
   ADT:  '-0300'
   AKDT: '-0800'
   AKST: '-0900'
@@ -84,7 +115,7 @@ module.exports.UTCOffsets =
   WGST: '-0200'
   WGT: '-0300'
 
-module.exports.regexEscape = (s)->
+export regexEscape = (s)->
   # Based on bobince's regex escape function.
   # source: http://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/3561711#3561711
   s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')

--- a/server/cleanUrls.coffee
+++ b/server/cleanUrls.coffee
@@ -1,0 +1,96 @@
+import Articles from '/imports/collections/articles.coffee'
+import IncidentReports from '/imports/collections/incidentReports.coffee'
+import CuratorSources from '/imports/collections/curatorSources.coffee'
+import { attemptBulkUpdate } from './dbUtils.coffee'
+import { cleanUrl } from '/imports/utils.coffee'
+
+###
+# updateUrls - looks for `https?` and `(www.)` patterns within the url
+#   property of the specified collection. @note this requires that the document
+#   has a `url` property as either a string or an array
+#
+# @param {object} collection, the mongo collection to search aggregately
+# @param {string} host, the hostname of the url to clean
+# @param {string} domain, the domain of the url to clean
+###
+updateUrls = (collection, host, domain) ->
+  bulkUpdates = []
+  parts = [new RegExp('^(?:https?:\/\/)', 'i'), new RegExp("^(www\.)#{host}\.#{domain}", 'i')]
+  full = new RegExp("^(https?:\/\/)?(www\.)?\\S+#{host}\.#{domain}", 'i')
+  query = {url: {$regex: full}}
+  cursor = collection.find(query)
+  len = cursor.count()
+  if len <= 0
+    return
+  cursor.forEach (d) ->
+    if _.isArray(d.url)
+      hasAnyBeenModified = false
+      cleaned = []
+      d.url.forEach (url) ->
+        if full.test(url)
+          cleanedUrl = cleanUrl(url, parts)
+          if cleanedUrl != url
+            hasAnyBeenModified = true
+        # we will overwrite the entire array of links, so all urls are pushed
+        cleaned.push(cleanedUrl)
+      if hasAnyBeenModified
+        bulkUpdates.push([d._id, {$set: {url: cleaned}}])
+    else
+      # working with a single value
+      if full.test(d.url)
+        cleanedUrl = cleanUrl(d.url, parts)
+        if cleanedUrl != d.url
+          bulkUpdates.push([d._id, {$set: {url: cleanedUrl}}])
+  if bulkUpdates.length > 0
+    attemptBulkUpdate(collection, bulkUpdates)
+
+###
+# updateMetadataLinks - looks for `https?` and `www.` patterns within the url
+#   property of the specified collection. @note this requires that the document
+#   has a `metadata.links` property as an array
+#
+# @param {object} collection, the mongo collection to search aggregately
+# @param {string} host, the hostname of the url to clean
+# @param {string} domain, the domain of the url to clean
+###
+updateMetadataLinks = (collection, host, domain) ->
+  bulkUpdates = []
+  parts = [new RegExp('^(?:https?:\/\/)', 'i'), new RegExp("^(www\.)#{host}\.#{domain}", 'i')]
+  full = new RegExp("^(https?:\/\/)?(www\.)?\\S+#{host}\.#{domain}", 'i')
+  query = {'metadata.links': {$regex: full }}
+  cursor = collection.find(query)
+  len = cursor.count()
+  if len <= 0
+    return
+  cursor.forEach (d) ->
+    if _.isArray(d.metadata.links)
+      hasAnyBeenModified = false
+      cleaned = []
+      d.metadata.links.forEach (url) ->
+        cleanedUrl = url
+        if full.test(url)
+          cleanedUrl = cleanUrl(url, parts)
+          if cleanedUrl != url
+            hasAnyBeenModified = true
+        # we will overwrite the entire array of links, so all urls are pushed
+        cleaned.push(cleanedUrl)
+      # flag, if anything has changed?
+      if hasAnyBeenModified
+        bulkUpdates.push([d._id, {$set: {'metadata.links': cleaned}}])
+  if bulkUpdates.length > 0
+    attemptBulkUpdate(collection, bulkUpdates)
+
+###
+# cleanPromedUrls - finds and cleans promedmail urls from `Articles`, `IncidentReports` and
+#   `CuratorSources` urls/links properties.
+###
+cleanPromedUrls = ->
+    host = 'promedmail'
+    domain = 'org'
+    updateUrls(Articles, host, domain)
+    updateUrls(IncidentReports, host, domain)
+    updateMetadataLinks(CuratorSources, host, domain)
+
+if Meteor.isServer
+  Meteor.startup ->
+    cleanPromedUrls()

--- a/server/dbUtils.coffee
+++ b/server/dbUtils.coffee
@@ -1,0 +1,90 @@
+###
+#  ensures that an index is created on a collection
+#
+# @param {object} collection, a meteor collection to apply the index
+# @param {object} keys, the index fields
+# @param {object} options, this index options
+# @see https://docs.mongodb.com/v3.2/reference/method/db.collection.createIndex/
+###
+export ensureIndexes = (collection, keys, options) ->
+  options = options || {}
+  collection.rawCollection().createIndex keys, options, (error) ->
+    if error
+      console.error "[#{collection._name} ensureIndexes]: ", error
+
+###
+# ObjectIdNotSupportedError - error thrown when a bulk update is performed with
+#   any Mongo ObjectID's, which are not supported.
+#
+# @param {string} [message], (optional) the message to the user
+###
+class ObjectIdNotSupportedError extends Error
+  name: 'ObjectIdNotSupportedError'
+  constructor: (message) ->
+    @message = message || 'Bulk Update does not support Mongo ObjectID.'
+    super()
+
+###
+# bulkUpdate - updates an array of documents at once
+#
+# @param {object} collection, a meteor collection to apply the updates
+# @param {object[]} updates, array containing positional values for the update
+# @param {object} updates[0], the string _id of the document
+# @param {object} updates[1], the fields to update with appropriate mongodb operator
+#   ex: `['iPKcdkR4ozb5ResKE', {$set: {url: 'some/place'}}]`
+# @param {function} callback, the method to execute when done
+#
+# @throws {ObjectIdNotSupported}
+# @note this method does not support ObjectIds inside a Meteor environment
+###
+export bulkUpdate = (collection, updates, callback) ->
+  if updates.length <= 0
+    return
+  # get the bulk operation interface
+  bulk = collection.rawCollection().initializeUnorderedBulkOp()
+  updates.forEach (update) ->
+    # not supported on mongodb ObjectId
+    if typeof update[0] == 'object'
+      throw new ObjectIdNotSupportedError()
+    bulk.find({_id: update[0]}).updateOne(update[1])
+  # execute all operations on mongodb at once
+  if typeof callback == 'function'
+    bulk.execute(callback)
+  else
+    bulk.execute()
+
+###
+# attemptBulkUpdate - implementation of bulkUpdate that falls back to single document
+#   update if it throws an ObjectIdNotSupported exception, outputs to console.info
+#
+# @param {object} collection, a meteor collection to apply the updates
+# @param {object[]} updates, array containing positional values for the update
+# @param {object} updates[0], the string _id of the document
+# @param {object} updates[1], the fields to update with appropriate mongodb operator
+#   ex: `['iPKcdkR4ozb5ResKE', {$set: {url: 'some/place'}}]`
+###
+export attemptBulkUpdate = (collection, updates) ->
+  try
+    bulkUpdate(collection, updates, (err, res) ->
+      if err
+        console.error "[#{collection._name} bulkUpdate] error: ", error
+        return
+      console.info "[#{collection._name} bulkUpdate] nInserted: #{res.nInserted}"
+      console.info "[#{collection._name} bulkUpdate] nUpserted: #{res.nUpserted}"
+      console.info "[#{collection._name} bulkUpdate] nMatched : #{res.nMatched}"
+      console.info "[#{collection._name} bulkUpdate] nModified: #{res.nModified}"
+      console.info "[#{collection._name} bulkUpdate] nRemoved : #{res.nRemoved}"
+    )
+  catch e
+    if e instanceof ObjectIdNotSupportedError
+      console.warn e.message
+      console.warn 'Falling back to individual updates'
+      # perform individual updates
+      count = 0
+      updates.forEach (u) ->
+        collection.update({_id: u[0]}, u[1])
+        count++
+      console.info "[#{collection._name}] updated: #{count}"
+    else
+      # rethrow the unknow error
+      throw e

--- a/server/indexes.coffee
+++ b/server/indexes.coffee
@@ -1,0 +1,13 @@
+import Articles from '/imports/collections/articles.coffee'
+import IncidentReports from '/imports/collections/incidentReports.coffee'
+import CuratorSources from '/imports/collections/curatorSources.coffee'
+import { ensureIndexes} from './dbUtils.coffee'
+
+###
+# indexes.coffee - provide a single location to ensure all db indexes on startup
+###
+
+Meteor.startup ->
+  ensureIndexes(Articles, {url: 1})
+  ensureIndexes(IncidentReports, {url: 1})
+  ensureIndexes(CuratorSources, {'metadata.links': 1})

--- a/server/interfaces.coffee
+++ b/server/interfaces.coffee
@@ -1,7 +1,9 @@
 UserEvents = require '/imports/collections/userEvents.coffee'
 Articles = require '/imports/collections/articles.coffee'
-utils = require '/imports/utils.coffee'
 PromedPosts = require '/imports/collections/promedPosts.coffee'
+
+import { formatUrl } from '/imports/utils.coffee'
+
 
 DateRegEx = /<span class="blue">Published Date:<\/span> ([^<]+)/
 
@@ -18,7 +20,8 @@ Meteor.methods
         api_key: "Cr9LPAtL"
         returnSourceContent: true
         showKeypoints: true
-        url: url
+        # formatUrl takes a database cleanUrl and adds 'http://'
+        url: formatUrl(url)
     })
     if result.data.error
       throw new Meteor.Error("grits-error", result.data.error)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/131123351

## Server

- adds startup methods to clean urls from the substrings `https?` and `(www.)?`
Example: http://www.promedmail.org/post/abc -> promedmail.org/post/abc

Steps:
1. Drop all `articles`, `counts`, and `curatorSources` collections from mongo
2. Perform mongorestore from backup that contains urls/links that need cleaned
2a. Extract a backup from AWS (this will create the directory `/var/log/dump/eidr-connect`)
2b. Change directories `cd /var/log/dump/eidr-connect`
2c. Run mongorestore `mongorestore -d eidr-connect .`
3. Verify that urls contain `https?` and `(www.)?`
4. Start meteor server
4a. Watch for output to stdout about bulkUpdate nModified for each collection
4b. Notice `curatorSources` falls back to single item updates due to its use of Mongo.ObjectID
5. Verify that the urls/metadata.links in `articles`, `counts`, and `curatorSources` appear correct.
6. Restart meteor server; Note: the queries return 0

## Client
Note: The client displays `formatUrl()` with http:// reinserted
![image](https://cloud.githubusercontent.com/assets/12954045/19779680/2d6b52fe-9c50-11e6-9661-e273542c7f50.png)
![image](https://cloud.githubusercontent.com/assets/12954045/19779705/4d377086-9c50-11e6-9b8f-2a1247dd4234.png)


## Notes
- @nathanathan - I started introducing CoffeeScript `import` and `export` methods vs. `require`. This allows for a slightly cleaner interface when importing individual methods. See CoffeeScript [ES6 Style Modules](http://coffeescript.org/#modules).  I can convert all the modules to use this syntax or revert.

- The backup `mongodump-2016-10-25.tar` has data that should be manually cleaned if its still on production.  See the following query: `db.getCollection('curatorSources').find({'_id': {$in: [ObjectId('57f6bb9bffd3ba063abcef57'), ObjectId('57ae633f04594a0e1adb626a')]}})`

- The implementation of this feature does introduce a slight bit of complexity. E.g. within the client it will be necessary to call `utils.cleanUrl()` prior to saving to the database (strips https? and www) and then `utils.formatUrl()` to reinsert the `http://` so that `<a>` functions properly within templates.