### PR TITLE
add feature to confirm closing suggestedIncidentsModal

### DIFF
--- a/client/controllers/cancelConfirmation/cancelConfirmationModal.coffee
+++ b/client/controllers/cancelConfirmation/cancelConfirmationModal.coffee
@@ -1,0 +1,3 @@
+Template.cancelConfirmationModal.helpers
+  data: ->
+    Template.instance().data

--- a/client/controllers/cancelConfirmation/cancelConfirmationModalBody.coffee
+++ b/client/controllers/cancelConfirmation/cancelConfirmationModalBody.coffee
@@ -1,4 +1,5 @@
 Template.cancelConfirmationModalBody.events
   'click .confirm': (event, instance) ->
+    instance.data.hasBeenWarned.set(true)
     instance.data.modalsToCancel.forEach (id) ->
       $("##{id}").modal('hide')

--- a/client/controllers/cancelConfirmation/cancelConfirmationModalBody.coffee
+++ b/client/controllers/cancelConfirmation/cancelConfirmationModalBody.coffee
@@ -1,0 +1,4 @@
+Template.cancelConfirmationModalBody.events
+  'click .confirm': (event, instance) ->
+    instance.data.modalsToCancel.forEach (id) ->
+      $("##{id}").modal('hide')

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -229,6 +229,16 @@ Template.suggestedIncidentsModal.helpers
     new Spacebars.SafeString(html)
 
 Template.suggestedIncidentsModal.events
+  "click .confirm-close-modal": (event, instance) ->
+    total = instance.incidentCollection.find().count()
+    count = instance.incidentCollection.find(accepted: true).count();
+    if count > 0
+      Modal.show 'cancelConfirmationModal',
+        modalsToCancel: ['suggestedIncidentsModal', 'cancelConfirmationModal']
+        displayName: "Abandon #{count} of #{total} incidents accepted?"
+    else
+      $('#suggestedIncidentsModal').modal('hide')
+
   "click .annotation": (event, instance) ->
     incident = instance.incidentCollection.findOne($(event.target).data("incident-id"))
     content = Template.instance().content.get()

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -60,8 +60,23 @@ parseSents = (text)->
       idx++
   return sents
 
+# determines if the user should be prompted before leaving the current modal
+#
+# @param {object} event, the DOM event
+# @param {object} instance, the template instance
+confirmAbandonChanges = (event, instance) ->
+  total = instance.incidentCollection.find().count()
+  count = instance.incidentCollection.find(accepted: true).count();
+  if count > 0 && instance.hasBeenWarned.get() == false
+    event.preventDefault()
+    Modal.show 'cancelConfirmationModal',
+      modalsToCancel: ['suggestedIncidentsModal', 'cancelConfirmationModal']
+      displayName: "Abandon #{count} of #{total} incidents accepted?"
+      hasBeenWarned: instance.hasBeenWarned
+
 Template.suggestedIncidentsModal.onCreated ->
   @incidentCollection = new Meteor.Collection(null)
+  @hasBeenWarned = new ReactiveVar(false)
   @loading = new ReactiveVar(true)
   @content = new ReactiveVar("")
   Meteor.call("getArticleEnhancements", @data.article, (error, result) =>
@@ -198,6 +213,7 @@ Template.suggestedIncidentsModal.onCreated ->
       )
     )
   )
+
 Template.suggestedIncidentsModal.helpers
   incidents: ->
     Template.instance().incidentCollection.find()
@@ -229,15 +245,8 @@ Template.suggestedIncidentsModal.helpers
     new Spacebars.SafeString(html)
 
 Template.suggestedIncidentsModal.events
-  "click .confirm-close-modal": (event, instance) ->
-    total = instance.incidentCollection.find().count()
-    count = instance.incidentCollection.find(accepted: true).count();
-    if count > 0
-      Modal.show 'cancelConfirmationModal',
-        modalsToCancel: ['suggestedIncidentsModal', 'cancelConfirmationModal']
-        displayName: "Abandon #{count} of #{total} incidents accepted?"
-    else
-      $('#suggestedIncidentsModal').modal('hide')
+  'hide.bs.modal #suggestedIncidentsModal': (event, instance) ->
+    confirmAbandonChanges(event, instance)
 
   "click .annotation": (event, instance) ->
     incident = instance.incidentCollection.findOne($(event.target).data("incident-id"))

--- a/client/views/cancelConfirmation/cancelConfirmationModal.jade
+++ b/client/views/cancelConfirmation/cancelConfirmationModal.jade
@@ -1,8 +1,8 @@
 template(name="cancelConfirmationModal")
-  .modal.fade#cancelConfirmationModal(role="dialog" data-keyboard="false" data-backdrop="static")
+  .modal.fade#cancelConfirmationModal(role="dialog")
     .modal-dialog
       .modal-content
-        form#delete-obj
+        form
           .close-modal(data-dismiss="modal" aria-label="Close")
           .modal-header
             h4.modal-title Confirm Cancel

--- a/client/views/cancelConfirmation/cancelConfirmationModal.jade
+++ b/client/views/cancelConfirmation/cancelConfirmationModal.jade
@@ -1,0 +1,10 @@
+template(name="cancelConfirmationModal")
+  .modal.fade#cancelConfirmationModal(role="dialog")
+    .modal-dialog
+      .modal-content
+        form#delete-obj
+          .close-modal(data-dismiss="modal" aria-label="Close")
+          .modal-header
+            h4.modal-title Confirm Cancel
+          .modal-body.clearfix
+            +cancelConfirmationModalBody data

--- a/client/views/cancelConfirmation/cancelConfirmationModal.jade
+++ b/client/views/cancelConfirmation/cancelConfirmationModal.jade
@@ -1,5 +1,5 @@
 template(name="cancelConfirmationModal")
-  .modal.fade#cancelConfirmationModal(role="dialog")
+  .modal.fade#cancelConfirmationModal(role="dialog" data-keyboard="false" data-backdrop="static")
     .modal-dialog
       .modal-content
         form#delete-obj

--- a/client/views/cancelConfirmation/cancelConfirmationModalBody.jade
+++ b/client/views/cancelConfirmation/cancelConfirmationModalBody.jade
@@ -1,9 +1,9 @@
 template(name="cancelConfirmationModalBody")
-  .delete-confirmation
-    i.fa.fa-trash-o
+  .cancel-confirmation
+    i.fa.fa-exclamation-triangle
     p Are you sure you want to abandon your changes?
     p=displayName
     .main-action
-      button.btn.btn-danger.btn-wide.confirm(type="button") Abandon
+      button.btn.btn-warning.btn-wide.confirm(type="button") Abandon
     .other-actions
       button.btn.btn-default.btn-sm(type="button" data-dismiss="modal") Cancel

--- a/client/views/cancelConfirmation/cancelConfirmationModalBody.jade
+++ b/client/views/cancelConfirmation/cancelConfirmationModalBody.jade
@@ -1,0 +1,9 @@
+template(name="cancelConfirmationModalBody")
+  .delete-confirmation
+    i.fa.fa-trash-o
+    p Are you sure you want to abandon your changes?
+    p=displayName
+    .main-action
+      button.btn.btn-danger.btn-wide.confirm(type="button") Abandon
+    .other-actions
+      button.btn.btn-default.btn-sm(type="button" data-dismiss="modal") Cancel

--- a/client/views/incidentReports/suggestedIncidentModal.jade
+++ b/client/views/incidentReports/suggestedIncidentModal.jade
@@ -1,5 +1,5 @@
 template(name="suggestedIncidentModal")
-  .modal.fade(role="dialog")
+  .modal.fade#suggestedIncidentModal(role="dialog")
     .modal-dialog
       .modal-content
         .modal-header

--- a/client/views/incidentReports/suggestedIncidentsModal.jade
+++ b/client/views/incidentReports/suggestedIncidentsModal.jade
@@ -1,9 +1,9 @@
 template(name="suggestedIncidentsModal")
-  .modal.fade#suggestedIncidentsModal(role="dialog" data-keyboard="false" data-backdrop="static")
+  .modal.fade#suggestedIncidentsModal(role="dialog")
     .modal-dialog.suggested-incidents
       .modal-content
         .modal-header
-          +modalConfirmCloseButton
+          +modalCloseButton
           h4.modal-title Suggested Incident Reports
             .small-text {{annotatedCount}}
         .modal-body
@@ -16,6 +16,6 @@ template(name="suggestedIncidentsModal")
             #suggested-locations-form.form-horizontal
               p.annotated-content=annotatedContent
         .modal-footer
-          button.btn.btn-default.confirm-close-modal(type="button") Close
+          button.btn.btn-default.confirm-close-modal(type="button" data-dismiss="modal") Close
           button.btn.btn-default#non-suggested-incident(type="button") Add New Incident
           button.btn.btn-primary#add-suggestions(type="button") Add Confirmed Suggestions

--- a/client/views/incidentReports/suggestedIncidentsModal.jade
+++ b/client/views/incidentReports/suggestedIncidentsModal.jade
@@ -1,5 +1,5 @@
 template(name="suggestedIncidentsModal")
-  .modal.fade#suggestedIncidentsModal(role="dialog")
+  .modal.fade#suggestedIncidentsModal(role="dialog" data-keyboard="false" data-backdrop="static")
     .modal-dialog.suggested-incidents
       .modal-content
         .modal-header

--- a/client/views/incidentReports/suggestedIncidentsModal.jade
+++ b/client/views/incidentReports/suggestedIncidentsModal.jade
@@ -1,10 +1,10 @@
 template(name="suggestedIncidentsModal")
-  .modal.fade(role="dialog")
+  .modal.fade#suggestedIncidentsModal(role="dialog")
     .modal-dialog.suggested-incidents
       .modal-content
         .modal-header
-          +modalCloseButton
-          h4.modal-title Suggested Incident Reports 
+          +modalConfirmCloseButton
+          h4.modal-title Suggested Incident Reports
             .small-text {{annotatedCount}}
         .modal-body
           if loading
@@ -16,6 +16,6 @@ template(name="suggestedIncidentsModal")
             #suggested-locations-form.form-horizontal
               p.annotated-content=annotatedContent
         .modal-footer
-          button.btn.btn-default(type="button" data-dismiss="modal") Close
+          button.btn.btn-default.confirm-close-modal(type="button") Close
           button.btn.btn-default#non-suggested-incident(type="button") Add New Incident
           button.btn.btn-primary#add-suggestions(type="button") Add Confirmed Suggestions

--- a/client/views/modalConfirmCloseButton.jade
+++ b/client/views/modalConfirmCloseButton.jade
@@ -1,0 +1,2 @@
+template(name="modalConfirmCloseButton")
+  .close-modal.confirm-close-modal(aria-label="Close")

--- a/client/views/modalConfirmCloseButton.jade
+++ b/client/views/modalConfirmCloseButton.jade
@@ -1,2 +1,0 @@
-template(name="modalConfirmCloseButton")
-  .close-modal.confirm-close-modal(aria-label="Close")

--- a/client/views/sourceModal.jade
+++ b/client/views/sourceModal.jade
@@ -1,5 +1,5 @@
 template(name="sourceModal")
-  .modal.fade(role="dialog")
+  .modal.fade#sourceModal(role="dialog")
     .modal-dialog
       .modal-content
         .modal-header

--- a/imports/stylesheets/cancelConfirmation.import.styl
+++ b/imports/stylesheets/cancelConfirmation.import.styl
@@ -1,0 +1,18 @@
+.cancel-confirmation
+  text-align center
+  padding-top 2em
+  padding-bottom 3.5em
+  p
+    &:first-of-type
+      margin .5em 0 .2em 0
+      font-size 125%
+    &:last-of-type
+      font-style italic
+      margin-bottom 2em
+  i
+    color lighten($warning, 20%)
+    font-size 5em
+  .other-actions
+    margin-top 1em
+    .btn:first-of-type
+      margin-right .5em

--- a/imports/stylesheets/index.styl
+++ b/imports/stylesheets/index.styl
@@ -15,6 +15,7 @@
 
 // Basic UI elements/components
 @import 'deleteConfirmation.import'
+@import 'cancelConfirmation.import'
 @import 'ui.import'
 @import 'panes.import'
 @import 'lists.import'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/134380381

To test:

1.  Login to the app and navigate to [Tracked Events]
2. Click on one of the events in the table
3. Click on the [Add Sources] button
4. Choose a `Suggested Article` by clicking on the text then click [Save]
5. Wait for the article to be processed...
6. Click on a red underlined text, wait for the next modal, then click [Confirm]
7. Note: that the number of accepted incidents has changed
8. Try to cancel/close the modal.
9. Note: a confirmation modal appears