### PR TITLE
Event page incident details styles

### DIFF
--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -44,37 +44,28 @@ Template.articles.helpers
           value
       }
     ]
-    if Roles.userIsInRole(Meteor.userId(), ['admin'])
-      fields.push({
-        key: "delete"
-        label: ""
-        cellClass: "remove-row"
-      })
-      fields.push({
-        key: "Edit"
-        label: ""
-        cellClass: "edit-row"
-      })
-    fields.push({
+
+    fields.push
       key: "expand"
       label: ""
-      cellClass: "open-row-right"
-    })
-    {
-      id: 'event-sources-table'
-      fields: fields
-      showFilter: false
-      showNavigationRowsPerPage: false
-      showRowCount: false
-      class: "table"
-      filters: ["sourceFilter"]
-    }
+      cellClass: "action open-right"
+
+    id: 'event-sources-table'
+    fields: fields
+    showFilter: false
+    showNavigationRowsPerPage: false
+    showRowCount: false
+    class: "table event-sources"
+    filters: ["sourceFilter"]
+
   selectedSource: ->
     selectedId = Template.instance().selectedSourceId.get()
     if selectedId
       Articles.findOne selectedId
+
   incidentsForSource: (sourceUrl) ->
     Incidents.find({userEventId: Template.instance().data.userEvent._id, url: sourceUrl}).fetch()
+
   locationsForSource: (sourceUrl) ->
     locations = {}
     incidents = Incidents.find({userEventId: Template.instance().data.userEvent._id, url: sourceUrl}).forEach( (incident) ->
@@ -82,31 +73,32 @@ Template.articles.helpers
         locations[location.id] = location.name
     )
     _.flatten locations
+
   formatUrl: (url) ->
     formatUrl(url)
 
 Template.articles.events
-  "click .reactive-table tbody tr": (event, template) ->
+  'click .reactive-table tbody tr': (event, template) ->
     $target = $(event.target)
-    $parentRow = $target.closest("tr")
-    currentOpen = template.$("tr.tr-details")
-    if $target.closest(".remove-row").length
+    $parentRow = $target.closest('tr')
+    currentOpen = template.$('tr.tr-details')
+    if $target.closest('.remove-row').length
       incidentCount = Incidents.find({userEventId: this.userEventId, url: this.url}).count()
       if incidentCount
-        plural = if incidentCount is 1 then "" else "s"
-        message = "There " +
-          (if incidentCount is 1 then "is an incident report" else "are #{incidentCount} incident reports") +
+        plural = if incidentCount is 1 then '' else 's'
+        message = 'There ' +
+          (if incidentCount is 1 then 'is an incident report' else "are #{incidentCount} incident reports") +
           " associated with this article. Please delete the incident report#{plural} before deleting the article."
         toastr.error(message)
-      else if window.confirm("Are you sure you want to delete this event source?")
+      else if window.confirm('Are you sure you want to delete this event source?')
         currentOpen.remove()
-        Meteor.call("removeEventSource", @_id)
-    else if $target.closest(".edit-row").length
+        Meteor.call('removeEventSource', @_id)
+    else if $target.closest('.edit-row').length
       modalData = @
       modalData.edit = true
       Modal.show("sourceModal", modalData)
-    else if not $parentRow.hasClass("tr-details")
-      closeRow = $parentRow.hasClass("details-open")
+    else if not $parentRow.hasClass('tr-details')
+      closeRow = $parentRow.hasClass('open')
       ###
       if currentOpen
         template.$("tr").removeClass("details-open")
@@ -114,17 +106,17 @@ Template.articles.events
       if not closeRow
         #TODO: Display event source details.
       ###
-  "click #event-sources-table tbody tr": (event, templateInstance) ->
+  'click #event-sources-table tbody tr': (event, templateInstance) ->
     event.preventDefault()
     templateInstance.selectedSourceId.set @_id
-    $(event.currentTarget).parent().find('tr').removeClass("details-open")
-    $(event.currentTarget).addClass("details-open")
-  "click .open-source-form": (event, template) ->
-    Modal.show("sourceModal", {userEventId: template.data.userEvent._id})
+    $(event.currentTarget).parent().find('tr').removeClass('open')
+    $(event.currentTarget).addClass('open')
+  'click .open-source-form': (event, template) ->
+    Modal.show('sourceModal', {userEventId: template.data.userEvent._id})
 
 
 Template.articleSelect2.onRendered ->
-  $input = @$("select")
+  $input = @$('select')
   options = {}
 
   if @data.multiple
@@ -133,9 +125,9 @@ Template.articleSelect2.onRendered ->
   $input.select2(options)
 
   if @data.selected
-    $input.val(@data.selected).trigger("change")
-  $input.next(".select2-container").css("width", "100%")
+    $input.val(@data.selected).trigger('change')
+  $input.next('.select2-container').css('width', '100%')
 
 Template.articleSelect2.onDestroyed ->
   templateInstance = Template.instance()
-  templateInstance.$("#" + templateInstance.data.selectId).select2("destroy")
+  templateInstance.$('#' + templateInstance.data.selectId).select2('destroy')

--- a/client/controllers/curatorInbox.coffee
+++ b/client/controllers/curatorInbox.coffee
@@ -183,9 +183,9 @@ Template.curatorInboxSection.onCreated ->
         moment(value).format('YYYY-MM-DD')
     },
     {
-      key: "expand"
-      label: ""
-      cellClass: "details-row"
+      key: 'expand'
+      label: ''
+      cellClass: 'action open-right'
     }
   ]
 

--- a/client/controllers/incidentForm.coffee
+++ b/client/controllers/incidentForm.coffee
@@ -19,11 +19,11 @@ Template.incidentForm.onCreated ->
         url: @incidentData.url[0]
       })?._id
     if @incidentData.cases
-      @incidentType.set("cases")
+      @incidentType.set('cases')
     else if @incidentData.deaths
-      @incidentType.set("deaths")
+      @incidentType.set('deaths')
     else if @incidentData.specify
-      @incidentType.set("other")
+      @incidentType.set('other')
 
 Template.incidentForm.onRendered ->
   $(document).ready =>
@@ -31,33 +31,40 @@ Template.incidentForm.onRendered ->
     if @incidentData.dateRange.start and @incidentData.dateRange.end
       datePickerOptions.startDate = @incidentData.dateRange.start
       datePickerOptions.endDate = @incidentData.dateRange.end
-    createInlineDateRangePicker(@.$("#rangePicker"), datePickerOptions)
+    createInlineDateRangePicker(@.$('#rangePicker'), datePickerOptions)
     datePickerOptions.singleDatePicker = true
-    createInlineDateRangePicker(@.$("#singleDatePicker"), datePickerOptions)
+    createInlineDateRangePicker(@.$('#singleDatePicker'), datePickerOptions)
 
 Template.incidentForm.helpers
   incidentData: ->
     Template.instance().incidentData
+
   incidentStatus: ->
-    "#{Template.instance().incidentData.status}": true
+    '#{Template.instance().incidentData.status}': true
+
   incidentType: ->
-    "#{Template.instance().incidentType.get()}": true
+    '#{Template.instance().incidentType.get()}': true
+
   articles: ->
-    return Template.instance().data.articles
+    Template.instance().data.articles
+
   showCountForm: ->
     type = Template.instance().incidentType.get()
-    return type is "cases" or type is "deaths"
+    type is 'cases' or type is 'deaths'
+
   showOtherForm: ->
-    return Template.instance().incidentType.get() is "other"
+    Template.instance().incidentType.get() is 'other'
+
   dayTabClass: ->
-    if Template.instance().incidentData.dateRange.type is "day"
-      return "active"
+    if Template.instance().incidentData.dateRange.type is 'day'
+      'active'
+
   rangeTabClass: ->
-    if Template.instance().incidentData.dateRange.type is "precise"
-      return "active"
+    if Template.instance().incidentData.dateRange.type is 'precise'
+      'active'
 
 Template.incidentForm.events
-  "change select[name='incidentType']": (e, template) ->
+  'change select[name=incidentType]': (e, template) ->
     template.incidentType.set($(e.target).val())
-  "change input[name='daterangepicker_start']": (e, template) ->
+  'change input[name=daterangepicker_start]': (e, template) ->
     $('#singleDatePicker').data('daterangepicker').clickApply()

--- a/client/controllers/incidentForm.coffee
+++ b/client/controllers/incidentForm.coffee
@@ -26,24 +26,23 @@ Template.incidentForm.onCreated ->
       @incidentType.set('other')
 
 Template.incidentForm.onRendered ->
-  $(document).ready =>
-    datePickerOptions = {}
-    if @incidentData.dateRange.start and @incidentData.dateRange.end
-      datePickerOptions.startDate = @incidentData.dateRange.start
-      datePickerOptions.endDate = @incidentData.dateRange.end
-    createInlineDateRangePicker(@.$('#rangePicker'), datePickerOptions)
-    datePickerOptions.singleDatePicker = true
-    createInlineDateRangePicker(@.$('#singleDatePicker'), datePickerOptions)
+  datePickerOptions = {}
+  if @incidentData.dateRange.start and @incidentData.dateRange.end
+    datePickerOptions.startDate = @incidentData.dateRange.start
+    datePickerOptions.endDate = @incidentData.dateRange.end
+  createInlineDateRangePicker(@.$('#rangePicker'), datePickerOptions)
+  datePickerOptions.singleDatePicker = true
+  createInlineDateRangePicker(@.$('#singleDatePicker'), datePickerOptions)
 
 Template.incidentForm.helpers
   incidentData: ->
     Template.instance().incidentData
 
   incidentStatus: ->
-    '#{Template.instance().incidentData.status}': true
+    "#{Template.instance().incidentData.status}": true
 
   incidentType: ->
-    '#{Template.instance().incidentType.get()}': true
+    "#{Template.instance().incidentType.get()}": true
 
   articles: ->
     Template.instance().data.articles
@@ -66,5 +65,6 @@ Template.incidentForm.helpers
 Template.incidentForm.events
   'change select[name=incidentType]': (e, template) ->
     template.incidentType.set($(e.target).val())
+
   'change input[name=daterangepicker_start]': (e, template) ->
     $('#singleDatePicker').data('daterangepicker').clickApply()

--- a/client/controllers/incidentModal.coffee
+++ b/client/controllers/incidentModal.coffee
@@ -40,7 +40,7 @@ Template.incidentModal.events
       Meteor.call 'editIncidentReport', incident, (error, result) ->
         if not error
           $('.reactive-table tr').removeClass('open')
-          $('.reactive-table tr.tr-details').remove()
+          $('.reactive-table tr.details').remove()
           toastr.success('Incident report updated.')
         else
           toastr.error(error.reason)

--- a/client/controllers/incidentModal.coffee
+++ b/client/controllers/incidentModal.coffee
@@ -2,44 +2,45 @@ utils = require '/imports/utils.coffee'
 incidentReportSchema = require '/imports/schemas/incidentReport.coffee'
 
 Template.incidentModal.events
-  "click .save-modal, click .save-modal-duplicate": (e, templateInstance) ->
-    duplicate = $(e.target).hasClass("save-modal-duplicate")
-    form = templateInstance.$("form")[0]
+  'click .save-modal, click .save-modal-duplicate': (e, templateInstance) ->
+    duplicate = $(e.target).hasClass('save-modal-duplicate')
+    form = templateInstance.$('form')[0]
     incident = utils.incidentReportFormToIncident(form)
+
     if not incident
       return
     incident.userEventId = templateInstance.data.userEventId
-    if this.add
-      Meteor.call("addIncidentReport", incident, (error, result) ->
+
+    if @add
+      Meteor.call 'addIncidentReport', incident, (error, result) ->
         if not error
-          $(".reactive-table tr").removeClass("details-open")
-          $(".reactive-table tr.tr-details").remove()
+          $('.reactive-table tr').removeClass('open')
+          $('.reactive-table tr.tr-details').remove()
           if !duplicate
-             $("#articleSource").val(null).trigger("change")
-             $(form.date).val("")
-             $("#incident-location-select2").val(null).trigger("change")
-             $(form.species).val("")
+             $('#articleSource').val(null).trigger('change')
+             $(form.date).val('')
+             $('#incident-location-select2').val(null).trigger('change')
+             $(form.species).val('')
              $(form.status).val(null)
-             $(form.count).val("")
-             $(form.incidentType).val(null).trigger("change")
+             $(form.count).val('')
+             $(form.incidentType).val(null).trigger('change')
              $(form.travelRelated).attr('checked', false)
-          toastr.success("Incident report added to event.")
+          toastr.success('Incident report added to event.')
         else
           errorString = error.reason
-          if error.details[0].name is "locations" and error.details[0].type is "minCount"
-            errorString = "You must specify at least one loction"
+          if error.details[0].name is 'locations' and error.details[0].type is 'minCount'
+            errorString = 'You must specify at least one loction'
           toastr.error(errorString)
-      )
-    if this.edit
-      incident._id = this.incident._id
-      incident.addedByUserId = this.incident.addedByUserId
-      incident.addedByUserName = this.incident.addedByUserName
-      incident.addedDate = this.incident.addedDate
-      Meteor.call("editIncidentReport", incident, (error, result) ->
+
+    if @edit
+      incident._id = @incident._id
+      incident.addedByUserId = @incident.addedByUserId
+      incident.addedByUserName = @incident.addedByUserName
+      incident.addedDate = @incident.addedDate
+      Meteor.call 'editIncidentReport', incident, (error, result) ->
         if not error
-          $(".reactive-table tr").removeClass("details-open")
-          $(".reactive-table tr.tr-details").remove()
-          toastr.success("Incident report updated.")
+          $('.reactive-table tr').removeClass('open')
+          $('.reactive-table tr.tr-details').remove()
+          toastr.success('Incident report updated.')
         else
           toastr.error(error.reason)
-    )

--- a/client/controllers/incidentReport.coffee
+++ b/client/controllers/incidentReport.coffee
@@ -1,8 +1,19 @@
 import { formatUrl } from '/imports/utils.coffee'
 
 Template.incidentReport.helpers
-  formatUrl: (url) ->
-    formatUrl(url)
+  formatUrl: formatUrl
+
+  caseCounts: ->
+    @deaths or @cases
+
+  deathsLabel: ->
+    pluralize 'Death', @deaths, false
+
+  casesLabel: ->
+    pluralize 'Case', @cases, false
+
+  importantDetails: ->
+    @deaths or @cases or @status
 
 Template.addIncidentReport.events
   "click .open-incident-form": (event, template) ->

--- a/client/controllers/incidentReport.coffee
+++ b/client/controllers/incidentReport.coffee
@@ -18,3 +18,6 @@ Template.incidentReport.helpers
 Template.addIncidentReport.events
   'click .open-incident-form': (event, template) ->
     Modal.show('incidentModal', {articles: template.data.articles, userEventId: template.data.userEvent._id, add: true})
+
+Template.detailIcon.onRendered ->
+  @$('[data-toggle=tooltip]').tooltip()

--- a/client/controllers/incidentReport.coffee
+++ b/client/controllers/incidentReport.coffee
@@ -16,5 +16,5 @@ Template.incidentReport.helpers
     @deaths or @cases or @status
 
 Template.addIncidentReport.events
-  "click .open-incident-form": (event, template) ->
-    Modal.show("incidentModal", {articles: template.data.articles, userEventId: template.data.userEvent._id, add: true})
+  'click .open-incident-form': (event, template) ->
+    Modal.show('incidentModal', {articles: template.data.articles, userEventId: template.data.userEvent._id, add: true})

--- a/client/controllers/incidentReports.coffee
+++ b/client/controllers/incidentReports.coffee
@@ -132,7 +132,7 @@ Template.incidentReports.helpers
           return ''
         sortFn: (value, object) ->
           +new Date(object.dateRange.end)
-      },
+      }
     ]
 
     fields.push
@@ -146,7 +146,7 @@ Template.incidentReports.helpers
     showNavigationRowsPerPage: false
     showRowCount: false
     class: 'table event-incidents'
-    rowClass: 'event-incident'
+    rowClass: "event-incident"
 
 Template.incidentReports.events
   'click #scatterPlot-toggleCumulative': (event, template) ->
@@ -186,11 +186,12 @@ Template.incidentReports.events
 
   'click .reactive-table tbody tr .edit': (event, template) ->
     templateData = template.data
-    Modal.show 'incidentModal',
+    incident =
       articles: templateData.articles
       userEventId: templateData.userEvent._id
       edit: true
       incident: @
+    Modal.show 'incidentModal', incident
 
   'click .reactive-table tbody tr .delete': (event, template) ->
     if window.confirm('Are you sure you want to delete this incident report?')

--- a/client/controllers/incidentReports.coffee
+++ b/client/controllers/incidentReports.coffee
@@ -33,6 +33,7 @@ Template.incidentReports.onCreated ->
   # therefore we will setup a reactive cursor to use with the plot as an
   # instance variable.
   @incidents = Incidents.find({userEventId: @data.userEvent._id}, {sort: {date: -1}})
+  console.log @incidents.fetch()
 
 Template.incidentReports.onRendered ->
   @filters =
@@ -143,7 +144,7 @@ Template.incidentReports.helpers
     fields.push
       key: "expand"
       label: ""
-      cellClass : "open-row"
+      cellClass : "action open-down"
 
     id: 'event-incidents-table'
     fields: fields
@@ -173,7 +174,7 @@ Template.incidentReports.events
     template.plot.resetZoom()
 
   'click #event-incidents-table th': (event, template) ->
-    template.$('tr').removeClass('details-open')
+    template.$('tr').removeClass('open')
     template.$('tr.details').remove()
 
   'click .reactive-table tbody tr': (event, template) ->
@@ -187,10 +188,10 @@ Template.incidentReports.events
     else if $target.closest('.edit-row').length
       Modal.show('incidentModal', {articles: template.data.articles, userEventId: template.data.userEvent._id, edit: true, incident: this})
     else if not $parentRow.hasClass('details')
-      closeRow = $parentRow.hasClass('details-open')
+      closeRow = $parentRow.hasClass('open')
       if currentOpen
-        template.$('tr').removeClass('details-open')
+        template.$('tr').removeClass('open')
         currentOpen.remove()
       if not closeRow
         $tr = $('<tr>').addClass('details').html(Blaze.toHTMLWithData(Template.incidentReport, this))
-        $parentRow.addClass('details-open').after($tr)
+        $parentRow.addClass('open').after($tr)

--- a/client/controllers/incidentReports.coffee
+++ b/client/controllers/incidentReports.coffee
@@ -95,8 +95,7 @@ Template.incidentReports.onRendered ->
       return
 
 Template.incidentReports.helpers
-  formatUrl: (url) ->
-    formatUrl(url)
+  formatUrl: formatUrl
   getSettings: ->
     fields = [
       {
@@ -139,50 +138,22 @@ Template.incidentReports.helpers
         sortFn: (value, object) ->
           +new Date(object.dateRange.end)
       },
-      {
-        key: "travelRelated"
-        label: "Travel Related"
-        fn: (value, object, key) ->
-          if value
-            return "Yes"
-          return ""
-      },
-      {
-        key: "species"
-        label: "Species"
-      }
     ]
 
-    if Meteor.user()
-      fields.push({
-        key: "delete"
-        label: ""
-        cellClass: "remove-row"
-      })
-
-      fields.push({
-        key: "Edit"
-        label: ""
-        cellClass: "edit-row"
-      })
-
-    fields.push({
+    fields.push
       key: "expand"
       label: ""
-      cellClass: "open-row"
-    })
+      cellClass : "open-row"
 
-    return {
-      id: 'event-incidents-table'
-      fields: fields
-      showFilter: false
-      showNavigationRowsPerPage: false
-      showRowCount: false
-      class: "table"
-    }
+    id: 'event-incidents-table'
+    fields: fields
+    showFilter: false
+    showNavigationRowsPerPage: false
+    showRowCount: false
+    class: "table event-incidents"
 
 Template.incidentReports.events
-  "click #scatterPlot-toggleCumulative": (event, template) ->
+  'click #scatterPlot-toggleCumulative': (event, template) ->
     $target = $(event.currentTarget)
     $icon = $target.find('i.fa')
     if $target.hasClass('active')
@@ -197,26 +168,29 @@ Template.incidentReports.events
       template.plot.removeFilter('notCumulative')
       template.plot.addFilter('cumulative', template.filters.cumulative)
       template.updatePlot()
-  "click #scatterPlot-resetZoom": (event, template) ->
+
+  'click #scatterPlot-resetZoom': (event, template) ->
     template.plot.resetZoom()
-  "click #event-incidents-table th": (event, template) ->
-    template.$("tr").removeClass("details-open")
-    template.$("tr.tr-details").remove()
-  "click .reactive-table tbody tr": (event, template) ->
+
+  'click #event-incidents-table th': (event, template) ->
+    template.$('tr').removeClass('details-open')
+    template.$('tr.details').remove()
+
+  'click .reactive-table tbody tr': (event, template) ->
     $target = $(event.target)
-    $parentRow = $target.closest("tr")
-    currentOpen = template.$("tr.tr-details")
-    if $target.closest(".remove-row").length
-      if window.confirm("Are you sure you want to delete this incident report?")
+    $parentRow = $target.closest('tr')
+    currentOpen = template.$('tr.details')
+    if $target.closest('.remove-row').length
+      if window.confirm('Are you sure you want to delete this incident report?')
         currentOpen.remove()
-        Meteor.call("removeIncidentReport", @_id)
-    else if $target.closest(".edit-row").length
-      Modal.show("incidentModal", {articles: template.data.articles, userEventId: template.data.userEvent._id, edit: true, incident: this})
-    else if not $parentRow.hasClass("tr-details")
-      closeRow = $parentRow.hasClass("details-open")
+        Meteor.call('removeIncidentReport', @_id)
+    else if $target.closest('.edit-row').length
+      Modal.show('incidentModal', {articles: template.data.articles, userEventId: template.data.userEvent._id, edit: true, incident: this})
+    else if not $parentRow.hasClass('details')
+      closeRow = $parentRow.hasClass('details-open')
       if currentOpen
-        template.$("tr").removeClass("details-open")
+        template.$('tr').removeClass('details-open')
         currentOpen.remove()
       if not closeRow
-        $tr = $("<tr>").addClass("tr-details").html(Blaze.toHTMLWithData(Template.incidentReport, this))
-        $parentRow.addClass("details-open").after($tr)
+        $tr = $('<tr>').addClass('details').html(Blaze.toHTMLWithData(Template.incidentReport, this))
+        $parentRow.addClass('details-open').after($tr)

--- a/client/controllers/locationList.coffee
+++ b/client/controllers/locationList.coffee
@@ -29,21 +29,21 @@ Template.locationList.helpers
   getSettings: ->
     fields = [
       {
-        key: "name"
-        label: "Name"
+        key: 'name'
+        label: 'Name'
         fn: (value, object, key) ->
           return formatLocation(object)
       },
       {
-        key: "addedDate"
-        label: "Added"
+        key: 'addedDate'
+        label: 'Added'
         fn: (value, object, key) ->
           return moment(value).fromNow()
       },
       {
-        key: "expand"
-        label: ""
-        cellClass: "open-row"
+        key: 'expand'
+        label: ''
+        cellClass: 'action open-down'
       }
     ]
 
@@ -53,27 +53,29 @@ Template.locationList.helpers
       showFilter: false
       showNavigationRowsPerPage: false
       showRowCount: false
-      class: "table"
-      filters: ["locationFilter"]
+      class: 'table'
+      filters: ['locationFilter']
     }
 
 Template.locationList.events
-  "keyup .reactive-table-input": (event, template) ->
+  'keyup .reactive-table-input': (event, template) ->
     if event.target.value.length
-      template.$("tr").removeClass("details-open")
-      template.$("tr.tr-details").remove()
-  "click #event-locations-table th": (event, template) ->
-    template.$("tr").removeClass("details-open")
-    template.$("tr.tr-details").remove()
-  "click .reactive-table tbody tr": (event, template) ->
+      template.$('tr').removeClass('open')
+      template.$('tr.tr-details').remove()
+
+  'click #event-locations-table th': (event, template) ->
+    template.$('tr').removeClass('open')
+    template.$('tr.tr-details').remove()
+
+  'click .reactive-table tbody tr': (event, template) ->
     $target = $(event.target)
-    $parentRow = $target.closest("tr")
-    if not $parentRow.hasClass("tr-details")
-      currentOpen = template.$("tr.tr-details")
-      closeRow = $parentRow.hasClass("details-open")
+    $parentRow = $target.closest('tr')
+    if not $parentRow.hasClass('tr-details')
+      currentOpen = template.$('tr.tr-details')
+      closeRow = $parentRow.hasClass('open')
       if currentOpen
-        template.$("tr").removeClass("details-open")
+        template.$('tr').removeClass('open')
         currentOpen.remove()
       if not closeRow
-        $tr = $("<tr>").addClass("tr-details").html(Blaze.toHTMLWithData(Template.location, this))
-        $parentRow.addClass("details-open").after($tr)
+        $tr = $('<tr>').addClass('tr-details').html(Blaze.toHTMLWithData(Template.location, this))
+        $parentRow.addClass('open').after($tr)

--- a/client/views/incidentReports.jade
+++ b/client/views/incidentReports.jade
@@ -25,52 +25,46 @@ template(name="addIncidentReport")
 
 template(name="incidentReport")
   td(colspan="7")
-    .tr-detail-container.form-horizontal
-      .row
-        .col-sm-2.control-label Source:
-        .col-sm-10
-          each val in url
-            p.form-control-static
-              a.ref-link(href="{{formatUrl(val)}}" target="_blank") {{formatUrl(val)}}
-      if dateRange
-        .row
-          .col-sm-2.control-label Date:
-          .col-sm-10
-            p.form-control-static {{formatDateRange(dateRange)}}
-      .row
-        .col-sm-2.control-label Location:
-        .col-sm-10
+    .details-container.incident-report--details
+      ul.list-unstyled
+        li
+          h5 Source:
+          ul.list-unstyled
+            each val in url
+              li
+                a.ref-link(href="{{formatUrl(val)}}" target="_blank") {{formatUrl(val)}}
+        if dateRange
+          li
+            h5 Date:
+            span {{formatDateRange(dateRange)}}
+        li
+          h5 Location:
           if locations.length
-            each locations
-              p.form-control-static {{formatLocation(this)}}
+            ul.list-unstyled
+              each locations
+                li {{formatLocation(this)}}
           else
-            p.form-control-static No location specified.
-      .row
-        .col-sm-2.control-label Species:
-        .col-sm-10
-          p.form-control-static {{species}}
-      .row
-        .col-sm-2.control-label Status:
-        .col-sm-10
-          p.form-control-static {{status}}
-      .row
-        if cases
-          +incidentDetails label="Cases" value=cases
-        if deaths
-          +incidentDetails label="Deaths" value=deaths
-        if specify
-          +incidentDetails label="Other" value=specify
-      .row
-        .col-sm-2.control-label Travel Related:
-        .col-sm-10
+            span No location specified.
+        li
+          h5 Species:
+          span=species
+        li
+          h5 Status:
+          span=status
+        li
+          if cases
+            +incidentDetails label="Cases" value=cases
+          if deaths
+            +incidentDetails label="Deaths" value=deaths
+          if specify
+            +incidentDetails label="Other" value=specify
+        li
           if travelRelated
-            p.form-control-static
-              i.fa.fa-lg.fa-check
+            i.fa.fa-lg.fa-plane
 
 template(name="incidentDetails")
-  .col-sm-2.control-label {{label}}:
-  .col-sm-10
-    p.form-control-static {{value}}
+  h5 #{label}:
+  span=value
 
 template(name="incidentModal")
   .modal.fade(role="dialog")

--- a/client/views/incidentReports.jade
+++ b/client/views/incidentReports.jade
@@ -25,46 +25,62 @@ template(name="addIncidentReport")
 
 template(name="incidentReport")
   td(colspan="7")
-    .details-container.incident-report--details
-      ul.list-unstyled
-        li
-          h5 Source:
-          ul.list-unstyled
-            each val in url
-              li
-                a.ref-link(href="{{formatUrl(val)}}" target="_blank") {{formatUrl(val)}}
-        if dateRange
-          li
-            h5 Date:
-            span {{formatDateRange(dateRange)}}
-        li
-          h5 Location:
-          if locations.length
-            ul.list-unstyled
-              each locations
-                li {{formatLocation(this)}}
-          else
-            span No location specified.
-        li
-          h5 Species:
-          span=species
-        li
-          h5 Status:
-          span=status
-        li
-          if cases
-            +incidentDetails label="Cases" value=cases
-          if deaths
-            +incidentDetails label="Deaths" value=deaths
-          if specify
-            +incidentDetails label="Other" value=specify
-        li
+    .details-container.incident-report--details.container-flex
+      if importantDetails
+        .incident-report--details--important
+          if status
+            .incident-report--details--status
+              i.fa(class=status)
+              h6=status
+          if caseCounts
+            .incident-report--details--counts
+              if deaths
+                +incidentCount label=deathsLabel count=deaths
+              if cases
+                +incidentCount label=casesLabel count=cases
           if travelRelated
-            i.fa.fa-lg.fa-plane
+            .incident-report--details--travel-related
+              i.fa.fa-lg.fa-plane
+              h6 Travel Related
 
-template(name="incidentDetails")
-  h5 #{label}:
-  span=value
+      .incident-report--details--metadata(class="{{#if importantDetails}} bordered {{/if}}")
+        if specify
+          h5=specify
+
+        ul.metadata.list-unstyled
+          li.container-flex
+            i.detail-icon.fa.fa-globe
+            if locations.length
+              ul.list-unstyled.locations
+                each locations
+                  li
+                    span {{formatLocation(this)}}
+            else
+              span No location specified.
+          if species
+            li.container-flex.single
+              i.detail-icon.fa.fa-paw
+              span=species
+          li.container-flex.single
+            i.detail-icon.fa.fa-calendar
+            span {{formatDateRange(dateRange)}}
+          li.container-flex
+            i.detail-icon.fa.fa-link
+            ul.list-unstyled
+              each val in url
+                li
+                  a.ref-link(href="{{formatUrl(val)}}" target="_blank")
+                    span {{formatUrl(val)}}
+
+      .incident-report--details--actions.container-flex
+        a.edit
+          i.fa.fa-edit
+        a.delete
+          i.fa.fa-trash
+
+template(name="incidentCount")
+  span.incident-count=count
+  h6.type=label
 
 template(name="incidentModal")
   .modal.fade(role="dialog")

--- a/client/views/incidentReports.jade
+++ b/client/views/incidentReports.jade
@@ -49,7 +49,7 @@ template(name="incidentReport")
 
         ul.metadata.list-unstyled
           li.container-flex
-            i.detail-icon.fa.fa-globe
+            +detailIcon icon="globe" title="Locations"
             if locations.length
               ul.list-unstyled.locations
                 each locations
@@ -59,13 +59,13 @@ template(name="incidentReport")
               span No location specified.
           if species
             li.container-flex.single
-              i.detail-icon.fa.fa-paw
+              +detailIcon icon="paw" title="Species"
               span=species
           li.container-flex.single
-            i.detail-icon.fa.fa-calendar
+            +detailIcon icon="calendar" title="Dates"
             span {{formatDateRange(dateRange)}}
           li.container-flex
-            i.detail-icon.fa.fa-link
+            +detailIcon icon="link" title="Source"
             ul.list-unstyled
               each val in url
                 li
@@ -81,6 +81,13 @@ template(name="incidentReport")
 template(name="incidentCount")
   span.incident-count=count
   h6.type=label
+
+template(name="detailIcon")
+  i.detail-icon.fa(
+    class="fa-#{icon}"
+    data-toggle="tooltip"
+    data-placement="top"
+    title=title)
 
 template(name="incidentModal")
   .modal.fade(role="dialog")

--- a/imports/stylesheets/buttons.import.styl
+++ b/imports/stylesheets/buttons.import.styl
@@ -81,6 +81,10 @@ $buttons()
   .fa
     margin-right .25em
 
+.btn-xs
+  font-size .75em
+  padding .5em 1.5em
+
 .btn-delete
   @extend .btn-danger
 

--- a/imports/stylesheets/event.import.styl
+++ b/imports/stylesheets/event.import.styl
@@ -469,6 +469,7 @@ $max-event-details-width = $max-ui-width+300
       span
         font-size .85em
       li
+        margin-bottom .25em
         &:last-of-type
           margin-bottom 0
   h5

--- a/imports/stylesheets/event.import.styl
+++ b/imports/stylesheets/event.import.styl
@@ -16,6 +16,10 @@ $max-event-details-width = $max-ui-width+300
       tr
         th
           border-color $border-primary-light
+    tr
+      &:not(.details)
+        &:hover
+          background $border-primary-light
     td
       &:first-child
         +below(3)
@@ -417,72 +421,63 @@ $max-event-details-width = $max-ui-width+300
       border-color $primary-dark
       background darken($primary-l-light, 5%)
 
-.disease-separator
-  border-top 1px solid #DDD
-  margin 10px 0
-
-.remove-row::before
-.edit-row::before
-.open-row::before
-.details-row::before
-.open-row-right::before
-  font-family FontAwesome
-
-.remove-row::before
-  content "\f014"
-
-.edit-row::before
-  content "\f044"
-
-.open-row::before
-  content "\f107"
-
-.details-row::before
-  content "\f105"
-  position absolute
-  right 1em
-  top 50%
-  transform translate(0, -50%)
-
-.open-row-right::before
-  content "\f054"
+.tab-content
+  .table
+    tr
+      &:not(.details)
+        cursor pointer
+      &:hover
+        .open-row
+          &:after
+            transform scale(1.3)
+    .open-row
+      max-width 1em
+      padding-right 1em
+      text-align right
+      &:after
+        font-family FontAwesome
+        content '\f137'
+        color $border-primary
+    .details-open
+      .open-row
+        &:after
+          content '\f13a'
+          color $primary
 
 .details-open
   background-color $selected
-  .open-row::before
-    content "\f106"
+  position relative
 
-.reactive-table tr.tr-details
-  cursor default
-
-.tr-detail-container
+.details-container
   padding 0 50px
   ul
     margin-bottom 0
 
 .annotation-text
   color red
+
 .annotation
   text-decoration underline
   cursor pointer
+
 .annotation.accepted
   color green
+
 .suggested-incidents
   width 800px
   .modal-body
     height 500px
     overflow-y scroll
+
 .annotated-content
   white-space pre-wrap
+
 .snippet
   max-height 250px
   overflow-y scroll
+
 .warn
   background-color yellow
-
-td.col-md-6.countCell.countCellLeft.text-center
-td.col-md-6.countCell.text-center
-  float left
 
 .event-sources-detail
   h4

--- a/imports/stylesheets/event.import.styl
+++ b/imports/stylesheets/event.import.styl
@@ -291,10 +291,11 @@ $max-event-details-width = $max-ui-width+300
     margin 0
 
 .ref-link
+  color $primary
   span
     padding-right 5px
   &:hover
-    text-decoration none
+    color $secondary-dark
 
 @media (max-width: 1200px)
   .main-facts
@@ -426,32 +427,123 @@ $max-event-details-width = $max-ui-width+300
     tr
       &:not(.details)
         cursor pointer
-      &:hover
-        .open-row
-          &:after
-            transform scale(1.3)
-    .open-row
-      max-width 1em
-      padding-right 1em
-      text-align right
-      &:after
-        font-family FontAwesome
-        content '\f137'
-        color $border-primary
-    .details-open
+    .open
+      background-color $selected
+      td
+        border-top 1px solid $border-primary
+        border-bottom 1px solid $border-primary
       .open-row
         &:after
           content '\f13a'
           color $primary
+    .details
+      background lighten($selected, 70%)
+      td
+        border-bottom 1px solid $border-primary
 
 .details-open
   background-color $selected
   position relative
 
 .details-container
-  padding 0 50px
+  margin-bottom .75em
+  margin-top .75em
   ul
     margin-bottom 0
+  .sources
+    margin-bottom 1em
+  .detail-icon
+    min-width 1.5em
+    &.fa
+      font-size 1.5em
+      color desaturate(darken($border-primary, 5%), 25%)
+  .metadata
+    li
+      margin-bottom 1em
+      align-items flex-start
+      &.single
+        span
+          margin-top .2em
+      &:last-of-type
+        margin 0
+      span
+        font-size .85em
+      li
+        &:last-of-type
+          margin-bottom 0
+  h5
+    font-size 1em
+    color lighten($primary, 20%)
+    margin-top 0
+    margin-bottom 1em
+
+.incident-report--details--important
+.incident-report--details--metadata
+  align-self center
+  margin-right 1.75em
+
+.incident-report--details--important
+  display flex
+  flex-direction column
+  div
+    margin-bottom 1em
+    text-align center
+    &:last-of-type
+      margin-bottom 0
+  h6
+    text-transform uppercase
+    margin .25em 0 0 0
+  .fa
+    font-size 2.5em
+
+.incident-report--details--metadata
+  margin-right 3em
+  &.bordered
+    border-left 1px solid lighten($border-primary, 40%)
+    padding-left 1.75em
+  ul
+    &:last-of-type
+      margin-bottom 0
+
+.incident-report--details--actions
+  margin-left auto
+  a
+    font-size 1.5em
+    color lighten($m-gray, 20%)
+    margin-right .5em
+    &:hover
+      color $primary
+    &:first-of-type
+      margin-top .07em
+    &:last-of-type
+      &:hover
+        color $delete
+
+.incident-report--details--counts
+  .incident-count
+    font-size 2.5em
+    font-weight 800
+    line-height 1
+    color $m-gray
+
+.incident-report--details--status
+  .confirmed
+    color $positive
+    &:before
+      content '\f058'
+  .suspected
+    color $warning
+    &:before
+      content '\f059'
+  .revoked
+    color $delete
+    &:before
+      content '\f05c'
+
+.incident-report--details--travel-related
+  .fa
+    color $delete
+
 
 .annotation-text
   color red
@@ -478,6 +570,11 @@ $max-event-details-width = $max-ui-width+300
 
 .warn
   background-color yellow
+
+.event-sources
+  tbody
+    tr
+      cursor pointer
 
 .event-sources-detail
   h4

--- a/imports/stylesheets/event.import.styl
+++ b/imports/stylesheets/event.import.styl
@@ -453,7 +453,7 @@ $max-event-details-width = $max-ui-width+300
   .sources
     margin-bottom 1em
   .detail-icon
-    min-width 1.5em
+    margin-right .5em
     &.fa
       font-size 1.5em
       color desaturate(darken($border-primary, 5%), 25%)

--- a/imports/stylesheets/globals.import.styl
+++ b/imports/stylesheets/globals.import.styl
@@ -82,8 +82,10 @@ tr
     transition .2s
 
 a
+  cursor pointer
   color $link-color
   &:hover
+  &:focus
     color $link-color-hover
     text-decoration none
 

--- a/imports/stylesheets/tables.import.styl
+++ b/imports/stylesheets/tables.import.styl
@@ -12,6 +12,9 @@
   border-color $border-primary-light
 
 .reactive-table
+  tbody
+    tr
+      cursor default
   tr
     &.tr-details
       cursor default
@@ -22,3 +25,28 @@
       &:last-of-type
       td
         border-bottom 1px solid $border-primary-light
+      &.selected
+      &.open
+        .action
+          color $primary
+          &.open-down
+            &::after
+              content '\f13a'
+      &:hover
+        .action
+          &::after
+            color $primary
+      .action
+        min-width 1em
+        max-width 1em
+        text-align right
+        color $border-primary
+        padding-right 1.5em
+        &:after
+          font-family FontAwesome
+        &.open-down
+          &::after
+            content '\f137'
+        &.open-right
+          &::after
+            content '\f105'

--- a/imports/stylesheets/tables.import.styl
+++ b/imports/stylesheets/tables.import.styl
@@ -11,5 +11,14 @@
 .table > tbody > tr > td
   border-color $border-primary-light
 
-table tr:last-child
-  border 0
+.reactive-table
+  tr
+    &.tr-details
+      cursor default
+
+.table
+  > tbody
+    > tr
+      &:last-of-type
+      td
+        border-bottom 1px solid $border-primary-light

--- a/imports/ui/helpers.coffee
+++ b/imports/ui/helpers.coffee
@@ -3,10 +3,10 @@ formatLocation = require '/imports/formatLocation.coffee'
 UI.registerHelper 'formatLocation', (location)->
   return formatLocation(location)
 
-@pluralize = (word, count) ->
+@pluralize = (word, count, showCount=true) ->
   if Number(count) isnt 1
     word += "s"
-  "#{count} #{word}"
+  if showCount then "#{count} #{word}" else word
 
 formatDateRange = (dateRange, readable)->
   dateFormat = "MMM D, YYYY"

--- a/methods/articles.coffee
+++ b/methods/articles.coffee
@@ -5,11 +5,10 @@ Meteor.methods
     user = Meteor.user()
     if user and Roles.userIsInRole(user._id, ['admin'])
       if source.url.length
-        insertArticle = {
-          url: source.url,
-          title: source.title,
+        insertArticle =
+          url: source.url
+          title: source.title
           userEventId: source.userEventId
-        }
         existingArticle = Articles.find(insertArticle).fetch()
         unless existingArticle.length is 0
           throw new Meteor.Error(501, 'This article has already been added')


### PR DESCRIPTION
Updates the Incident Report details area like so:
![screen shot 2016-11-04 at 3 53 26 pm](https://cloud.githubusercontent.com/assets/4105343/20023224/155df958-a2b5-11e6-8af9-0a63ec53f34a.png)

It looks like there's a bunch of changes but its mostly cleaning up code styling. Like using `'` instead of `"`, removing excessive curly brackets for object declarations, etc.
We probably need to establish common patterns for stuff like this and establish a JSLint file. 
I noticed we use 3 different naming conventions to refer to the template instance in events: `instance`, `template` and `templateInstance`. I think in recent projects we've used `instance`. Maybe we should fix all of these at some point?

(layout may break on smaller screens — I can update those styles in another PR)

PT Chore: https://www.pivotaltracker.com/story/show/133691167