### PR TITLE
fix curatorInbox date filter bug

### DIFF
--- a/client/controllers/curatorInbox/curatorInbox.coffee
+++ b/client/controllers/curatorInbox/curatorInbox.coffee
@@ -124,7 +124,7 @@ Template.curatorInbox.events
     endDate = $('#date-picker').data('daterangepicker').endDate
 
     if startDate and !endDate
-      endDate = startDate
+      endDate = moment(startDate).set({hour: 23, minute: 59, second: 59, millisecond: 999})
 
     if startDate and endDate
       template.calendarState.set(false)


### PR DESCRIPTION
This happens when the user click on a startDate and does not choose an endDate, then clicks [Apply]. The code would see endDate is null and then set endDate as an object reference to startDate, thus startDate === endDate.  The fix is to make endDate as a copy of startDate and set its time to a millisecond before midnight.

- make the endDate a copy of startDate at a millisecond before midnight

https://www.pivotaltracker.com/story/show/134378881