### PR TITLE
Fix events header UI on small screens

### DIFF
--- a/client/views/events/userEvents.jade
+++ b/client/views/events/userEvents.jade
@@ -1,8 +1,8 @@
 template(name="userEvents")
   .user-events
-    .container-fluid-padded.page-heading.container-flex
+    .container-fluid-padded.page-heading.container-flex.no-break
       h1 Tracked Events
-      .page-options.container-flex
+      .page-options.container-flex.no-break.vertically-centered
         if isInRole "admin"
           button.btn.btn-primary(
             data-toggle="modal"

--- a/imports/stylesheets/ui.import.styl
+++ b/imports/stylesheets/ui.import.styl
@@ -76,6 +76,8 @@
     +above(2)
       margin-left 1em
       margin-bottom 0
+    +between(2,3)
+      margin-left 0
   .page-options--search
     min-width 300px
 
@@ -86,9 +88,18 @@
     flex-direction row
   +between(2,3)
     button
-      padding 0
+      padding .1em .5em
+      margin-right .25em
       border 0
       background none
       font-size 1.5em
+      &:hover
+      &:focus
+      &:focus:hover
+        background none
+        color $secondary-dark
       span
         display none
+      &.btn
+        .fa
+          margin 0


### PR DESCRIPTION
Fixes a small visual bug that was causing the elements in the events header (the "tracked events" heading, button, and search input) to break into incorrect positions.

[PT Bug](https://www.pivotaltracker.com/story/show/135662111)
