### PR TITLE
Curator inbox positioned panes

### DIFF
--- a/client/controllers/footer.coffee
+++ b/client/controllers/footer.coffee
@@ -1,3 +1,7 @@
 Template.footer.helpers
   hideFooter: ->
-    Router.current().route.getName() is 'event-map'
+    pagesWithoutFooter = [
+      'event-map'
+      'curator-inbox'
+    ]
+    Router.current().route.getName() in pagesWithoutFooter

--- a/client/views/curatorInbox.jade
+++ b/client/views/curatorInbox.jade
@@ -1,37 +1,39 @@
 template(name="curatorInbox")
-  .container-fluid
-    .row
-      .col-sm-6.curator-inbox-sources
-        .row.curator-inbox-header
-          h2 Sources
-          .curator-inbox-options
-            a.curator-filter-calendar-icon(class="{{#if calendarState}} active {{/if}}")
-              i.fa.fa-calendar
-            a.curator-filter-reviewed-icon(class="{{#unless reviewFilterActive}} active {{/unless}}")
-              i.fa.fa-check-circle
-            .input-group
-              input#curator-inbox-article-filter.map-search.form-control(type="text" placeholder="Filter by event name")
-              i.fa.fa-search.search-icon
-        .row.curator-inbox-datepicker(class="{{#if calendarState}} active {{/if}}")
-          .text-center
-            #date-picker.inlineRangePicker
-          .text-center
-            a#calendar-btn-apply.btn.btn-primary(href="") Apply
-            a#calendar-btn-reset.btn.btn-primary(href="") Reset
-            a#calendar-btn-cancel.btn.btn-default(href="") Cancel
-        .curator-inbox-source-list.row
-          if isReady
-            each day in days
-              +curatorInboxSection(
-                date=day
-                index=@index
-                reviewFilter=reviewFilter
-                selectedSourceId=selectedSourceId)
-          else
-            .loading
-      if isReady
-        .col-sm-6.curator-source-details
-          +curatorSourceDetails selectedSourceId=selectedSourceId query=query
+  .pane-container.curator-inbox
+    .curator-inbox-header.pane-head.pane-head-l
+      h2 Sources
+      .curator-inbox-options
+        if isLoading
+          a.curator-refresh-icon
+            i.fa.fa-refresh.fa-spin
+        a.curator-filter-calendar-icon(class="{{#if calendarState}} active {{/if}}")
+          i.fa.fa-calendar
+        a.curator-filter-reviewed-icon(class="{{#unless reviewFilterActive}} active {{/unless}}")
+          i.fa.fa-check-circle
+        .input-group
+          input#curator-inbox-article-filter.map-search.form-control(type="text" placeholder="Filter by event name")
+          i.fa.fa-search.search-icon
+    .curator-inbox-sources.pane.pane-l.curator-inbox--pane
+      .curator-inbox-datepicker(class="{{#if calendarState}} active {{/if}}")
+        .text-center
+          #date-picker.inlineRangePicker
+        .text-center
+          a#calendar-btn-apply.btn.btn-primary(href="") Apply
+          a#calendar-btn-reset.btn.btn-primary(href="") Reset
+          a#calendar-btn-cancel.btn.btn-default(href="") Cancel
+      .curator-inbox-source-list
+        if isReady
+          each day in days
+            +curatorInboxSection(
+              date=day
+              index=@index
+              reviewFilter=reviewFilter
+              selectedSourceId=selectedSourceId)
+        else
+          .loading
+    if isReady
+      .curator-source-details.pane.pane-r.curator-inbox--pane
+        +curatorSourceDetails selectedSourceId=selectedSourceId query=query
 
 template(name="curatorInboxSection")
   if post

--- a/imports/stylesheets/_main.styl
+++ b/imports/stylesheets/_main.styl
@@ -10,6 +10,7 @@
 @import 'select2.import.styl'
 @import 'reactiveTable.import'
 
+@import 'panes.import'
 @import 'panels.import'
 @import 'tooltips.import'
 @import 'buttons.import'

--- a/imports/stylesheets/curator.import.styl
+++ b/imports/stylesheets/curator.import.styl
@@ -9,7 +9,7 @@
 
 .curator-inbox-header
   background $primary
-  padding .5em 1.5em
+  padding 10px 15px 10px 55px
   min-height 54px
   display flex
   align-items center
@@ -91,13 +91,14 @@
     margin 0
 
 .curator-inbox-source-list
-  border-right 1px solid $border-primary
   .reactive-table-options
     display none
 
 .curator-inbox-table
   margin-bottom 0
   color $primary
+  max-width calc(100% + 1px)
+  width calc(100% + 1px)
   thead
     display none
   tr
@@ -115,6 +116,8 @@
   font-size 14px
   padding-top 8px
   cursor pointer
+  &:first-of-type
+    border-top 0
   &:hover
     background darken(@background, 4%)
 
@@ -129,6 +132,7 @@
   background none
   border-bottom 2px solid $border-primary
   overflow hidden
+  padding-left 1.5em
   h2
     color $primary
     flex 1
@@ -408,7 +412,7 @@
 
 .curator-events-header
   min-height 50px
-  padding .5em 1.5em
+  padding .5em 2em .5em 1.5em
   border-top 1px solid $border-primary
   border-bottom 1px solid $border-primary
   display flex

--- a/imports/stylesheets/mixins.import.styl
+++ b/imports/stylesheets/mixins.import.styl
@@ -51,3 +51,10 @@ centerPosition($h=-50%,$v=-50%)
 
 icon()
   font-family FontAwesome
+
+addBorder($sides, $h, $color)
+  if $sides == all
+    border unit($h, 'px') solid $color
+  else
+    for $side in $sides
+      border-{$side} unit($h,'px') solid $color

--- a/imports/stylesheets/panes.import.styl
+++ b/imports/stylesheets/panes.import.styl
@@ -1,0 +1,63 @@
+.pane-container
+  @extend .gradient-bottom
+  position fixed
+  top $header-height
+  bottom 0
+  left 0
+  right 0
+  z-index $mid-layer
+  .loading
+    loading(false)
+    position absolute
+    top 100px
+    transform translate(-50%, 0)
+    left 50%
+
+.pane
+  position absolute
+  top 0
+  bottom 0
+  padding-bottom 5em
+  z-index $mid-layer
+  overflow-y auto
+  background white
+  .text-center
+    padding 0 15px
+
+.pane-l
+  left 0
+  top $curator-pane-head-height
+
+.pane-m
+  width 55%
+  left 22.5%
+  addBorder(left right, 1, $border-primary-light)
+  .pane-actions
+    padding-right 20px
+    padding-left 20px
+
+.pane-r
+  right 0
+
+.pane-head
+  position absolute
+  min-height $curator-pane-head-height
+  max-height $curator-pane-head-height
+  overflow hidden
+  z-index $top-layer
+  width $curator-pane-width
+  addBorder(bottom, 1, $border-primary)
+  input
+    margin-bottom 0
+
+.pane-head-l
+  left 0
+
+.pane-head-r
+  right 0
+
+.curator-inbox--pane
+  width $curator-pane-width
+  border-right 1px solid $border-primary
+  &:last-of-type
+    border 0

--- a/imports/stylesheets/utils.import.styl
+++ b/imports/stylesheets/utils.import.styl
@@ -27,4 +27,17 @@ for $num in 1 2 3 4 5 6
 .veil
   full-width()
   background alpha(white, 80%)
-  z-index 100
+  z-index $mid-layer
+
+.gradient-bottom
+  &::after
+    position absolute
+    bottom 0
+    left 0
+    right 0
+    content ''
+    height 50px
+    background white
+    z-index $top-layer
+    background linear-gradient(to bottom, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%)
+    pointer-events none

--- a/imports/stylesheets/variables.import.styl
+++ b/imports/stylesheets/variables.import.styl
@@ -48,3 +48,14 @@ $map-menu-width-max = 500px
 $map-width-small = 'calc(100% - %s)' % $map-menu-width-small
 $map-width-max = 'calc(100% - %s)' % $map-menu-width-max
 $map-width-large = 100 - $map-menu-width-large
+
+$curator-pane-width = 50%
+$curator-pane-head-height = 50px
+
+// Z-index layers
+$cosmos-layer = 3000
+$modal-layer = 2000
+$top-layer = 1000
+$mid-layer = 100
+$bottom-layer = 10
+$page-layer = 0


### PR DESCRIPTION
Uses the "pane" layout pattern established [in Tater](https://github.com/ecohealthalliance/tater/blob/master/packages/styles/layout.import.styl) to position the source list and details. The two panes now scroll independently.

Also:
- Hides footer to devote as much of the screen to the panes as possible
- Adds a `addBorder` mixin swiped from Tater.
- Adds variables for z-index strata

PT: https://www.pivotaltracker.com/story/show/133182923