### PR TITLE
upgrade chimp, allow for args to run-tests.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "EIDR",
   "private": true,
   "scripts": {
-    "start": "meteor -p 3000 --settings settings-dev.json",
+    "start": "meteor -p 13000 --settings settings-dev.json",
     "start-test": "meteor -p 13000 --settings settings-dev.json",
     "chimp-test": "bash run-tests.sh",
     "chimp-watch": "WATCH=true bash run-tests.sh"
   },
   "devDependencies": {
-    "chimp": "^0.40.7",
+    "chimp": "^0.41.2",
     "mongodb-prebuilt": "^5.0.6",
     "coffee-script": "^1.6.3"
   },

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,9 +1,49 @@
 #!/bin/bash
 
-# Instructions:
-#   run meteor app instance on port 13000
-#   execute this script
+# example:
+#
+# ./run-tests.sh --app_uri=http://127.0.0.1 --app_port=13000 --mongo_host=127.0.0.1 --mongo_port=13001 --prod_db=eidr-connect --test_db=eidr-connect-test
 
+for i in "$@"
+do
+case $i in
+    --prod_db=*)
+    prod_db="${i#*=}"
+    shift
+    ;;
+    --test_db=*)
+    test_db="${i#*=}"
+    shift
+    ;;
+    --mongo_host=*)
+    mongo_host="${i#*=}"
+    shift
+    ;;
+    --mongo_port=*)
+    mongo_port="${i#*=}"
+    shift
+    ;;
+    --app_uri=*)
+    app_uri="${i#*=}"
+    shift
+    ;;
+    --app_port=*)
+    app_port="${i#*=}"
+    shift
+    ;;
+    *)
+    ;;
+esac
+shift
+done
+
+# use args or default
+prod_db=${prod_db:=eidr-connect}
+test_db=${test_db:=eidr-connect-tests}
+mongo_host=${mongo_host:=127.0.0.1}
+mongo_port=${mongo_port:=27017}
+app_uri=${app_uri:=http://localhost}
+app_port=${app_port:=13000}
 
 chimp=node_modules/chimp/bin/chimp.js
 mongo=node_modules/mongodb-prebuilt/binjs/
@@ -19,9 +59,9 @@ fi
 # Clean-up
 function finish {
   echo "Cleaning-up..."
-  $mongo/mongo.js localhost:13001/meteor .scripts/drop-database.js
-  echo "Restoring the original 'meteor' db from a dump file..."
-  $mongo/mongorestore.js -h 127.0.0.1 --port 13001 -d meteor tests/dump/meteor --quiet
+  $mongo/mongo.js $mongo_host:$mongo_port/$test_db .scripts/drop-database.js
+  echo "Restoring the original '$test_db' db from a dump file..."
+  $mongo/mongorestore.js -h $mongo_host --port $mongo_port -d $test_db tests/dump/$prod_db --quiet
   echo "done."
   rm -rf tests/dump/ # cle
 }
@@ -36,13 +76,11 @@ trap finish SIGTERM # 15
 
 # Back up the current database
 rm -rf tests/dump/
-echo "Creating a bson dump of our 'meteor' db..."
-$mongo/mongodump.js -h 127.0.0.1 --port 13001 -d meteor -o tests/dump/ --quiet
+echo "Creating a bson dump of our 'eidr-connect' db..."
+$mongo/mongodump.js -h $mongo_host --port $mongo_port -d $prod_db -o tests/dump/ --quiet
 echo "done."
 
-
-# Run the tests
-$chimp $watch --ddp=http://localhost:13000 \
+$chimp $watch --ddp=$app_uri:$app_port \
         --path=tests/ \
         --coffee=true \
         --compiler=coffee:coffee-script/register \


### PR DESCRIPTION
Example:

```
./run-tests.sh --app_uri=http://127.0.0.1 --app_port=13000 --mongo_host=127.0.0.1 --mongo_port=13001 --prod_db=eidr-connect --test_db=eidr-connect-test
```