### PR TITLE
Fix scatter plot update

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -2,7 +2,7 @@
 #
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
-
+eidr:fixtures
 eha:nojs-banner
 mquandalle:jade
 coffeescript@1.11.1_1

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -33,6 +33,7 @@ diff-sequence@1.0.6
 ecmascript@0.5.9-beta.5
 ecmascript-runtime@0.3.15-beta.5
 eha:nojs-banner@1.0.7
+eidr:fixtures@0.0.1
 ejson@1.0.12
 email@1.1.17_1
 fastclick@1.0.12

--- a/client/controllers/incidentReports/incidentReports.coffee
+++ b/client/controllers/incidentReports/incidentReports.coffee
@@ -189,13 +189,13 @@ Template.incidentReports.events
       $icon.removeClass('fa-check-circle').addClass('fa-circle-o')
       template.plot.removeFilter('cumulative')
       template.plot.addFilter('notCumulative', template.filters.notCumulative)
-      template.plot.applyFilters()
+      template.plot.draw()
     else
       $target.addClass('active')
       $icon.removeClass('fa-circle-o').addClass('fa-check-circle')
       template.plot.removeFilter('notCumulative')
       template.plot.addFilter('cumulative', template.filters.cumulative)
-      template.plot.applyFilters()
+      template.plot.draw()
     $(event.currentTarget).blur()
 
   'click #scatterPlot-resetZoom': (event, template) ->

--- a/imports/charts/Plot.coffee
+++ b/imports/charts/Plot.coffee
@@ -114,7 +114,7 @@ class Plot
         @axes.update(nodes)
       else
         shouldSetInitialMinMax = @mergeGroups(nodes)
-        @axes.update(@getGroupsNodes())
+        @axes.update(@getGroupsNodes(false))
         if shouldSetInitialMinMax
           @axes.setInitialMinMax(@axes.currentMinMax)
     else
@@ -172,9 +172,11 @@ class Plot
   ###
   mergeGroups: (groups) ->
     notMerged = Object.keys(@groups_)
+    hasNewGroup = false
     Object.keys(groups).forEach (k) =>
       group = @groups_[k]
       if typeof group == 'undefined'
+        hasNewGroup = true
         group = new Group(@, {id: k, onEnter: @options.group.onEnter})
       else
         idx = notMerged.indexOf(k)
@@ -185,7 +187,10 @@ class Plot
       # remove groups that haven't been merged
       notMerged.forEach((k) => @removeGroup(k))
       return true
-    return false
+    if hasNewGroup
+      return true
+    else
+      return false
 
   ###
   # getWidth
@@ -293,22 +298,35 @@ class Plot
   ###
   # getGroups - returns the size of all the groups
   #
-  # @param {boolean} shouldFilter, should the nodes be filtered
+  # @param {boolean} shouldFilter, should the nodes be filtered by domain
   # @return {Number} size, the size of all the groups
   ###
-  getGroupsSize: () ->
-    @getGroups().reduce((prev, nextObj) ->
-      prev + nextObj.applyFilters().length
+  getGroupsSize: (shouldFilter) ->
+    @getGroups().reduce((prev, nextObj) =>
+      if shouldFilter
+        return prev + nextObj.applyFilters().length
+      else
+        filters = Object.assign({}, @filters)
+        if filters.hasOwnProperty('_domain')
+          delete filters['_domain']
+        return prev + nextObj.applyFilters(filters).length
     , 0)
 
   ###
   # getGroupsNodes - returns all the nodes for each group
   #
+  # @param {boolean} shouldFilter, should the nodes be filtered by domain
   # @return {array} nodes, an array of nodes
   ###
-  getGroupsNodes: () ->
-    @getGroups().reduce((prevArr, nextObj) ->
-      prevArr.concat(nextObj.applyFilters())
+  getGroupsNodes: (shouldFilter) ->
+    @getGroups().reduce((prevArr, nextObj) =>
+      if shouldFilter
+        return prevArr.concat(nextObj.applyFilters())
+      else
+        filters = Object.assign({}, @filters)
+        if filters.hasOwnProperty('_domain')
+          delete filters['_domain']
+        return prevArr.concat(nextObj.applyFilters(filters))
     , [])
 
   ###

--- a/imports/charts/Plot.coffee
+++ b/imports/charts/Plot.coffee
@@ -187,7 +187,7 @@ class Plot
       # remove groups that haven't been merged
       notMerged.forEach((k) => @removeGroup(k))
       return true
-    if hasNewGroup
+    if hasNewGroup and @axes.initialized == true
       return true
     else
       return false

--- a/imports/charts/ScatterPlot.coffee
+++ b/imports/charts/ScatterPlot.coffee
@@ -94,12 +94,6 @@ class ScatterPlot extends Plot
     @
 
   ###
-  # applyFilters - draw the plot without updating the axes
-  ###
-  applyFilters: () ->
-    @draw()
-
-  ###
   # remove - removes the plot from the DOM and any event listeners
   #
   # @return {object} this

--- a/packages/_tests/package.js
+++ b/packages/_tests/package.js
@@ -9,5 +9,5 @@ Package.onUse(function(api) {
   api.versionsFrom("1.1.0.2");
   api.use("coffeescript");
   api.use("xolvio:cleaner");
-  api.addFiles("fixtures.coffee");
+  api.addFiles("fixtures.coffee", "server");
 });

--- a/start-test-server.sh
+++ b/start-test-server.sh
@@ -64,7 +64,7 @@ if [ $is_docker = "true" ]; then
   # copy settings-dev.json from the shared volume
   cp $shared_dir/settings-dev.json ${pwd}/settings-dev.json
   # checkout the correct branch
-  git checkout -f origin/$ghprbSourceBranch
+  git checkout origin/$ghprbSourceBranch
   # perform npm install in case the branch added new dependencies
   npm install .
 else

--- a/tests/features/incident.feature
+++ b/tests/features/incident.feature
@@ -1,0 +1,11 @@
+Feature: Incident
+
+  Background:
+    Given I am on the site
+    And I am logged in as an admin
+
+  Scenario: Add incident report
+    Given I can go to the event list
+    Then I can click the first item in the event list
+    Then I can add an incident report with count "100000001"
+    And I can verify scatter plot group with count "100000001"

--- a/tests/features/step_definitions/incident_steps.coffee
+++ b/tests/features/step_definitions/incident_steps.coffee
@@ -1,0 +1,52 @@
+do ->
+  'use strict'
+
+  module.exports = ->
+    url = require('url')
+
+    @Before ->
+      @server.call('load')
+
+    @After ->
+      @server.call('reset')
+
+    @Given /^I can click the first item in the event list$/, ->
+      elements = @client.elements('.reactive-table tbody')
+      if elements.value.length <= 0
+        throw new Error('Tracked Events table is empty')
+      @client.click('.reactive-table tbody tr:first-child')
+      @client.pause(1000)
+
+    @Given /^I can add an incident report with count "([^']*)"$/, (count) ->
+      elements = @client.elements('.reactive-table tbody')
+      if elements.value.length <= 0
+        throw new Error('Event Incidents table is empty')
+      @client.click('button.open-incident-form')
+      @client.pause(1000)
+      # article URL
+      @client.click('span[aria-labelledby="select2-articleSource-container"]')
+      @client.pause(1000)
+      @client.waitForVisible('#select2-articleSource-results')
+      @client.click('#select2-articleSource-results li:first-child')
+      # Location
+      @client.click('input[placeholder="Search for a location..."]')
+      @client.pause(1000)
+      @client.waitForVisible('#select2-incident-location-select2-results')
+      @client.click('#select2-incident-location-select2-results li:first-child')
+      # Status
+      @client.click('li[data-value="suspected"]')
+      # Type
+      @client.click('li[data-value="cases"]')
+      # Count
+      @client.waitForVisible('input[name="count"]')
+      @client.setValue('input[name="count"]', count)
+      # Submit
+      @client.click('button.save-modal[type="button"]')
+      @client.waitForExist('.toast-success')
+
+    @Given /^I can verify scatter plot group with count "([^']*)"$/, (count) ->
+      @client.pause(2000)
+      selector = "[id*=\":#{count}:false\"]"
+      groups = @client.elements(selector)
+      if groups.value.length != 1
+        throw new Error('ScatterPlot Group is empty')


### PR DESCRIPTION
Fixes "EIDR-C incident plot doesn't update when incident is added"

This would happen when a user added an incident outside the plot's current _domain filter.  The fix  was to keep track of when new groups are added during the merge operation so that the domain filter can be temporarily disabled.

Integration tests have been added.

https://www.pivotaltracker.com/story/show/135206307 


