### PR TITLE
Fix start-test-server script to perform git fetch prior to checkout

### DIFF
--- a/start-test-server.sh
+++ b/start-test-server.sh
@@ -64,7 +64,7 @@ if [ $is_docker = "true" ]; then
   # copy settings-dev.json from the shared volume
   cp $shared_dir/settings-dev.json ${pwd}/settings-dev.json
   # checkout the correct branch
-  git checkout origin/$ghprbSourceBranch
+  git fetch && git checkout origin/$ghprbSourceBranch
   # perform npm install in case the branch added new dependencies
   npm install .
 else

--- a/tests/features/step_definitions/admin_steps.coffee
+++ b/tests/features/step_definitions/admin_steps.coffee
@@ -52,6 +52,7 @@ do ->
       expect(initialLen).not.toEqual(currentLen)
 
     @Given /^I can click on the create new event button$/, ->
+      @client.waitForVisible('button[data-target="#create-event-modal"]')
       @client.click('button[data-target="#create-event-modal"]')
 
     @Then /^I can(not)? create an event with name "([^']*)" and summary "([^']*)"$/, (negated, name, summary) ->


### PR DESCRIPTION
This PR fixes the issue with the git error `error: pathspec 'origin/some-branch-name' did not match any file(s) known to git.` 

Note: Since the container is started with the `command: ['bash', '-c', '/home/meteor/eidr-connect/start-test-server.sh --mongo_host=mongodb --is_docker=true']`, the script start-test-server.sh is already running, so if this file is modified by the branch, doing `git checkout origin/some-branch-name` will not take effect during the current jenkins job.

One workaround for this is to log into jenkins, start a containter for the image eidr-connect-test:latest, perform a `git fetch && git checkout origin/some-branch-name && git checkout -b some-branch-name`, exit the container and update the image through `docker commit`.  

Another alternative would be to alter the eidr-connect-test.yml file to start a the app with a command that sleeps indefinitely. This would be given PID 1 and run indefinitely. Then an intermediate build script could be launched by jenkins that does the git pull prior to running start-test-server.sh. The downside to this approach is that the docker container would not stop when the app server stops and has a potential to hang. However, when jenkins issues the `docker-compose ... down` command it will be forced-closed anyway and jenkins job can have a timeout.

I chose the prior method as its quicker and seems to adhere to docker best practices as a single PID/service for each container. In addition, the `start-test-server.sh` script shouldn't need modified all that frequently.

https://www.pivotaltracker.com/story/show/135716747