### PR TITLE
fixing escape to close modals bug

### DIFF
--- a/client/controllers/layout.coffee
+++ b/client/controllers/layout.coffee
@@ -1,0 +1,5 @@
+Template.layout.events
+  # handles closing modals using the escape key when there are multiple modals on the same page
+  'keyup': (event, template) ->
+    if event.keyCode is 27
+      $('.modal').each (modal) -> $(@).modal 'hide'

--- a/client/controllers/layout.coffee
+++ b/client/controllers/layout.coffee
@@ -1,5 +1,0 @@
-Template.layout.events
-  # handles closing modals using the escape key when there are multiple modals on the same page
-  'keyup': (event, template) ->
-    if event.keyCode is 27
-      $('.modal').each (modal) -> $(@).modal 'hide'

--- a/client/startup.coffee
+++ b/client/startup.coffee
@@ -1,0 +1,7 @@
+Meteor.startup ->
+  $(document).on('show.bs.modal', (evt)->
+    $(@).on 'keyup', (event) ->
+      if event.keyCode is 27
+        $('.modal').each (modal) -> $(@).modal 'hide'
+  ).on 'hide.bs.modal', ->
+    $(@).off 'keyup'


### PR DESCRIPTION
right now if there are two modals on a page the "escape to close" functionality will not work.