### PR TITLE
change incident delete alert into a modal

### DIFF
--- a/client/controllers/incidentDeleteModal.coffee
+++ b/client/controllers/incidentDeleteModal.coffee
@@ -1,0 +1,17 @@
+Template.incidentDeleteModal.helpers
+  getFirstLocation: () ->
+    Template.instance().data.locations[0].name
+  formatDate: (date) ->
+    moment(date).format("MMM D, YYYY")
+
+Template.incidentDeleteModal.events
+  'click .delete-event-confirmation': (event, instance) ->
+    Meteor.call 'removeIncidentReport', instance.data._id, (error) ->
+      if error
+        toastr.error(error.message)
+        return
+      $('#incident-delete-modal').modal('hide')
+      $('body').removeClass 'modal-open'
+      $('.modal-backdrop').remove()
+      $('.incident-report--details').closest('tr').fadeOut(-> @.remove())
+      toastr.success('The incident has been deleted.')

--- a/client/controllers/incidentReports.coffee
+++ b/client/controllers/incidentReports.coffee
@@ -194,12 +194,10 @@ Template.incidentReports.events
     Modal.show 'incidentModal', incident
 
   'click .reactive-table tbody tr .delete': (event, template) ->
-    if window.confirm('Are you sure you want to delete this incident report?')
-      template.$('tr.details').remove()
-      Meteor.call('removeIncidentReport', @_id)
+    Modal.show 'incidentDeleteModal', @
 
   # Remove any open incident report details elements on pagination
   'click .next-page,
    click .prev-page,
    change .reactive-table-navigation .form-control': (event, template) ->
-    template.$('tr.details').remove()
+     template.$('tr.details').remove()

--- a/client/views/incidentDeleteModal.jade
+++ b/client/views/incidentDeleteModal.jade
@@ -1,0 +1,18 @@
+
+template(name="incidentDeleteModal")
+  #incident-delete-modal.modal.fade(role="dialog")
+    .modal-dialog
+      .modal-content
+        form#deleteIncident
+          .close-modal(data-dismiss="modal" aria-label="Close")
+          .modal-header
+            h4.modal-title Confirm Delete
+          .modal-body.clearfix
+            .delete-confirmation
+              i.fa.fa-trash-o
+              p Are you sure you want to delete this incident?
+              p {{ getFirstLocation }} on {{ formatDate(dateRange.start) }}
+              .main-action
+                button.btn.btn-danger.btn-wide.delete-event-confirmation(type="button") Delete Incident
+              .other-actions
+                button.btn.btn-default.btn-sm(type="button" data-dismiss="modal") Cancel


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/133695987

Steps:
1. Click Tracked Events
2. Sort by # incidents descending
3. Choose Event with # incidents > 0
4. Click the toggle on the Incidents table
![image](https://cloud.githubusercontent.com/assets/12954045/20196901/d11d664c-a76a-11e6-929d-f2ab5bc866db.png)
5. click the trash icon
![image](https://cloud.githubusercontent.com/assets/12954045/20196837/812fc9e0-a76a-11e6-9769-0113ca6f1892.png)
6. choose delete