### PR TITLE
Show next source after reviewal

### DIFF
--- a/client/controllers/curatorEvents.coffee
+++ b/client/controllers/curatorEvents.coffee
@@ -4,15 +4,20 @@ CuratorSources = require '/imports/collections/curatorSources.coffee'
 Articles = require '/imports/collections/articles.coffee'
 
 Template.curatorEvents.onCreated ->
-  @subscribe("articles", {
-    url:
-      $regex: "post\/" + @data._sourceId + "$"
-  })
-  @associatedEventIdsToArticles = new ReactiveVar([])
+  instance = @
+  @autorun ->
+    sourceId = instance.data.selectedSourceId.get()
+
+    instance.subscribe("articles", {
+      url:
+        $regex: "post\/" + sourceId + "$"
+    })
+    instance.associatedEventIdsToArticles = new ReactiveVar([])
+
   @autorun =>
     @associatedEventIdsToArticles.set _.object(Articles.find(
       url:
-        $regex: "post\/" + @data._sourceId + "$"
+        $regex: "post\/" + instance.data.selectedSourceId.get() + "$"
     ).map((article)->
       [article.userEventId, article]
     ))
@@ -80,7 +85,7 @@ Template.curatorEvents.events
       Blaze.renderWithData(Template.curatorEventIncidents, this, $tr[0])
   "click .associate-event": (event, template) ->
     Meteor.call('addEventSource', {
-      url: "http://www.promedmail.org/post/" + template.data._sourceId,
+      url: "http://www.promedmail.org/post/" + template.data.selectedSourceId.get(),
       userEventId: @_id
       publishDate: template.data.publishDate
       publishDateTZ: "EST"

--- a/client/controllers/curatorInbox.coffee
+++ b/client/controllers/curatorInbox.coffee
@@ -280,7 +280,7 @@ Template.curatorSourceDetails.events
         nextSource = CuratorSources.findOne {reviewed: false},  sort: publishDate: -1
         template.data.selectedSourceId.set nextSource._id
         notifying.set false
-      , 700
+      , 1200
 
   'click .toggle-source-content': (event, template) ->
     open = template.contentIsOpen

--- a/client/views/curatorInbox.jade
+++ b/client/views/curatorInbox.jade
@@ -71,9 +71,11 @@ template(name="curatorSourceDetails")
             span Mark Reviewed
       if notifying
         .notification
-          i.fa.fa-check-circle.confirmation
+          .checks
+            i.fa.fa-check-circle.confirmation
+            .circle
           p Preparing next source
-          i.fa.fa-cog.fa-spin
+      .transition(class="{{#if notifying}} active {{/if}}")
     .curator-source-details-content
       if contentIsOpen
         .curator-source-details-copy-wrapper

--- a/client/views/curatorInbox.jade
+++ b/client/views/curatorInbox.jade
@@ -31,7 +31,7 @@ template(name="curatorInbox")
             .loading
       if isReady
         .col-sm-6.curator-source-details
-          +curatorSourceDetails selectedSourceId=selectedSourceId
+          +curatorSourceDetails selectedSourceId=selectedSourceId query=query
 
 template(name="curatorInboxSection")
   if post

--- a/client/views/curatorInbox.jade
+++ b/client/views/curatorInbox.jade
@@ -54,7 +54,7 @@ template(name="curatorInboxSection")
         class="table table-hover curator-inbox-table")
 
 template(name="curatorSourceDetails")
-  with post
+  with source
     .curator-inbox-header.curator-source-details-header(class="{{#if isReviewed}} reviewed {{/if}}")
       h2= title
       .curator-source-details-options

--- a/client/views/curatorInbox.jade
+++ b/client/views/curatorInbox.jade
@@ -5,9 +5,6 @@ template(name="curatorInbox")
         .row.curator-inbox-header
           h2 Sources
           .curator-inbox-options
-            if isLoading
-              a.curator-refresh-icon
-                i.fa.fa-refresh.fa-spin
             a.curator-filter-calendar-icon(class="{{#if calendarState}} active {{/if}}")
               i.fa.fa-calendar
             a.curator-filter-reviewed-icon(class="{{#unless reviewFilterActive}} active {{/unless}}")
@@ -25,14 +22,16 @@ template(name="curatorInbox")
         .curator-inbox-source-list.row
           if isReady
             each day in days
-              +curatorInboxSection date=day index=@index reviewFilter=reviewFilter
+              +curatorInboxSection(
+                date=day
+                index=@index
+                reviewFilter=reviewFilter
+                selectedSourceId=selectedSourceId)
           else
-            .text-center
-              br
-              p Loading...
+            .loading
       if isReady
         .col-sm-6.curator-source-details
-          .curator-inbox-header
+          +curatorSourceDetails selectedSourceId=selectedSourceId
 
 template(name="curatorInboxSection")
   if post
@@ -48,7 +47,11 @@ template(name="curatorInboxSection")
           else
             i.fa.fa-chevron-circle-left
     if isOpen
-      +reactiveTable collection=posts settings=settings selector=selector class="table table-hover curator-inbox-table" rowClass="curator-inbox-table-row"
+      +reactiveTable(
+        collection=posts
+        settings=settings
+        selector=selector
+        class="table table-hover curator-inbox-table")
 
 template(name="curatorSourceDetails")
   with post
@@ -66,8 +69,15 @@ template(name="curatorSourceDetails")
             span Reviewed
           else
             span Mark Reviewed
+      if notifying
+        .notification
+          i.fa.fa-check-circle.confirmation
+          p Preparing next source
+          i.fa.fa-cog.fa-spin
     .curator-source-details-content
       if contentIsOpen
         .curator-source-details-copy-wrapper
           .curator-source-details-copy= content
-      +curatorEvents
+      +curatorEvents selectedSourceId=selectedSourceId
+      if notifying
+        .veil

--- a/imports/stylesheets/curator.import.styl
+++ b/imports/stylesheets/curator.import.styl
@@ -91,6 +91,8 @@
 
 .curator-inbox-source-list
   border-right 1px solid $border-primary
+  .reactive-table-options
+    display none
 
 .curator-inbox-table
   margin-bottom 0
@@ -100,22 +102,20 @@
   tr
     padding-left 7px
     padding-right 7px
-  .details-open
-    background $secondary-light
-    &:hover
-      background $secondary-light
   .title
     max-width 400px
 
 .curator-inbox-section-head
   color $primary
   background $primary-l-light
-  border-top 1px $primary-light solid
-  border-bottom 1px $primary-light solid
+  border-top 1px solid $border-primary
+  border-bottom 1px solid $border-primary
   height 37px
   font-size 14px
   padding-top 8px
   cursor pointer
+  &:hover
+    background darken(@background, 4%)
 
 .curator-inbox-buttons
   margin-bottom 30px
@@ -124,6 +124,7 @@
   padding 0
 
 .curator-source-details-header
+  position relative
   background none
   border-bottom 2px solid $border-primary
   h2
@@ -138,6 +139,37 @@
   &.reviewed
     h2
       color darken($positive, 35%)
+  .notification
+    position absolute
+    top 0
+    bottom 0
+    left 0
+    right 0
+    z-index 101
+    background desaturate(lighten($positive, 20%), 10%)
+    display flex
+    align-items center
+    justify-content center
+    height 50px
+    overflow hidden
+    p
+      margin 0
+      color $primary-dark
+      font-size 1.2em
+      font-weight 300
+      text-transform uppercase
+      letter-spacing .03em
+    i
+    .confirmation
+      color white
+    .confirmation
+      font-size 6em
+      margin-right .2em
+    .fa-spin
+      color alpha($primary, 30%)
+      margin-left .5em
+      font-size 1.5em
+
 
 .curator-source-details-options
   display flex
@@ -224,18 +256,36 @@
   .open-icon
     margin-right 30px
 
-.curator-inbox-table-row
-  .curator-inbox-curated-row::before
-    content "\f058"
-    font-family FontAwesome
-    color $positive
-  td:first-of-type
-    width 45px
-    text-align right
-  td:nth-of-type(-n+2)
-    display table-cell !important
-    padding-top 8px
-    padding-bottom 8px
+.curator-inbox-table
+  border-radius 0
+  border 0
+  tr
+    position relative
+    &:first-of-type
+      td
+        border 0
+    .curator-inbox-curated-row
+      &::before
+        content "\f058"
+        font-family FontAwesome
+        color $positive
+    td
+      border-color $border-primary-light
+      &:first-of-type
+        width 45px
+        text-align right
+      &:nth-of-type(-n+2)
+        display table-cell !important
+        padding-top 8px
+        padding-bottom 8px
+    &.selected
+      background $selected
+      cursor default
+      &:hover
+        background @background
+    .details-row
+      position relative
+      color $border-primary
 
 .curator-events
   margin-bottom 2em

--- a/imports/stylesheets/curator.import.styl
+++ b/imports/stylesheets/curator.import.styl
@@ -58,7 +58,7 @@
     left 10px
     z-index 10
   a
-    color $primary-light
+    color lighten($primary, 60%)
     position relative
     top 5px
     margin-right 15px
@@ -67,9 +67,10 @@
     +below(4)
       display none
     &:hover
-      color $l-gray
+      color lighten(@color, 50%)
   .curator-filter-reviewed-icon,
   .curator-filter-calendar-icon
+    cursor pointer
     &.active
       color $positive
 
@@ -261,6 +262,8 @@
   border 0
   tr
     position relative
+    &:hover
+      background-color $border-primary-light
     &:first-of-type
       td
         border 0

--- a/imports/stylesheets/curator.import.styl
+++ b/imports/stylesheets/curator.import.styl
@@ -128,6 +128,7 @@
   position relative
   background none
   border-bottom 2px solid $border-primary
+  overflow hidden
   h2
     color $primary
     flex 1
@@ -146,12 +147,12 @@
     bottom 0
     left 0
     right 0
-    z-index 101
+    z-index 110
     background desaturate(lighten($positive, 20%), 10%)
     display flex
     align-items center
     justify-content center
-    height 50px
+    height 49px
     overflow hidden
     p
       margin 0
@@ -160,17 +161,35 @@
       font-weight 300
       text-transform uppercase
       letter-spacing .03em
+      margin-left 1em
     i
     .confirmation
       color white
     .confirmation
       font-size 6em
-      margin-right .2em
     .fa-spin
       color alpha($primary, 30%)
       margin-left .5em
       font-size 1.5em
-
+    .checks
+      position relative
+  .transition
+    position absolute
+    top 50%
+    left 50%
+    transform translate(-50%, -50%)
+    height 10px
+    width 10px
+    background white
+    z-index 120
+    transition .3s ease-in-out
+    transition-delay .1s
+    border-radius 50%
+    opacity 0
+    &.active
+      transition-delay .9s
+      opacity 1
+      transform scale(100)
 
 .curator-source-details-options
   display flex

--- a/imports/stylesheets/event.import.styl
+++ b/imports/stylesheets/event.import.styl
@@ -284,6 +284,10 @@
 
 .details-row::before
   content "\f105"
+  position absolute
+  right 1em
+  top 50%
+  transform translate(0, -50%)
 
 .open-row-right::before
   content "\f054"

--- a/imports/stylesheets/tables.import.styl
+++ b/imports/stylesheets/tables.import.styl
@@ -4,5 +4,11 @@
   border-radius $tableRadius $tableRadius 0 0
   border 1px solid #CCC
 
+
+
+.table > tbody > tr > th
+.table > tbody > tr > td
+  border-color $border-primary-light
+
 table tr:last-child
   border 0

--- a/imports/stylesheets/tables.import.styl
+++ b/imports/stylesheets/tables.import.styl
@@ -4,7 +4,8 @@
   border-radius $tableRadius $tableRadius 0 0
   border 1px solid #CCC
 
-
+.table-hover > tbody > tr:hover
+  background-color lighten($border-primary-light, 35%)
 
 .table > tbody > tr > th
 .table > tbody > tr > td

--- a/imports/stylesheets/variables.import.styl
+++ b/imports/stylesheets/variables.import.styl
@@ -1,6 +1,6 @@
 $primary = #345E7E
 $primary-light = #EAEEF2
-$primary-l-light = lighten($primary, 90%)
+$primary-l-light = #F5F7F9
 $primary-dark = darken($primary, 30%)
 $secondary = #F7B297
 $secondary-light = #FAF0EC

--- a/methods/curatorSources.coffee
+++ b/methods/curatorSources.coffee
@@ -1,7 +1,8 @@
 CuratorSources = require '/imports/collections/curatorSources.coffee'
 
 Meteor.methods
-  curateSource: (id, reviewed) ->
+  markSourceReviewed: (id, reviewed) ->
+    console.log id, reviewed
     if Roles.userIsInRole(Meteor.userId(), ['curator', 'admin'])
       CuratorSources.update({_id: id}, {
         $set:

--- a/methods/curatorSources.coffee
+++ b/methods/curatorSources.coffee
@@ -2,7 +2,6 @@ CuratorSources = require '/imports/collections/curatorSources.coffee'
 
 Meteor.methods
   markSourceReviewed: (id, reviewed) ->
-    console.log id, reviewed
     if Roles.userIsInRole(Meteor.userId(), ['curator', 'admin'])
       CuratorSources.update({_id: id}, {
         $set:

--- a/methods/promedPosts.coffee
+++ b/methods/promedPosts.coffee
@@ -36,6 +36,7 @@ if Meteor.isServer
         addedDate: new Date()
         publishDate: post.promedDate
         content: post.content
+        reviewed: false
         metadata:
           links: post.links
-      CuratorSources.upsert({_id: post._id}, {$set: normalizedPost})
+      CuratorSources.upsert({_id: post._id}, {$setOnInsert: normalizedPost})

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -27,15 +27,7 @@ Meteor.publish "userEvents", () ->
 
 # Curator Sources
 ReactiveTable.publish "curatorSources", CuratorSources, {}
-Meteor.publish "curatorSources", (range) ->
-  endDate = range?.endDate || new Date()
-  startDate = moment(endDate).subtract(2, 'weeks').toDate()
-  if range?.startDate
-    startDate = range.startDate
-  query =
-    publishDate:
-      $gte: new Date(startDate)
-      $lte: new Date(endDate)
+Meteor.publish "curatorSources", (query) ->
   CuratorSources.find(query, {
     sort:
       publishDate: -1

--- a/server/startup.coffee
+++ b/server/startup.coffee
@@ -3,6 +3,7 @@ Incidents = require '/imports/collections/incidentReports.coffee'
 articleSchema = require '/imports/schemas/article.coffee'
 Articles = require '/imports/collections/articles.coffee'
 PromedPosts = require '/imports/collections/promedPosts.coffee'
+CuratorSources = require '/imports/collections/curatorSources'
 
 Meteor.startup ->
   incidents = Incidents.find().fetch()
@@ -12,6 +13,7 @@ Meteor.startup ->
     catch error
       console.log error
       console.log JSON.stringify(incident, 0, 2)
+
   for article in Articles.find().fetch()
     promedId = /promedmail\.org\/post\/(\d+)$/ig.exec(article.url)?[1]
     if promedId
@@ -33,3 +35,9 @@ Meteor.startup ->
         console.log JSON.stringify(article, 0, 2)
     else
       console.log "non-ProMED Article:", article.url
+
+  CuratorSources.update
+    reviewed:
+      $exists: false
+    {$set: reviewed: false}
+    {multi: true}


### PR DESCRIPTION
This selects the next unreviewed source when a curator marks the currently selected source as reviewed.

Also reworks how we display source details in the curator inbox:
- Uses template in jade instead of calling `Blaze.renderWithData` in the controller
- Creates a reactiveVar which tracks which source is selected (used in the reactive table and the details template)
- Notifies user that next source is being prepared or retrieved after reviewal

And cleans up the styles of the main source table

I noticed a possible issue. [This method](https://github.com/ecohealthalliance/eidr-connect/blob/master/methods/promedPosts.coffee#L29-L41) seems to overwrite some properties such as `addedDate` locally? I wanted to find a place to add a `reviewed` property and set it false to prevent having to run [this sort of query](https://github.com/ecohealthalliance/eidr-connect/blob/39e46fb540480f4912cb57d020ef1845dfecc4e3/client/controllers/curatorInbox.coffee#L42-L46). But if I added it to the method mentioned above, it is reset every time the view is loaded. Maybe I'm doing this in the wrong place?
