### PR TITLE
scatterPlot markers as line segments

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -9,7 +9,6 @@ coffeescript@1.11.1_1
 stylus@2.513.5_1
 iron:router
 twbs:bootstrap
-d3
 okgrow:analytics
 http@1.2.9_1
 fortawesome:fontawesome
@@ -51,4 +50,3 @@ shell-server@0.2.1
 aldeed:simple-schema
 dangrossman:bootstrap-daterangepicker
 stevezhu:lodash
-d3js:d3

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -22,8 +22,6 @@ callback-hook@1.0.9
 check@1.2.3
 chrismbeckett:toastr@2.1.2_1
 coffeescript@1.11.1_1
-d3@1.0.0
-d3js:d3@3.5.8
 dangrossman:bootstrap-daterangepicker@2.1.13
 ddp@1.2.5
 ddp-client@1.3.1_1

--- a/imports/charts/Errors.coffee
+++ b/imports/charts/Errors.coffee
@@ -1,0 +1,21 @@
+###
+# InvalidNodeError - error thrown when an object is not instanceof Node
+#
+# @param {string} [message], (optional) the message to the user
+###
+export class InvalidNodeError extends Error
+  name: 'InvalidNodeError'
+  constructor: (message) ->
+    @message = message || 'Is not instanceof Node.'
+    super()
+
+###
+# InvalidGroupError - error thrown when an object is not instanceof Group
+#
+# @param {string} [message], (optional) the message to the user
+###
+export class InvalidGroupError extends Error
+  name: 'InvalidGroupError'
+  constructor: (message) ->
+    @message = message || 'Is not instanceof Group.'
+    super()

--- a/imports/charts/Grid.coffee
+++ b/imports/charts/Grid.coffee
@@ -1,3 +1,5 @@
+import d3 from 'd3'
+
 class Grid
   ###
   # Grid - constructs grids lines for the plot
@@ -9,8 +11,8 @@ class Grid
   #
   ###
   constructor: (axes, plot, options) ->
-    @options = options
     @plot = plot
+    @options = options || {}
     @axes = axes
     @init()
     #return
@@ -21,16 +23,20 @@ class Grid
   ###
   init: () ->
     # x
-    @xGrid = d3.svg.axis().scale(@axes.xScale).orient('bottom').tickFormat('').tickSize((@plot.getHeight()) * -1, 0, 0)
+    @xGrid = d3.axisBottom().scale(@axes.xScale).tickFormat('').tickSize((@plot.getHeight()) * -1, 0, 0)
     @xGroup = @plot.container.insert('g', ':first-child')
       .attr('class', 'grid')
       .attr('transform', "translate(#{@plot.margins.left}, #{@plot.getHeight()})")
+      # use the opacity from the stylesheet
+      .attr('opacity', null)
       .call(@xGrid)
     # y
-    @yGrid = d3.svg.axis().scale(@axes.yScale).orient('left').tickFormat('').tickSize((@plot.getWidth()) * -1, 0, 0)
+    @yGrid = d3.axisLeft().scale(@axes.yScale).tickFormat('').tickSize((@plot.getWidth()) * -1, 0, 0)
     @yGroup = @plot.container.insert('g', ':first-child')
       .attr('class', 'grid')
       .attr('transform', "translate(#{@plot.margins.left}, 0)")
+      # use the opacity from the stylesheet
+      .attr('opacity', null)
       .call(@yGrid)
 
   ###

--- a/imports/charts/Group.coffee
+++ b/imports/charts/Group.coffee
@@ -1,0 +1,171 @@
+import d3 from 'd3'
+import Node from '/imports/charts/Node.coffee'
+import { InvalidNodeError } from '/imports/charts/Errors.coffee'
+import _ from 'underscore'
+
+
+genId = () ->
+  length = 9
+  prefix = 'group-'
+  prefix + Math.random().toString(36).substr(2, length);
+
+class Group
+  name: 'Group'
+  constructor: (plot, options) ->
+    @options = options || {}
+    @id = @options.id || genId()
+    onEnter = @options.onEnter || Group.onEnter
+    @onEnter = _.bind(onEnter, @)
+    onUpdate = @options.onUpdate || Group.onUpdate
+    @onUpdate = _.bind(onUpdate, @)
+    onExit = @options.onExit || Group.onExit
+    @onExit = _.bind(onExit, @)
+    @nodes_ = {}
+    @plot = plot
+    @plot.addGroup(@)
+
+  ###
+  # size - returns the size of the Group's nodes
+  #
+  # @return {number} size, the size of the group
+  ###
+  size: () ->
+    Object.values(@nodes_).length
+
+  ###
+  # addNode - adds a node to this group
+  #
+  # @param {object} node, the node to add
+  # @throws {InvalidGroupError} error
+  # @return {Group} this
+  ###
+  addNode: (node) ->
+    if !node instanceof Node
+      throw new InvalidNodeError()
+    @nodes_[node.id] = node
+    # return
+    @
+
+  ###
+  # removeNode - removes a node from this group
+  #
+  # @param {string} id, the id to remove
+  # @return {object} this
+  ###
+  removeNode: (id) ->
+    if @nodes_.hasOwnProperty(id)
+      delete @nodes_[id]
+    #return
+    @
+
+  ###
+  # getNodes - returns the nodes associated with this group
+  #
+  # @return {array} nodes, the nodes associated with this group
+  ###
+  getNodes: () ->
+    Object.values(@nodes_)
+
+  ###
+  # update - handles updating the marker
+  #
+  # @return {object} this
+  ###
+  update: () ->
+    if typeof @group == 'undefined'
+      return
+    filtered = @applyFilters()
+    filteredLen = filtered.length
+    @group.attr('numNodes', filteredLen)
+    nodes = @group.selectAll('.node').data(filtered, (d) -> d.id)
+    nodes.enter().append((node) -> node.detached()).call(@onEnter)
+    nodes.each((node) -> node.update()).call(@onUpdate)
+    nodes.exit().remove().call(@onExit)
+
+  ###
+  # detached - builds a detached svg group and returns the node
+  #
+  # @return {object} node, the SVG node to append to the parent during .call()
+  ###
+  detached: () ->
+    @remove()
+    @group = d3.select(document.createElementNS(d3.namespaces.svg, 'g')).attr('id', @id).attr('class', 'group').remove()
+    @update()
+    #returns
+    @group.node()
+
+  ###
+  # applyFilters - apply any filters from the plot
+  #
+  # @param {object} filters, an array of filters to apply
+  # @returns {array} filtered, the filtered data
+  ###
+  applyFilters: (filters) ->
+    filters = filters || @plot.filters
+    filtered = []
+    if @nodes_
+      filtered = @getNodes().filter (d) ->
+        valid = true
+        keys = Object.keys(filters)
+        i = 0
+        keysLen = keys.length
+        while i < keysLen
+          key = keys[i++]
+          f = filters[key](d)
+          if typeof f == 'undefined'
+            valid = false
+            break
+        if valid
+          return d
+    return filtered
+
+  ###
+  # remove - removes the group from the DOM
+  ###
+  remove: () ->
+    # remove layer from the plot
+    if @group
+      @group.remove()
+    #return
+    @
+
+  ###
+  # destroy - destroys the group and any associated elements
+  ###
+  destroy: () ->
+    @remove()
+    @plot.removeLayer(@id)
+    @nodes = null
+    @plot = null
+    @group = null
+
+
+###
+# onEnter - the default event handler for a group. This may be overridden or
+#   a new event handler passed into the constructor as `options.onEnter`
+#
+# @param {object} selections - the d3 selection object containing the children for this group
+###
+Group.onEnter = () ->
+  return
+
+###
+# onUpdate - the default event handler for a group. This may be overridden or
+#   a new event handler passed into the constructor as `options.onUpdate`
+#
+# @param {object} selections - the d3 selection object for this group
+###
+Group.onUpdate = (selections) ->
+  return
+
+###
+# onExit - the default event handler for a group. This may be overridden or
+#   a new event handler passed into the constructor as `options.onExit`
+#
+# @param {object} selections - the d3 selection object for this group
+###
+Group.onExit = (selections) ->
+  return
+
+
+module.exports = Group

--- a/imports/charts/Node.coffee
+++ b/imports/charts/Node.coffee
@@ -1,0 +1,24 @@
+import d3 from 'd3'
+
+genId = () ->
+  length = 9
+  prefix = 'node-'
+  prefix + Math.random().toString(36).substr(2, length);
+
+class Node
+  name: 'Node'
+  ###
+  # Node - base class
+  #
+  # @param {object} options, the options used to construct the SegmentMarker
+  # @param {object} options.meta, the optional meta data associated with the node (e.g. used in the Tooltip)
+  # @return {object} this
+  ###
+  constructor: (options) ->
+    @id = options.id || genId()
+    @meta = options.meta || {}
+
+    #return
+    @
+
+module.exports = Node

--- a/imports/charts/SegmentMarker.coffee
+++ b/imports/charts/SegmentMarker.coffee
@@ -1,0 +1,324 @@
+import d3 from 'd3'
+import Node from '/imports/charts/Node.coffee'
+
+MINIMUM_LINE_STROKE = 4
+MINIMUM_LINE_WIDTH = 4
+MINIMUM_CIRCLE_RADIUS = 5
+MINIMUM_LINE_THRESHOLD = 2
+
+class SegmentMarker extends Node
+  ###
+  # SegmentMarker - a line marker with beginning and end
+  #
+  # @param {object} options, the options used to construct the SegmentMarker
+  # @param {number} options.x, the value for x position
+  # @param {number} options.y, the value for y position
+  # @param {number} options.l, the value for the length of the line
+  # @param {number} options.h, the value for the height
+  # @param {string} options.f, the fill of the line
+  # @param {number} options.o, the opacity of the line
+  # @param {object} options.meta, the optional meta data associated with the marker (e.g. used in the Tooltip)
+  # @return {object} this
+  ###
+  constructor: (plot, options) ->
+    super(options)
+    @plot = plot
+    @x = options.x
+    @y = options.y
+    @w = options.w
+    @h = options.h || MINIMUM_LINE_STROKE
+    @r = options.r || MINIMUM_CIRCLE_RADIUS
+    @f = options.f || '#345e7e'
+    @o = options.o || 0.3
+    @meta = options.meta || {}
+
+    #return
+    @
+
+  ###
+  # remove - removes the marker from the DOM
+  #
+  # @return {object} this
+  ###
+  remove: () ->
+    if @group
+      @group.remove()
+
+  ###
+  # filteredOrderedPair - determine if the pair exists within the domain
+  ###
+  filteredOrderedPair: (orderedPair) ->
+    if orderedPair[0] < @plot.axes.xScale.range()[0]
+      orderedPair[0] = null
+    if orderedPair[0] > @plot.axes.xScale.range()[1]
+      orderedPair[0] = null
+    if orderedPair[1] < @plot.axes.yScale.range()[1]
+      orderedPair[1] = null
+    if orderedPair[1] > @plot.axes.yScale.range()[0]
+      orderedPair[1] = null
+    orderedPair
+
+  ###
+  # update - handles updating the marker
+  #
+  # @return {object} this
+  ###
+  update: () ->
+    if typeof @group == 'undefined'
+      @group = d3.select("##{@id}")
+
+    linePairs = [[@plot.axes.xScale(@x), @plot.axes.yScale(@y)], [@plot.axes.xScale(@w), @plot.axes.yScale(@y)]]
+    lineDistance = @distance(linePairs)
+    totalRange = @plot.axes.xScale.range()[1]
+    linePercentage = Math.floor((lineDistance / totalRange) * 100)
+
+    startPoint = @filteredOrderedPair([@plot.axes.xScale(@x), @plot.axes.yScale(@y)])
+
+    # check the domain of the startPoint, if it contains a null value, it shouldn't be displayed
+    start = @group.selectAll('.start-circle').data([@], (d) -> d.id)
+    if startPoint[0] != null && startPoint[1] != null
+      # create
+      start.enter().append('circle')
+        .attr('class', 'start-circle')
+        .style('fill', @f)
+        .attr('cx', startPoint[0])
+        .attr('cy', startPoint[1])
+        .attr('r', (d) =>
+          radius = @r
+          radius = Math.ceil((radius * (linePercentage / 100)) + radius)
+          if radius < MINIMUM_CIRCLE_RADIUS
+            radius = MINIMUM_CIRCLE_RADIUS
+          radius
+        )
+      # update
+      start
+        .attr('cx', startPoint[0])
+        .attr('cy', startPoint[1])
+        .attr('r', (d) =>
+          radius = @r
+          radius = Math.ceil((radius * (linePercentage / 100)) + radius)
+          if radius < MINIMUM_CIRCLE_RADIUS
+            radius = MINIMUM_CIRCLE_RADIUS
+          radius
+        )
+      # remove
+      start.exit().remove()
+    else
+      @group.selectAll('.start-circle').remove()
+
+    if linePercentage >= MINIMUM_LINE_THRESHOLD
+      line = @group.selectAll('line').data([@], (d) -> d.id)
+      # create
+      line.enter().append('line')
+        .attr('x1', () =>
+          if linePairs[0][0] <= @plot.axes.xScale.range()[0]
+            return @plot.axes.xScale.range()[0]
+          if linePairs[0][0] >= @plot.axes.xScale.range()[1]
+            return null
+          linePairs[0][0]
+        )
+        .attr('y1', linePairs[0][1])
+        .attr('x2', () =>
+          if linePairs[1][0] >= @plot.axes.xScale.range()[1]
+            return @plot.axes.xScale.range()[1]
+          if linePairs[1][0] <= @plot.axes.xScale.range()[0]
+            return null
+          linePairs[1][0]
+        )
+        .attr('y2', linePairs[1][1])
+        # the thickness of the line
+        .attr('stroke-width', () =>
+          height = @h
+          height = Math.ceil((height * (linePercentage / 100)) + height)
+          if height < MINIMUM_LINE_STROKE
+            return MINIMUM_LINE_STROKE
+          height
+        )
+        .attr('stroke', @f)
+      # update
+      line
+        .attr('x1', () =>
+          if linePairs[0][0] <= @plot.axes.xScale.range()[0]
+            return @plot.axes.xScale.range()[0]
+          if linePairs[0][0] >= @plot.axes.xScale.range()[1]
+            return null
+          linePairs[0][0]
+        )
+        .attr('y1', linePairs[0][1])
+        .attr('x2', () =>
+          if linePairs[1][0] >= @plot.axes.xScale.range()[1]
+            return @plot.axes.xScale.range()[1]
+          if linePairs[1][0] <= @plot.axes.xScale.range()[0]
+            return null
+          linePairs[1][0]
+        )
+        .attr('y2', linePairs[1][1])
+        # the thickness of the line
+        .attr('stroke-width', () =>
+          height = @h
+          height = Math.ceil((height * (linePercentage / 100)) + height)
+          if height < MINIMUM_LINE_STROKE
+            return MINIMUM_LINE_STROKE
+          height
+        )
+    else
+      # we shouldn't have any lines in this group
+      @group.selectAll('line').remove()
+
+    # check the domain of the endPoint, if it contains a null value, it shouldn't be displayed
+    endPoint = @filteredOrderedPair([@plot.axes.xScale(@w), @plot.axes.yScale(@y)])
+    if linePercentage >= MINIMUM_LINE_THRESHOLD
+      if endPoint[0] != null && endPoint[1] != null
+        end = @group.selectAll('.end-circle').data([@], (d) -> d.id)
+        # create
+        end.enter().append('circle')
+          .attr('class', 'end-circle')
+          .attr('cx', endPoint[0])
+          .attr('cy', endPoint[1])
+          .attr('r', () =>
+            radius = @r
+            radius = Math.ceil(((radius * linePercentage) / 100) + radius)
+            if radius < MINIMUM_CIRCLE_RADIUS
+              radius = MINIMUM_CIRCLE_RADIUS
+            return radius
+          )
+          .style('fill', @f)
+        # update
+        end
+          .attr('class', 'end-circle')
+          .attr('cx', endPoint[0])
+          .attr('cy', endPoint[1])
+          .attr('r', () =>
+            radius = @r
+            radius = Math.ceil(((radius * linePercentage) / 100) + radius)
+            if radius < MINIMUM_CIRCLE_RADIUS
+              radius = MINIMUM_CIRCLE_RADIUS
+            return radius
+          )
+      else
+        # we shouldn't have any end circles in this group
+        @group.selectAll('.end-circle').remove()
+    else
+      # we shouldn't have any end circles in this group
+      @group.selectAll('.end-circle').remove()
+
+    #return
+    @
+
+  ###
+  # detached - builds a detached svg group and returns the node
+  #
+  # @return {object} node, the SVG node to append to the parent during .call()
+  ###
+  detached: () ->
+    @remove()
+    @group = d3.select(document.createElementNS(d3.namespaces.svg, 'g'))
+      .attr('id', @id)
+      .attr('class', 'node')
+      .attr('opacity', @o).remove()
+    @update()
+    #return
+    @group.node()
+
+  ###
+  # distance - determine the distance between two pairs
+  ###
+  distance: (pairs) ->
+    Math.sqrt((Math.pow(Math.abs(pairs[0][0] - pairs[1][0]), 2) + Math.pow(Math.abs(pairs[0][1] - pairs[1][1]), 2)))
+
+###
+# createFromIncident - method to construct a SegmentMarker from an incident
+#
+# @param {object} incident, the incident used to create a marker
+# @return {object} SegmentMarker, the marker that is created
+###
+SegmentMarker.createFromIncident = (plot, incident) ->
+  if typeof incident == 'undefined'
+    return
+  if typeof incident.dateRange != 'object'
+    return
+  m = {
+    id: "node-#{incident._id}"
+    meta: {}
+  }
+  x = -1
+  w = -1
+  if incident.dateRange.type == 'precise'
+    x = moment(incident.dateRange.start).valueOf()
+    w = moment(incident.dateRange.end).valueOf()
+  else if incident.dateRange.type == 'day'
+    x = moment(incident.dateRange.start).hours(0).valueOf()
+    w = moment(incident.dateRange.start).hours(0).add(24, 'hours').valueOf()
+  if x <= 0 || w <= 0
+    return
+  m.x = x
+  m.w = w
+  m.y = 0
+  if typeof incident.cases != 'undefined'
+    m.meta.type = 'case'
+    m.f = '#345e7e'
+    m.y += incident.cases
+  if typeof incident.deaths != 'undefined'
+    m.meta.type = 'death'
+    m.f = '#f07382'
+    m.y += incident.deaths
+  if typeof m.meta.type == 'undefined'
+    return
+  if incident.locations.length > 0
+    m.meta.location = incident.locations[0].name
+  if incident.dateRange.cumulative
+    m.meta.cumulative = true
+  new SegmentMarker(plot, m)
+
+###
+# groupOverlappingSegments - group overlapping segments together
+#
+# @param {array} segments, an array of SegmentMarker's
+# @return {object} groups, groups of overlapping segments
+###
+SegmentMarker.groupOverlappingSegments = (segments) ->
+  groups = {}
+  # first group segments by their y-axis value
+  segmentsByHeightAndCumulative = _.groupBy(segments, (segment) ->
+    if typeof segment.meta.cumulative == 'undefined'
+      c = false
+    else
+      c = segment.meta.cumulative
+    return segment.y + ':' + c
+  )
+  # determine if they are overlapping
+  for key of segmentsByHeightAndCumulative
+    values = segmentsByHeightAndCumulative[key]
+    # sort the values by ascending x1
+    values.sort((a, b) -> a.x - b.x)
+    i = 0
+    # determine overlapping segments within the y-axis group
+    points = []
+    while i < values.length
+      if i == 0
+        points[0] = values[0]
+        groupName = '' + values[0].w + ':' + key
+        groups[groupName] = [values[0]]
+        i++
+        continue
+      lastIdx = points.length - 1
+      if lastIdx < 0
+        break
+      lastPoint = points[lastIdx]
+      if values[i].x >= lastPoint.x && values[i].w <= lastPoint.w
+        groupName = '' + lastPoint.w + ':' + key
+        group = groups[groupName]
+        if typeof group == 'undefined'
+          group = []
+        group.push(values[i])
+        i++
+      else
+        points[lastIdx+1] = values[i]
+        groupName = '' + values[i].w + ':' + key
+        groups[groupName] = [values[i]]
+        i++
+  #return
+  groups
+
+
+module.exports = SegmentMarker

--- a/imports/charts/Tooltip.coffee
+++ b/imports/charts/Tooltip.coffee
@@ -1,3 +1,5 @@
+import d3 from 'd3'
+
 class Tooltip
   ###
   # Tooltip - allows for an HTML div to be faded in/out on mouseover of a marker
@@ -10,21 +12,21 @@ class Tooltip
   # @return {object} this
   ###
   constructor: (plot, options) ->
-    @tooltipOpts = options.tooltip || { 'opacity': 0.9, 'template': _.template("<p>x: <%= obj.x %> y: <%= obj.y %></p>")}
+    @tooltipOpts = options.tooltip || { 'opacity': 1, 'template': _.template("<p>x: <%= obj.x %> y: <%= obj.y %></p>")}
     @template = @tooltipOpts.template
     @opacity = @tooltipOpts.opacity
     # we render the template without data to get the estimated width of the element
     @element = d3.select('body').append('div')
       .attr('class', 'scatterPlot-tooltip')
       .style('opacity', 0)
-      .html(@template({meta:{}}))
+      .html(@template({}))
     #return
     @
 
   ###
   # mouseover - unbound method for mouseover event
   #
-  # @param {object} d, the marker with meta data
+  # @param {object} d, the data
   # @param {number} x, the x coordinate
   # @param {number} y, the y coordinate
   # @return {object} this
@@ -59,6 +61,5 @@ class Tooltip
   ###
   remove: () ->
     @element.remove()
-
 
 module.exports = Tooltip

--- a/imports/charts/Zoom.coffee
+++ b/imports/charts/Zoom.coffee
@@ -1,3 +1,5 @@
+import d3 from 'd3'
+
 MINIMUM_ZOOM_THRESHOLD = 5 # move at least 5x5 pixels to zoom
 
 class Zoom
@@ -14,11 +16,11 @@ class Zoom
 
     @bandPos = [-1, -1];
     @zoomArea =
-      x1: @options.axes.x.minMax[0],
-      y1: @options.axes.y.minMax[0],
-      x2: @options.axes.x.minMax[1],
-      y2: @options.axes.y.minMax[1]
-    @drag = d3.behavior.drag();
+      x1: 0,
+      y1: 0,
+      x2: 0,
+      y2: 0
+    @drag = d3.drag();
     @zoomGroup = plot.container.append('g').attr('class', 'scatterPlot-zoom')
     @zoomBand = @zoomGroup.append('rect')
       .attr('width', 0)
@@ -34,7 +36,7 @@ class Zoom
       .call(@drag);
 
     self = @
-    @drag.on 'dragstart.plot', () ->
+    @drag.on 'start.plot', () ->
       pos = d3.mouse(@)
       self.dragStart = pos
 
@@ -43,7 +45,7 @@ class Zoom
       pos = d3.mouse(@)
       _.bind(self.ondrag, self)(pos)
 
-    @drag.on 'dragend.plot', () ->
+    @drag.on 'end.plot', () ->
       # Note: @ (this) is not the Zoom class but the DOM event
       pos = d3.mouse(@)
 
@@ -114,7 +116,6 @@ class Zoom
   ###
   zoom: () ->
     @plot.axes.zoom(@zoomArea)
-    @plot.clear()
     @plot.draw()
 
   ###
@@ -122,7 +123,6 @@ class Zoom
   ###
   reset: () ->
     @plot.axes.reset()
-    @plot.clear()
     @plot.draw()
 
   ###
@@ -131,7 +131,7 @@ class Zoom
   remove: () ->
     @zoomGroup.remove()
     @drag.on('drag.plot', null)
-    @drag.on('dragend.plot', null)
-
+    @drag.on('end.plot', null)
+    @drag.on('start.plot', null)
 
 module.exports = Zoom

--- a/imports/stylesheets/scatterPlot.import.styl
+++ b/imports/stylesheets/scatterPlot.import.styl
@@ -34,7 +34,7 @@
 .scatterPlot-tooltip
   position absolute
   padding 5px
-  background lightsteelblue
+  background #f4e8e3
   border 0px
   border-radius 8px
   pointer-events none
@@ -42,7 +42,13 @@
 .scatterPlot-tooltip
   font-size 10px
 
-.grid .tick
+i.case
+  color #345e7e
+
+i.death
+  color #f07382
+
+.grid .tick line
   stroke lightgrey
   opacity 0.7
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "bcrypt": "^0.8.7",
+    "d3": "^4.3.0",
+    "pluralize": "^3.0.0",
     "rupture": "^0.6.1"
   }
 }


### PR DESCRIPTION
# Feature to add scatterPlot markers as line segments

- upgraded to d3v4 via `npm`

Updates to the ScatterPlot interface:
- created concept of a Group which contains Nodes
- each node should be an instanceof `Node`
- each group should be an instanceof `Group`
- throws errors `InvalidNodeError` and `InvalidGroupError`
- `plot.update()` accepts an array or an object
  - if its an array: a default group will be created and all nodes will be appended
  - if its an object: each key will be a new group and its value as an array of nodes
- the creation of nodes and groups is transparent to keep the API simple
- when constructing the ScatterPlot, there is an option for `group`, which allows binding an event handler during onEnter.
```
    # group events
    group: {
      # methods to be applied when a new group is created
      onEnter: () ->
        # bind mouseover/mouseout events to the plot tooltip
        @.group.on('mouseover', () =>
          if @plot.tooltip
            @plot.tooltip.mouseover(@, d3.event.pageX, d3.event.pageY)
        ).on('mouseout', () =>
          if @plot.tooltip
            @plot.tooltip.mouseout()
        )
    },
```

New type of marker `SegmentMarker`:
- has start, end point with slope of 0
- `SegmentMarker.groupOverlappingSegments()` will group overlapping segments on the y-axis together, so the tooltip displays multiple overlapping nodes.

![image](https://cloud.githubusercontent.com/assets/12954045/20185846/99289178-a73b-11e6-8077-4521b4372b86.png)
 
![image](https://cloud.githubusercontent.com/assets/12954045/20186530/67d77a32-a73e-11e6-97e4-f7ac95c15898.png)


https://www.pivotaltracker.com/story/show/132224301