### PR TITLE
Add feature to display user status for curator inbox

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -51,3 +51,4 @@ dangrossman:bootstrap-daterangepicker
 stevezhu:lodash
 new3rs:html2canvas
 tmeasday:acceptance-test-driver
+mizzao:user-status

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -65,6 +65,8 @@ meteor-base@1.0.4
 minifier-js@1.2.14_1
 minifiers@1.1.7
 minimongo@1.0.17
+mizzao:timesync@0.3.4
+mizzao:user-status@0.6.6
 mobile-experience@1.0.4
 mobile-status-bar@1.0.12
 modules@0.7.7-beta.5

--- a/client/controllers/curatorInbox/curatorUserStatus.coffee
+++ b/client/controllers/curatorInbox/curatorUserStatus.coffee
@@ -1,0 +1,38 @@
+Template.curatorUserStatus.onCreated ->
+  @userStatusHandle = @subscribe('userStatus')
+  @autorun =>
+    Meteor.call 'updateCuratorUserStatus', @data.selectedSourceId.get(), (err, res) =>
+      if err
+        toastr.error(err.message)
+
+Template.curatorUserStatus.onDestroyed ->
+  Meteor.call 'updateCuratorUserStatus', null, (err, res) =>
+    if err
+      toastr.error(err.message)
+
+userCount = (sourceId) ->
+  Meteor.users.find({'status.online': true, 'status.curatorInboxSourceId': sourceId}).count() - 1
+
+Template.curatorUserStatus.helpers
+  hasOnlineUsers: () ->
+    hasOnlineUsers = false
+    count = 0
+    instance = Template.instance()
+    if instance.userStatusHandle.ready()
+      sourceId = instance.data.selectedSourceId.get()
+      count = userCount(sourceId)
+    if count > 0
+      hasOnlineUsers = true
+    hasOnlineUsers
+  usersOnlineCount: () ->
+    instance = Template.instance()
+    sourceId = instance.data.selectedSourceId.get()
+    userCount(sourceId)
+  usersOnlineMessage: () ->
+    instance = Template.instance()
+    sourceId = instance.data.selectedSourceId.get()
+    count = userCount(sourceId)
+    if count == 1
+      return "There is #{count} other user viewing this source"
+    if count > 1
+      return "There are #{count} other users viewing this source"

--- a/client/views/curatorInbox/curatorEvents.jade
+++ b/client/views/curatorInbox/curatorEvents.jade
@@ -2,6 +2,7 @@ template(name="curatorEvents")
   .associated-events.curator-events
     .curator-events-header
       h3 Associated Events
+      +curatorUserStatus selectedSourceId=selectedSourceId
       .curator-events--options
         button.btn.btn-default.btn-sm.btn-wide.add-new-event
           i.fa.fa-plus-circle
@@ -18,7 +19,6 @@ template(name="curatorEvents")
                   _id=_id)
     else
       p.no-events.muted-text Currently no associated events
-
 
   .suggested-events.curator-events
     +suggestedEvents selectedSourceId=selectedSourceId associatedEventIdsToArticles=associatedEventIdsToArticles
@@ -39,9 +39,7 @@ template(name="curatorEvents")
             i.fa.fa-lg.fa-chevron-circle-left
     if allEventsOpen
       +reactiveTable collection=userEvents settings=settings
-
   +editEventDetailsModal
-
 
 template(name="noAssociatedEvents")
   p.muted-text Currently no associated events

--- a/client/views/curatorInbox/curatorUserStatus.jade
+++ b/client/views/curatorInbox/curatorUserStatus.jade
@@ -1,0 +1,3 @@
+template(name="curatorUserStatus")
+  if hasOnlineUsers
+    span.badge(style="margin-left: 5px" title="#{usersOnlineMessage}") {{usersOnlineCount}}

--- a/methods/userStatus.coffee
+++ b/methods/userStatus.coffee
@@ -1,0 +1,9 @@
+
+Meteor.methods
+  updateCuratorUserStatus: (sourceId) ->
+    user = Meteor.user()
+    if user
+      Meteor.users.update(user, {$set : {'status.curatorInboxSourceId': sourceId}})
+      return true
+    else
+      return false

--- a/server/accounts.coffee
+++ b/server/accounts.coffee
@@ -2,17 +2,15 @@ Accounts.emailTemplates.siteName = "EIDR-Connect"
 Accounts.emailTemplates.from = "EIDR-C <no-reply@eha.io>"
 
 Meteor.startup ->
-  user = Meteor.users.findOne({'profile.name': 'Admin'})
-  if user
-    return
-  userData = Meteor.settings.private.initial_user
-  if userData
-    userData.profile = { name: 'Admin' }
-    console.log "[ Creating initial user with email #{userData.email} ]"
-    Accounts.createUser userData
-    newUserRecord = Meteor.users.findOne('emails.address': userData.email)
-    if newUserRecord
-      Roles.addUsersToRoles(newUserRecord._id, ['admin'])
-  else
-    console.warn '[ Meteor.settings.private.initial_user object \
-                        is required to create the initial user record ]'
+  unless Meteor.users.find().count()
+    userData = Meteor.settings.private.initial_user
+    if userData
+      userData.profile = { name: 'Admin' }
+      console.log "[ Creating initial user with email #{userData.email} ]"
+      Accounts.createUser userData
+      newUserRecord = Meteor.users.findOne('emails.address': userData.email)
+      if newUserRecord
+        Roles.addUsersToRoles(newUserRecord._id, ['admin'])
+    else
+      console.warn '[ Meteor.settings.private.initial_user object \
+                          is required to create the initial user record ]'

--- a/server/accounts.coffee
+++ b/server/accounts.coffee
@@ -2,15 +2,17 @@ Accounts.emailTemplates.siteName = "EIDR-Connect"
 Accounts.emailTemplates.from = "EIDR-C <no-reply@eha.io>"
 
 Meteor.startup ->
-  unless Meteor.users.find().count()
-    userData = Meteor.settings.private.initial_user
-    if userData
-      userData.profile = { name: 'Admin' }
-      console.log "[ Creating initial user with email #{userData.email} ]"
-      Accounts.createUser userData
-      newUserRecord = Meteor.users.findOne('emails.address': userData.email)
-      if newUserRecord
-        Roles.addUsersToRoles(newUserRecord._id, ['admin'])
-    else
-      console.warn '[ Meteor.settings.private.initial_user object \
-                          is required to create the initial user record ]'
+  user = Meteor.users.findOne({'profile.name': 'Admin'})
+  if user
+    return
+  userData = Meteor.settings.private.initial_user
+  if userData
+    userData.profile = { name: 'Admin' }
+    console.log "[ Creating initial user with email #{userData.email} ]"
+    Accounts.createUser userData
+    newUserRecord = Meteor.users.findOne('emails.address': userData.email)
+    if newUserRecord
+      Roles.addUsersToRoles(newUserRecord._id, ['admin'])
+  else
+    console.warn '[ Meteor.settings.private.initial_user object \
+                        is required to create the initial user record ]'

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -42,3 +42,7 @@ Meteor.publish 'articles', (query={}) ->
 
 Meteor.publish 'feeds', ->
   Feeds.find()
+
+# User status
+Meteor.publish 'userStatus', () ->
+  Meteor.users.find({'status.online': true }, {fields: {'status': 1 }})

--- a/server/startup.coffee
+++ b/server/startup.coffee
@@ -6,18 +6,6 @@ PromedPosts = require '/imports/collections/promedPosts.coffee'
 CuratorSources = require '/imports/collections/curatorSources'
 
 Meteor.startup ->
-  # update articles to include their title
-  noTitles = Articles.find({title: null}).fetch()
-  console.log "found " + noTitles.length + " articles without titles.  Attempting to set titles now."
-  for article in noTitles
-    promedId = /promedmail\.org\/post\/(\d+)$/ig.exec(article.url)?[1]
-    if promedId
-      article.title = PromedPosts.findOne({promedId: promedId}, {"subject.raw": 1}).subject.raw
-      Articles.update(article._id, $set: article)
-    else
-      console.log "non-ProMED Article:", article.url
-  console.log "Done setting titles."
-
   # set incident dates
   incidents = Incidents.find().fetch()
   for incident in incidents
@@ -27,33 +15,13 @@ Meteor.startup ->
       console.log error
       console.log JSON.stringify(incident, 0, 2)
 
-  for article in Articles.find().fetch()
-    promedId = /promedmail\.org\/post\/(\d+)$/ig.exec(article.url)?[1]
-    if promedId
-      post = PromedPosts.findOne(
-        promedId: promedId
-      )
-      if not post
-        console.log "Post has not been scraped yet. Post Id:", post
-        continue
-      article.publishDate = post.promedDate
-      # Aproximate DST for New York timezone
-      daylightSavings = moment.utc(
-        post.promedDate.getUTCFullYear() + "-03-08") <= post.promedDate
-      daylightSavings = daylightSavings and moment.utc(
-        post.promedDate.getUTCFullYear() + "-11-01") >= post.promedDate
-      article.publishDateTZ = if daylightSavings then "EDT" else "EST"
-      Articles.update(article._id, $set: article)
-      try
-        articleSchema.validate(article)
-      catch error
-        console.log error
-        console.log JSON.stringify(article, 0, 2)
-    else
-      console.log "non-ProMED Article:", article.url
-
   CuratorSources.update
     reviewed:
       $exists: false
     {$set: reviewed: false}
     {multi: true}
+
+  # Clean-up curatorInboxSourceId when user goes offline
+  Meteor.users.find({'status.online': true}).observe
+    removed: (user) ->
+      Meteor.users.update(user._id, {$set : {'status.curatorInboxSourceId': null}})


### PR DESCRIPTION
This PR adds the meteor package `mizzao:user-status` to keep track of which users are online.  It adds a property to the user document called 'status'.  The client then runs reactive queries against users whose status.online == true and curatorInboxSourceId == the current selectedSourceId.

The result of the queries is a count.  If the count is greater than 1 (accounting for their own status), then a bootstrap badge is displayed with the number of online users within the header of the `Associated Events`.

When the template isRemoved, the meteor method that sets curatorInboxSourceId is called again with null, to update that the user is no longer active on that curator source. 

The server also guards against users who loose connectivity and go offline by performing a server-side observe of status.online and setting curatorInboxSourceId = null for any user who goes offline.

![image](https://cloud.githubusercontent.com/assets/12954045/21021892/8949d0c8-bd48-11e6-85e8-94d675b56f4b.png)

To test:

Open two Chrome incognito browsers and login with separate accounts then navigate to curator inbox and experiment selecting sources with both browser windows open.

https://www.pivotaltracker.com/story/show/134787043