### PR TITLE
Clear searches

### DIFF
--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -8,7 +8,6 @@ Template.articles.onCreated ->
   @selectedSourceId = new ReactiveVar null
 
 Template.articles.onRendered ->
-  @$('#sourceFilter input').attr 'placeholder', 'Search sources'
   instance = @
   @autorun ->
     instance.selectedSourceId.get()
@@ -19,44 +18,44 @@ Template.articles.helpers
   getSettings: ->
     fields = [
       {
-        key: "title"
-        label: "Title"
+        key: 'title'
+        label: 'Title'
         fn: (value, object, key) ->
           # switching over to displaying the title in this column.  If that's not loaded in the DB show the URL.
           return object.title || value
       },
       {
-        key: "addedDate"
-        label: "Added"
+        key: 'addedDate'
+        label: 'Added'
         fn: (value, object, key) ->
           return moment(value).fromNow()
         sortFn: (value) ->
           value
       },
       {
-        key: "publishDate"
-        label: "Publication Date"
+        key: 'publishDate'
+        label: 'Publication Date'
         fn: (value, object, key) ->
           if value
             return moment(value).format('MMM D, YYYY')
-          return ""
+          return ''
         sortFn: (value) ->
           value
       }
     ]
 
     fields.push
-      key: "expand"
-      label: ""
-      cellClass: "action open-right"
+      key: 'expand'
+      label: ''
+      cellClass: 'action open-right'
 
     id: 'event-sources-table'
     fields: fields
     showFilter: false
     showNavigationRowsPerPage: false
     showRowCount: false
-    class: "table event-sources"
-    filters: ["sourceFilter"]
+    class: 'table event-sources'
+    filters: ['sourceFilter']
 
   selectedSource: ->
     selectedId = Template.instance().selectedSourceId.get()
@@ -64,18 +63,29 @@ Template.articles.helpers
       Articles.findOne selectedId
 
   incidentsForSource: (sourceUrl) ->
-    Incidents.find({userEventId: Template.instance().data.userEvent._id, url: sourceUrl}).fetch()
+    Incidents.find
+      userEventId: Template.instance().data.userEvent._id
+      url: sourceUrl
 
   locationsForSource: (sourceUrl) ->
     locations = {}
-    incidents = Incidents.find({userEventId: Template.instance().data.userEvent._id, url: sourceUrl}).forEach( (incident) ->
-      for location in incident.locations
-        locations[location.id] = location.name
-    )
+    Incidents
+      .find
+        userEventId: Template.instance().data.userEvent._id
+        url: sourceUrl
+      .forEach (incident) ->
+        for location in incident.locations
+          locations[location.id] = location.name
     _.flatten locations
 
   formatUrl: (url) ->
     formatUrl(url)
+
+  searchSettings: ->
+    id: 'sourceFilter'
+    placeholder: 'Search sources'
+    toggleable: true
+    props: ['title']
 
 Template.articles.events
   'click #event-sources-table tbody tr': (event, instance) ->

--- a/client/controllers/curatorInbox/curatorEvents.coffee
+++ b/client/controllers/curatorInbox/curatorEvents.coffee
@@ -7,10 +7,9 @@ Template.curatorEvents.onCreated ->
   instance = @
   @suggestedEventsHeaderState = new ReactiveVar true
   @autorun =>
-    instance.subscribe("articles", {
+    instance.subscribe "articles",
       url:
         $regex: "post\/" + CuratorSources.findOne(@data.selectedSourceId.get())._sourceId + "$"
-    })
     instance.associatedEventIdsToArticles = new ReactiveVar {}
 
   @autorun =>
@@ -20,9 +19,6 @@ Template.curatorEvents.onCreated ->
     ).map((article)->
       [article.userEventId, article]
     ))
-
-Template.curatorEvents.onRendered ->
-  @$('#curatorEventsFilter input').attr 'placeholder', 'Search events'
 
 Template.curatorEvents.helpers
   userEvents: ->
@@ -74,6 +70,13 @@ Template.curatorEvents.helpers
 
   allEventsOpen: ->
     Template.instance().suggestedEventsHeaderState.get()
+
+  searchSettings: ->
+    id: 'curatorEventsFilter'
+    textFilter: Template.instance().textFilter
+    placeholder: 'Search Events'
+    searching: new ReactiveVar false
+    toggleable: true
 
 Template.curatorEvents.events
   'click .curator-events-table .curator-events-table-row': (event, instance) ->

--- a/client/controllers/curatorInbox/curatorInbox.coffee
+++ b/client/controllers/curatorInbox/curatorInbox.coffee
@@ -96,29 +96,32 @@ Template.curatorInbox.helpers
   query: ->
     Template.instance().query
 
-  searching: ->
+  searchString: ->
+    Template.instance().textFilter.get().$regex
+
+  searchWaiting: ->
     Template.instance().searching.get()
 
 Template.curatorInbox.events
-  "keyup #curator-inbox-article-filter, input #curator-inbox-article-filter": (event, template) ->
-    template.textFilter.set
-      $regex: $(event.target).val()
+  'keyup #curator-inbox-article-filter, input #curator-inbox-article-filter': (event, instance) ->
+    instance.textFilter.set
+      $regex: instance.$(event.target).val()
       $options: 'i'
 
-  "click .curator-filter-reviewed-icon": (event, template) ->
-    reviewFilter = template.reviewFilter
+  'click .curator-filter-reviewed-icon': (event, instance) ->
+    reviewFilter = instance.reviewFilter
     if reviewFilter.get()
       reviewFilter.set null
     else
       reviewFilter.set $ne: true
     $(event.currentTarget).tooltip 'destroy'
 
-  "click .curator-filter-calendar-icon": (event, template) ->
-    calendarState = template.calendarState
+  'click .curator-filter-calendar-icon': (event, instance) ->
+    calendarState = instance.calendarState
     calendarState.set not calendarState.get()
     $(event.currentTarget).tooltip 'destroy'
 
-  "click #calendar-btn-apply": (event, template) ->
+  'click #calendar-btn-apply': (event, instance) ->
     range = null
     startDate = $('#date-picker').data('daterangepicker').startDate
     endDate = $('#date-picker').data('daterangepicker').endDate
@@ -127,34 +130,41 @@ Template.curatorInbox.events
       endDate = moment(startDate).set({hour: 23, minute: 59, second: 59, millisecond: 999})
 
     if startDate and endDate
-      template.calendarState.set(false)
-      template.ready.set(false)
-      range = {
+      instance.calendarState.set(false)
+      instance.ready.set(false)
+      range =
         startDate: startDate.toDate()
         endDate: endDate.toDate()
-      }
-      template.dateRange.set range
+      instance.dateRange.set range
 
-  "click #calendar-btn-reset": (event, template) ->
-    template.calendarState.set(false)
-    template.ready.set(false)
-
+  'click #calendar-btn-reset': (event, instance) ->
+    instance.calendarState.set(false)
+    instance.ready.set(false)
     createNewCalendar()
-
-    template.dateRange.set
+    instance.dateRange.set
       startDate: moment().subtract(1, 'weeks').toDate()
       endDate: new Date()
 
-  "click #calendar-btn-cancel": (event, template) ->
-    template.calendarState.set(false)
+  'click #calendar-btn-cancel': (event, instance) ->
+    instance.calendarState.set(false)
 
-  'click .search-icon': (event, instance) ->
+  'click .search-icon:not(.cancel)': (event, instance) ->
     searching = instance.searching
     searching.set not searching.get()
     setTimeout ->
       $('#curator-inbox-article-filter').focus()
     , 200
     $(event.currentTarget).tooltip 'destroy'
+
+  'click .cancel, keyup #curator-inbox-article-filter': (event, instance) ->
+    isKeyup = event.type is 'keyup'
+    $target = instance.$(event.target)
+    return if isKeyup and event.keyCode isnt 27
+    instance.textFilter.set('')
+    if isKeyup
+      $target.val('')
+    else
+      $target.prev().val('')
 
 Template.curatorInboxSection.onCreated ->
   @selectedSourceId = new ReactiveVar null
@@ -272,8 +282,8 @@ Template.curatorInboxSection.helpers
         'selected'
 
 Template.curatorInboxSection.events
-  'click .curator-inbox-table tbody tr': (event, template) ->
-    template.data.selectedSourceId.set @_id
+  'click .curator-inbox-table tbody tr': (event, instance) ->
+    instance.data.selectedSourceId.set @_id
 
-  'click .curator-inbox-section-head': (event, template) ->
-    template.isOpen.set(!template.isOpen.curValue)
+  'click .curator-inbox-section-head': (event, instance) ->
+    instance.isOpen.set(!instance.isOpen.curValue)

--- a/client/controllers/curatorInbox/curatorInbox.coffee
+++ b/client/controllers/curatorInbox/curatorInbox.coffee
@@ -27,7 +27,6 @@ Template.curatorInbox.onCreated ->
   @reviewFilter.set({$ne: true})
   @selectedSourceId = new ReactiveVar null
   @query = new ReactiveVar null
-  @searching = new ReactiveVar false
 
   @autorun =>
     range = @dateRange.get()
@@ -96,11 +95,14 @@ Template.curatorInbox.helpers
   query: ->
     Template.instance().query
 
-  searching: ->
-    Template.instance().searching
+  searchSettings: ->
+    id:"inboxFilter"
+    textFilter: Template.instance().textFilter
+    classes: 'option'
+    placeholder: 'Search inbox'
+    toggleable: true
 
 Template.curatorInbox.events
-
   'click .curator-filter-reviewed-icon': (event, instance) ->
     reviewFilter = instance.reviewFilter
     if reviewFilter.get()

--- a/client/controllers/curatorInbox/curatorInbox.coffee
+++ b/client/controllers/curatorInbox/curatorInbox.coffee
@@ -96,17 +96,10 @@ Template.curatorInbox.helpers
   query: ->
     Template.instance().query
 
-  searchString: ->
-    Template.instance().textFilter.get().$regex
-
-  searchWaiting: ->
-    Template.instance().searching.get()
+  searching: ->
+    Template.instance().searching
 
 Template.curatorInbox.events
-  'keyup #curator-inbox-article-filter, input #curator-inbox-article-filter': (event, instance) ->
-    instance.textFilter.set
-      $regex: instance.$(event.target).val()
-      $options: 'i'
 
   'click .curator-filter-reviewed-icon': (event, instance) ->
     reviewFilter = instance.reviewFilter
@@ -147,24 +140,6 @@ Template.curatorInbox.events
 
   'click #calendar-btn-cancel': (event, instance) ->
     instance.calendarState.set(false)
-
-  'click .search-icon:not(.cancel)': (event, instance) ->
-    searching = instance.searching
-    searching.set not searching.get()
-    setTimeout ->
-      $('#curator-inbox-article-filter').focus()
-    , 200
-    $(event.currentTarget).tooltip 'destroy'
-
-  'click .cancel, keyup #curator-inbox-article-filter': (event, instance) ->
-    isKeyup = event.type is 'keyup'
-    $target = instance.$(event.target)
-    return if isKeyup and event.keyCode isnt 27
-    instance.textFilter.set('')
-    if isKeyup
-      $target.val('')
-    else
-      $target.prev().val('')
 
 Template.curatorInboxSection.onCreated ->
   @selectedSourceId = new ReactiveVar null

--- a/client/controllers/events/locationList.coffee
+++ b/client/controllers/events/locationList.coffee
@@ -1,8 +1,5 @@
 formatLocation = require '/imports/formatLocation.coffee'
 
-Template.locationList.onRendered ->
-  @$('#locationFilter input').attr 'placeholder', 'Search locations'
-
 Template.locationList.helpers
   incidentLocations: ->
     locations = {}
@@ -55,6 +52,12 @@ Template.locationList.helpers
     class: 'table'
     filters: ['locationFilter']
 
+  searchSettings: ->
+    id: 'locationFilter'
+    class: 'table-filter'
+    placeholder: 'Search locations'
+    toggleable: true
+    props: ['name']
 
 Template.locationList.events
   'keyup .reactive-table-input': (event, template) ->

--- a/client/controllers/events/userEvents.coffee
+++ b/client/controllers/events/userEvents.coffee
@@ -73,9 +73,6 @@ Template.userEvents.onCreated ->
       Session.set 'events-field-sort-order-' + field.fieldName, @sortOrder[field.fieldName].get()
       Session.set 'events-field-sort-direction-' + field.fieldName, @sortDirection[field.fieldName].get()
 
-Template.userEvents.onRendered ->
-  @$('#eventFilter input').attr 'placeholder', 'Search events'
-
 Template.userEvents.helpers
   settings: ->
     fields = []
@@ -102,6 +99,16 @@ Template.userEvents.helpers
     showFilter: false
     class: 'table featured'
     filters: ['eventFilter']
+
+  textFilter: ->
+    Template.instance().textFilter
+
+  searchSettings: ->
+    id:"eventFilter"
+    classes: 'event-search page-options--search'
+    textFilter: Template.instance().textFilter
+    placeholder: 'Search Events'
+    props: ['eventName']
 
 Template.userEvents.events
   "click .reactive-table tbody tr": (event) ->

--- a/client/controllers/maps/mapFilters.coffee
+++ b/client/controllers/maps/mapFilters.coffee
@@ -36,13 +36,17 @@ Template.mapFilters.onRendered ->
         varQuery._id = {$in: eventIds}
         filters.push(varQuery)
 
-    userSearchText = Template.instance().userSearchText.get()
-    nameQuery = []
-    searchWords = userSearchText.split(' ')
-    _.each searchWords, -> nameQuery.push {eventName: new RegExp(userSearchText, 'i')}
-    filters.push $or: nameQuery
+    userSearchText = instance.userSearchText.get().$regex
+    if userSearchText
+      nameQuery = []
+      searchWords = userSearchText.split(' ')
+      _.each searchWords, -> nameQuery.push {eventName: new RegExp(userSearchText, 'i')}
+      filters.push $or: nameQuery
 
-    Template.instance().data.query.set({ $and: filters })
+    if filters.length
+      instance.data.query.set({ $and: filters })
+    else
+      instance.data.query.set({})
 
 Template.mapFilters.helpers
   dateVariables: ->
@@ -75,19 +79,15 @@ Template.mapFilters.helpers
   calendarState: ->
     Template.instance().calendarState.get()
 
+  searchSettings: ->
+    id: 'mapFilters'
+    textFilter: Template.instance().userSearchText
+    placeholder: 'Search events'
+
 Template.mapFilters.events
   'cancel.daterangepicker': (e, instance) ->
     $(e.target).val("")
     setVariables instance, 'on', []
-
-  'input .map-search': _.debounce (e, templateInstance) ->
-    e.preventDefault()
-    text = $(e.target).val()
-    templateInstance.userSearchText.set(text)
-
-  'click .clear-search': (e, instance) ->
-    instance.$('.map-search').val('')
-    Template.instance().userSearchText.set('')
 
   'click .map-event-list--item': (e, instance) ->
     selectedEvents = instance.data.selectedEvents

--- a/client/controllers/searchInput.coffee
+++ b/client/controllers/searchInput.coffee
@@ -1,0 +1,35 @@
+clearSearch = (instance) ->
+  instance.textFilter.set('')
+  instance.$('.search').val('')
+
+Template.searchInput.onCreated ->
+  @searching = @data.searching
+  @textFilter = @data.textFilter
+
+Template.searchInput.helpers
+  searchString: ->
+    Template.instance().textFilter.get().$regex
+
+  searchWaiting: ->
+    Template.instance().searching.get()
+
+Template.searchInput.events
+  'keyup .search, input .search': (event, instance) ->
+    if event.type is 'keyup' and event.keyCode is 27
+      clearSearch(instance)
+    else
+      instance.textFilter.set
+        $regex: instance.$(event.target).val()
+        $options: 'i'
+
+  'click .search-icon:not(.cancel)': (event, instance) ->
+    searching = instance.searching
+    searching.set not searching.get()
+    setTimeout ->
+      $('#curator-inbox-article-filter').focus()
+    , 200
+    $(event.currentTarget).tooltip 'destroy'
+
+  'click .cancel, keyup #curator-inbox-article-filter': (event, instance) ->
+    return if event.type is 'keyup' and event.keyCode isnt 27
+    clearSearch()

--- a/client/views/articles.jade
+++ b/client/views/articles.jade
@@ -8,10 +8,7 @@ template(name="articles")
           .flex-col
             +sourceModalButton
           .flex-col
-            +reactiveTableFilter(
-              id="sourceFilter"
-              label=" "
-              class="table-filter with-icon no-addon")
+            +searchInput searchSettings
         +reactiveTable collection=articles settings=getSettings
 
       else

--- a/client/views/curatorInbox/curatorEvents.jade
+++ b/client/views/curatorInbox/curatorEvents.jade
@@ -28,10 +28,8 @@ template(name="curatorEvents")
       h4 All Events
       .curator-events--options
         .filter-wrapper(class="{{#unless allEventsOpen }} subtle {{/unless}}")
-          +reactiveTableFilter(
-            id="curatorEventsFilter"
-            label=" "
-            class="with-icon no-addon")
+          +searchInput searchSettings
+
         .curator-events-collapse
           if allEventsOpen
             i.fa.fa-lg.fa-chevron-circle-down

--- a/client/views/curatorInbox/curatorInbox.jade
+++ b/client/views/curatorInbox/curatorInbox.jade
@@ -13,11 +13,12 @@ template(name="curatorInbox")
           data-toggle="tooltip"
           title="Filter by Date Range")
           i.fa.fa-calendar
-        .option.input-wrapper(class="{{#unless searching}} stagged {{/unless}}")
+        .option.input-wrapper(class="{{#unless searchWaiting}} stagged {{/unless}}")
           input#curator-inbox-article-filter.form-control.icon-right(type="text" placeholder="Search inbox")
           i.fa.fa-search.search-icon.right(
             data-toggle="tooltip"
-            title="Search")
+            title="Search"
+            class="{{#if searchString}} cancel {{/if}}")
     .curator-inbox-sources.pane.pane-l.curator-inbox--pane
       .curator-inbox-datepicker(class="{{#if calendarState}} active {{/if}}")
         .text-center

--- a/client/views/curatorInbox/curatorInbox.jade
+++ b/client/views/curatorInbox/curatorInbox.jade
@@ -13,7 +13,8 @@ template(name="curatorInbox")
           data-toggle="tooltip"
           title="Filter by Date Range")
           i.fa.fa-calendar
-        +searchInput textFilter=textFilter searching=searching
+        +searchInput searchSettings
+
     .curator-inbox-sources.pane.pane-l.curator-inbox--pane
       .curator-inbox-datepicker(class="{{#if calendarState}} active {{/if}}")
         .text-center

--- a/client/views/curatorInbox/curatorInbox.jade
+++ b/client/views/curatorInbox/curatorInbox.jade
@@ -13,12 +13,7 @@ template(name="curatorInbox")
           data-toggle="tooltip"
           title="Filter by Date Range")
           i.fa.fa-calendar
-        .option.input-wrapper(class="{{#unless searchWaiting}} stagged {{/unless}}")
-          input#curator-inbox-article-filter.form-control.icon-right(type="text" placeholder="Search inbox")
-          i.fa.fa-search.search-icon.right(
-            data-toggle="tooltip"
-            title="Search"
-            class="{{#if searchString}} cancel {{/if}}")
+        +searchInput textFilter=textFilter searching=searching
     .curator-inbox-sources.pane.pane-l.curator-inbox--pane
       .curator-inbox-datepicker(class="{{#if calendarState}} active {{/if}}")
         .text-center

--- a/client/views/events/locationList.jade
+++ b/client/views/events/locationList.jade
@@ -3,10 +3,7 @@ template(name="locationList")
     .flex-col.bordered
       if incidentLocations.length
         .tab-form
-          +reactiveTableFilter(
-            id="locationFilter"
-            label=" "
-            class="table-filter with-icon no-addon")
+          +searchInput searchSettings
         +reactiveTable collection=incidentLocations settings=getSettings
       else
         p No locations are associated with this event.

--- a/client/views/events/userEvents.jade
+++ b/client/views/events/userEvents.jade
@@ -9,10 +9,7 @@ template(name="userEvents")
             data-target="#create-event-modal")
             i.fa.fa-plus-circle
             span Create New Event
-        +reactiveTableFilter(
-          id="eventFilter"
-          label=" "
-          class="event-search with-icon no-addon page-options--search")
+        +searchInput searchSettings
 
     .featured-table
       .loading

--- a/client/views/maps/mapFilters.jade
+++ b/client/views/maps/mapFilters.jade
@@ -2,9 +2,7 @@ template(name="mapFilters")
   .map-menu
     .search-wrap
       i.fa.fa-calendar.toggle-calendar-state(class="{{#if calendarState}} showing {{/if}}")
-      .map-search
-        i.fa.fa-search
-        input.form-control(type="text" placeholder="Search events")
+      +searchInput searchSettings
     if calendarState
       +dateSelector(dateVariables=dateVariables filtering=filtering)
     ul.map-event-list.list-group

--- a/client/views/searchInput.jade
+++ b/client/views/searchInput.jade
@@ -1,8 +1,12 @@
 template(name="searchInput")
-  .option.input-wrapper(class="{{#unless searchWaiting}} stagged {{/unless}}")
+  .search-wrapper.input-wrapper(
+    id=id
+    class="{{#unless searchWaiting}} stagged {{/unless}} {{classes}}")
     input.search.form-control.icon-right(
-      type="text" placeholder="Search inbox")
+      type="text"
+      placeholder=placeholder)
     i.fa.fa-search.search-icon.right(
-      data-toggle="tooltip"
-      title="Search"
-      class="{{#if searchString}} cancel {{/if}}")
+      data-toggle="{{#if toggleable}} tooltip {{/if}}"
+      data-placement="left"
+      title="{{#if toggleable}} Search {{/if}}"
+      class="{{#if searchString}} cancel {{/if}} {{#if toggleable}} toggleable {{/if}}")

--- a/client/views/searchInput.jade
+++ b/client/views/searchInput.jade
@@ -1,0 +1,8 @@
+template(name="searchInput")
+  .option.input-wrapper(class="{{#unless searchWaiting}} stagged {{/unless}}")
+    input.search.form-control.icon-right(
+      type="text" placeholder="Search inbox")
+    i.fa.fa-search.search-icon.right(
+      data-toggle="tooltip"
+      title="Search"
+      class="{{#if searchString}} cancel {{/if}}")

--- a/imports/stylesheets/curator.import.styl
+++ b/imports/stylesheets/curator.import.styl
@@ -73,9 +73,10 @@ $header-BG = $border-primary-light
       display flex
       align-items center
       font-size 1.2em
-      cursor pointer
       transition .1s ease-in-out
-      color $m-gray
+      &.cancel
+        &::before
+          content '\f057'
     input
       transition .3s
       opacity 1

--- a/imports/stylesheets/curator.import.styl
+++ b/imports/stylesheets/curator.import.styl
@@ -64,43 +64,8 @@ $header-BG = $border-primary-light
     align-self stretch
     &:last-child
       margin 0
-  .input-wrapper
-    align-self center
-    transition .3s
-    width 260px
-    transform translate(0,0)
-    .search-icon
-      display flex
-      align-items center
-      font-size 1.2em
-      transition .1s ease-in-out
-      &.cancel
-        &::before
-          content '\f057'
-    input
-      transition .3s
-      opacity 1
-      border-radius 3px
-      border 1px solid $border-primary
-      &:focus
-        border-color $primary
-    &.stagged
-      width 35px
-      input
-        visibility hidden
-        opacity 0
-      .search-icon
-        font-size 1.75em
-        color $primary
-        &:hover
-          color lighten(@color, 50%)
   input
-    box-shadow none
     min-width 250px
-    border 0
-    &:focus
-      box-shadow none
-      outline 0
   a
     color $primary
     font-size 1.75em
@@ -444,6 +409,9 @@ $header-BG = $border-primary-light
   min-width 50%
   button
     font-size .85em
+  .search-wrapper.stagged
+    .search-icon
+      font-size 1.5em
 
 .curator-events-collapse
   color $primary

--- a/imports/stylesheets/events/event.import.styl
+++ b/imports/stylesheets/events/event.import.styl
@@ -189,7 +189,6 @@ $max-event-details-width = $max-ui-width+300
       width auto
   input
   .btn
-    margin-bottom 1em
     min-width 100%
     display block
     +above(2)

--- a/imports/stylesheets/forms/forms.import.styl
+++ b/imports/stylesheets/forms/forms.import.styl
@@ -22,33 +22,3 @@ input
     margin-bottom .5em
     text-transform capitalize
     color $primary
-
-.search-icon
-  position absolute
-  top 50%
-  transform translate(0, -50%)
-  color $border-primary
-  cursor pointer
-  &.right
-    right 10px
-    left auto
-  &.cancel
-    color lighten($delete, 10%)
-
-.with-icon
-  position relative
-  &::after
-    content '\f002'
-    position absolute
-    right 1em
-    top 50%
-    padding-left .2em
-    transform translate(0, -50%)
-    z-index 10
-    font-family FontAwesome
-    color $m-gray
-    cursor default
-
-.no-addon
-  .input-group-addon
-    display none

--- a/imports/stylesheets/forms/forms.import.styl
+++ b/imports/stylesheets/forms/forms.import.styl
@@ -28,9 +28,12 @@ input
   top 50%
   transform translate(0, -50%)
   color $border-primary
+  cursor pointer
   &.right
     right 10px
     left auto
+  &.cancel
+    color lighten($delete, 10%)
 
 .with-icon
   position relative

--- a/imports/stylesheets/index.styl
+++ b/imports/stylesheets/index.styl
@@ -28,6 +28,7 @@
 @import 'loading.import'
 @import 'download.import'
 @import 'forms/index.import'
+@import 'searchInput.import'
 
 // Pages or unique areas
 @import 'navTabs.import.styl'

--- a/imports/stylesheets/searchInput.import.styl
+++ b/imports/stylesheets/searchInput.import.styl
@@ -1,0 +1,51 @@
+.search-icon
+  position absolute
+  top 50%
+  transform translate(0, -50%)
+  color $border-primary
+  cursor default
+  &.toggleable
+    cursor pointer
+  &.right
+    right 10px
+    left auto
+  &.cancel
+    color lighten($delete, 10%)
+    font-size 1.25em
+    transition font-size .1s ease-in-out
+    cursor pointer
+    &::before
+      content '\f057'
+    &:hover
+      color $delete
+      font-size 1.45em
+    &:active
+      color $secondary-dark
+
+.search-wrapper
+  align-self center
+  transition .3s
+  width 260px
+  transform translate(0,0)
+  margin-left auto
+  .search-icon
+    display flex
+    align-items center
+    transition .1s ease-in-out
+  input
+    transition .3s
+    opacity 1
+    border-radius 3px
+    border 1px solid $border-primary
+    &:focus
+      border-color $primary
+  &.stagged
+    width 35px
+    input
+      visibility hidden
+      opacity 0
+    .search-icon
+      font-size 1.75em
+      color $primary
+      &:hover
+        color lighten(@color, 50%)


### PR DESCRIPTION
I went ahead and created a single template for all the search inputs. I figured it would reduce a fair amount of repetition with clearing inputs and force us into a consistent search UI/UX.

The template receives an object with options including:
- `textFilter`: either a `reactiveVar` or `ReactiveTableFilter`
- `id` the id associated with the element and `ReactiveTableFilter` if its passed
- `props` if a `ReactiveTableFilter` is not passed, one will be created with the `id` and `props` which is an array
- `toggleable`If set to true, the input will be initially hidden and appear when the search icon is clicked. When the user clicks on the search icon within the input, the input returns to its hidden state.
- `placeholder` defaults to 'Search'
- `classes` classes which will be applied to the input's parent element

