### PR TITLE
Add visibility toggle for suggested events and refactor existing

### DIFF
--- a/client/controllers/curatorEvents.coffee
+++ b/client/controllers/curatorEvents.coffee
@@ -5,6 +5,7 @@ Articles = require '/imports/collections/articles.coffee'
 
 Template.curatorEvents.onCreated ->
   instance = @
+  @suggestedEventsHeaderState = new ReactiveVar true
   @autorun ->
     sourceId = instance.data.selectedSourceId.get()
 
@@ -27,16 +28,14 @@ Template.curatorEvents.onRendered ->
 
 Template.curatorEvents.helpers
   userEvents: ->
-    UserEvents.find(
+    UserEvents.find
       _id:
         $nin: _.keys(Template.instance().associatedEventIdsToArticles.get())
-    )
 
   associatedUserEvents: ->
-    UserEvents.find(
+    UserEvents.find
       _id:
         $in: _.keys(Template.instance().associatedEventIdsToArticles.get())
-    )
 
   associatedEventIdsToArticles: ->
     Template.instance().associatedEventIdsToArticles
@@ -76,6 +75,9 @@ Template.curatorEvents.helpers
       class: "table table-hover col-sm-12"
     }
 
+  allEventsOpen: ->
+    Template.instance().suggestedEventsHeaderState.get()
+
 Template.curatorEvents.events
   "click .curator-events-table .curator-events-table-row": (event, template) ->
     $target = $(event.target)
@@ -98,3 +100,11 @@ Template.curatorEvents.events
     })
   "click .deassociate-event": (event, template) ->
     Meteor.call('removeEventSource', template.associatedEventIdsToArticles.get()[@_id])
+
+  'click .curator-events-header.all-events': (event, template) ->
+    suggestedEventsHeaderState = template.suggestedEventsHeaderState
+    suggestedEventsHeaderState.set not suggestedEventsHeaderState.get()
+
+  'click #curatorEventsFilter': (event, template) ->
+    event.stopPropagation()
+    template.suggestedEventsHeaderState.set true

--- a/client/controllers/curatorSuggestedEvents.coffee
+++ b/client/controllers/curatorSuggestedEvents.coffee
@@ -12,8 +12,8 @@ UserEvents = require '/imports/collections/userEvents.coffee'
 ###
 
 Template.suggestedEvents.onCreated ->
-  @isOpen = new ReactiveVar(true)
-  @events = new ReactiveVar([])
+  @headerState = new ReactiveVar true
+  @events = new ReactiveVar []
   @initialEvents = []
 
   # sets the suggestedEvents table fields
@@ -71,7 +71,7 @@ Template.suggestedEvents.onCreated ->
 Template.suggestedEvents.helpers
   # controls the visiblity of the suggested-events-table and toggles the chevron
   isOpen: ->
-    Template.instance().isOpen.get()
+    Template.instance().headerState.get()
   # the reactive array that populates the reactive-`table
   events: ->
     Template.instance().events.get()
@@ -94,8 +94,6 @@ Template.suggestedEvents.helpers
 
 Template.suggestedEvents.events
   # event handler to toggle the reactive var isOpen
-  'click .curator-collapse': (event, template) ->
-    if template.isOpen.get()
-      template.isOpen.set false
-    else
-      template.isOpen.set true
+  'click .curator-events-header.suggested-events': (event, template) ->
+    headerState = template.headerState
+    headerState.set not headerState.get()

--- a/client/views/curatorEvents.jade
+++ b/client/views/curatorEvents.jade
@@ -17,10 +17,18 @@ template(name="curatorEvents")
     +suggestedEvents title=title associatedEventIdsToArticles=associatedEventIdsToArticles
 
   .all-events.curator-events
-    .curator-events-header
+    .curator-events-header.all-events.toggleable
       h4 All Events
-      +reactiveTableFilter id="curatorEventsFilter" label=" "
-    +reactiveTable collection=userEvents settings=settings
+      .curator-events--options
+        .filter-wrapper(class="{{#unless allEventsOpen }} subtle {{/unless}}")
+          +reactiveTableFilter id="curatorEventsFilter" label=" "
+        .curator-events-collapse
+          if allEventsOpen
+            i.fa.fa-lg.fa-chevron-circle-down
+          else
+            i.fa.fa-lg.fa-chevron-circle-left
+    if allEventsOpen
+      +reactiveTable collection=userEvents settings=settings
 
 template(name="noAssociatedEvents")
   p.muted-text Currently no associated events

--- a/client/views/curatorSuggestedEvents.jade
+++ b/client/views/curatorSuggestedEvents.jade
@@ -1,11 +1,11 @@
 template(name='suggestedEvents')
-  .curator-events-header.curator-collapse
-    h4
-      | Suggested Events
-    .curator-events-collapse
-      if isOpen
-        i.fa.fa-lg.fa-chevron-circle-down
-      else
-        i.fa.fa-lg.fa-chevron-circle-left
+  .curator-events-header.suggested-events.toggleable
+    h4 Suggested Events
+    .curator-events--options
+      .curator-events-collapse
+        if isOpen
+          i.fa.fa-lg.fa-chevron-circle-down
+        else
+          i.fa.fa-lg.fa-chevron-circle-left
   if isOpen
     +reactiveTable collection=events settings=settings class='table curator-events-table'

--- a/imports/stylesheets/curator.import.styl
+++ b/imports/stylesheets/curator.import.styl
@@ -1,3 +1,6 @@
+$header-BG = $border-primary-light
+$header-BG-hover = darken($header-BG, 4%)
+
 .curator-heading
   color $primary
   font-weight 400
@@ -108,18 +111,22 @@
     max-width 400px
 
 .curator-inbox-section-head
+.curator-events-header
   color $primary
-  background $primary-l-light
+  background $header-BG
   border-top 1px solid $border-primary
   border-bottom 1px solid $border-primary
-  height 37px
-  font-size 14px
+
+.curator-inbox-section-head
+  min-height 40px
+  font-size 1em
+  padding-bottom 8px
   padding-top 8px
   cursor pointer
+  &:hover
+    background $header-BG-hover
   &:first-of-type
     border-top 0
-  &:hover
-    background darken(@background, 4%)
 
 .curator-inbox-buttons
   margin-bottom 30px
@@ -343,10 +350,16 @@
     .tr-incidents-wrapper
       padding 0
 
-.curator-collapse
-  cursor pointer
-.curator-events-collapse
+.curator-events--options
   margin-left auto
+  display flex
+  align-items center
+  justify-content flex-end
+  min-width 50%
+
+.curator-events-collapse
+  color $primary
+  cursor pointer
 
 #associated-events
 #suggested-events-table
@@ -396,7 +409,7 @@
   td
     display flex
     align-items center
-    padding-right 1.5em
+    padding-right 2em
     .event-info
       margin-left auto
       color $border-primary
@@ -413,30 +426,46 @@
 .curator-events-header
   min-height 50px
   padding .5em 2em .5em 1.5em
-  border-top 1px solid $border-primary
-  border-bottom 1px solid $border-primary
   display flex
   align-items center
-  #curatorEventsFilter
-    position relative
-    margin-left auto
-    min-width 30%
-    &::after
-      content '\f002'
-      position absolute
-      right 1em
-      top 50%
-      transform translate(0, -50%)
-      z-index 10
-      font-family FontAwesome
-      color $m-gray
-    input
-      border-radius 4px
-      border-color $border-primary
-      box-shadow none
-      padding-right 2em
   .input-group-addon
     display none
+  &.toggleable
+    cursor pointer
+    &:hover
+      background $header-BG-hover
+      .curator-events-collapse
+        transition transform .1s ease-in-out
+        transform scale(1.2)
+      h4
+        color $primary
+
+#curatorEventsFilter
+  position relative
+  display block
+  &::after
+    content '\f002'
+    position absolute
+    right 1em
+    top 50%
+    transform translate(0, -50%)
+    z-index 10
+    font-family FontAwesome
+    color $m-gray
+  input
+    float none
+    border-radius 4px
+    border-color $border-primary
+    box-shadow none
+    padding-right 2em
+
+.filter-wrapper
+  opacity 1
+  transition .3s
+  margin-right 1em
+  min-width 70%
+  &.subtle
+    opacity .4
 
 .spacer
   display inline


### PR DESCRIPTION
Adds a toggle to the suggested events header to show and hide the associated table.
Slight refactoring to the existing toggle both in the styles and controller.

PT: https://www.pivotaltracker.com/story/show/133300025
