### PR TITLE
Fix unscrollable modals

### DIFF
--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -214,6 +214,10 @@ Template.suggestedIncidentsModal.onCreated ->
     )
   )
 
+Template.suggestedIncidentsModal.onRendered ->
+  $('#sourceModal').on 'hidden.bs.modal', ->
+    $('body').addClass('modal-open')
+
 Template.suggestedIncidentsModal.helpers
   incidents: ->
     Template.instance().incidentCollection.find()

--- a/client/views/createEventModal.jade
+++ b/client/views/createEventModal.jade
@@ -5,7 +5,8 @@ template(name="createEventModal")
         form#createEvent(novalidate)
           +modalCloseButton
           .modal-header
-            h4.modal-title Create a New Event
+            .modal-header--title
+              h4 Create a New Event
 
           .modal-body
             .form-group

--- a/client/views/deleteConfirmation/deleteConfirmationModal.jade
+++ b/client/views/deleteConfirmation/deleteConfirmationModal.jade
@@ -3,8 +3,9 @@ template(name="deleteConfirmationModal")
     .modal-dialog
       .modal-content
         form#delete-obj
-          .close-modal(data-dismiss="modal" aria-label="Close")
+          +modalCloseButton
           .modal-header
-            h4.modal-title Confirm Delete
+            .modal-header--title
+              h4 Confirm Delete
           .modal-body.clearfix
             +deleteConfirmationModalBody data

--- a/client/views/events/editEventDetailsModal.jade
+++ b/client/views/events/editEventDetailsModal.jade
@@ -3,13 +3,14 @@ template(name="editEventDetailsModal")
     .modal-dialog
       .modal-content
         form#editEvent
-          .close-modal(data-dismiss="modal" aria-label="Close")
+          +modalCloseButton
           .modal-header
-            h4.modal-title
-              if adding
-                | Add New Event
-              else
-                | Edit Event Details
+            .modal-header--title
+              h4
+                if adding
+                  | Add New Event
+                else
+                  | Edit Event Details
           .modal-body.clearfix
             unless confirmingDeletion
               .form-group

--- a/client/views/incidentReports/incidentModal.jade
+++ b/client/views/incidentReports/incidentModal.jade
@@ -4,12 +4,13 @@ template(name="incidentModal")
       .modal-content
         .modal-header
           +modalCloseButton
-          h4.modal-title
-            if edit
-              | Edit
-            else
-              | Add
-            |  Incident Report
+          .modal-header--title
+            h4
+              if edit
+                | Edit
+              else
+                | Add
+              |  Incident Report
         .modal-body
           if edit
             +incidentForm(

--- a/client/views/incidentReports/suggestedIncidentModal.jade
+++ b/client/views/incidentReports/suggestedIncidentModal.jade
@@ -4,7 +4,8 @@ template(name="suggestedIncidentModal")
       .modal-content
         .modal-header
           +modalCloseButton
-          h4.modal-title Edit and Confirm Incident Report
+          .modal-header--title
+            h4 Edit and Confirm Incident Report
         .modal-body
           .well.annotated-content.snippet=incidentText
           +incidentForm(

--- a/client/views/incidentReports/suggestedIncidentsModal.jade
+++ b/client/views/incidentReports/suggestedIncidentsModal.jade
@@ -4,17 +4,19 @@ template(name="suggestedIncidentsModal")
       .modal-content
         .modal-header
           +modalCloseButton
-          h4.modal-title Suggested Incident Reports
-            .small-text {{annotatedCount}}
+          .modal-header--title
+            h4 Suggested Incident Reports
+            span.annotation-count=annotatedCount
         .modal-body
-          if loading
-            i.fa.fa-circle-o-notch.fa-spin
-            | Processing article
-          else
-            unless incidentsFound
-              .warn No incident reports could be automatically extracted from the article.
+          .suggested-incidents-wrapper
             #suggested-locations-form.form-horizontal
-              p.annotated-content=annotatedContent
+              if loading
+                i.fa.fa-circle-o-notch.fa-spin
+                | Processing article
+              else
+                unless incidentsFound
+                  .warn No incident reports could be automatically extracted from the article.
+                p.annotated-content=annotatedContent
         .modal-footer
           button.btn.btn-default.confirm-close-modal(type="button" data-dismiss="modal") Close
           button.btn.btn-default#non-suggested-incident(type="button") Add New Incident

--- a/client/views/sourceModal.jade
+++ b/client/views/sourceModal.jade
@@ -3,11 +3,12 @@ template(name="sourceModal")
     .modal-dialog
       .modal-content
         .modal-header
-          h4.modal-title
-            if edit
-              | Edit Event Source
-            else
-              | Add Event Source
+          .modal-header--title
+            h4
+              if edit
+                | Edit Event Source
+              else
+                | Add Event Source
           +modalCloseButton
         .modal-body
           form#add-source.form-horizontal(novalidate)

--- a/imports/stylesheets/curator.import.styl
+++ b/imports/stylesheets/curator.import.styl
@@ -313,19 +313,7 @@ $header-BG = $border-primary-light
 
 .curator-source-details-copy-wrapper
   position relative
-  &::before
-  &::after
-    content ''
-    height 20px
-    position absolute
-    left 0
-    right 0
-  &::before
-    background linear-gradient(to bottom, white, alpha(white, 0%))
-    top 0
-  &::after
-    background linear-gradient(to bottom, alpha(white, 0%), white)
-    bottom 0
+  gradientTopAndBottom()
 
 .curator-source-details-copy
   max-height 25vh

--- a/imports/stylesheets/globals.import.styl
+++ b/imports/stylesheets/globals.import.styl
@@ -58,11 +58,11 @@ h3
     font-size 18px
 
 h4
-  color body-text
+  color $body-text
   font-weight 600
   font-size 15px
   +below(3)
-    color body-text
+    color $body-text
     font-weight 600
     font-size 15px
 h5

--- a/imports/stylesheets/incidents/incidents.import.styl
+++ b/imports/stylesheets/incidents/incidents.import.styl
@@ -11,10 +11,45 @@
   color green
 
 .suggested-incidents
-  width 800px
+  margin 30px
+  width calc(100% - 60px)
+  +above(3)
+    width 65%
+    max-width 800px
+    margin 30px auto
+  .modal-content
+    display flex
+    flex-direction column
+    height calc(100vh - 60px)
+    min-height 400px
   .modal-body
-    height 500px
-    overflow-y scroll
+    padding 0
+    position relative
+    gradientTopAndBottom()
+    flex 1
+  .modal-footer
+    margin-top auto
+
+  .annotation-count
+    display block
+    color $primary
+    font-size 1em
+    text-decoration none
+    margin-top .5em
+
+  .btn[data-dismiss]
+    display none
+    +above(3)
+      display inline-block
+
+.suggested-incidents-wrapper
+  position absolute
+  top 0
+  bottom 0
+  left 0
+  right 0
+  padding 25px
+  overflow-y scroll
 
 .annotated-content
   white-space pre-wrap

--- a/imports/stylesheets/mixins.import.styl
+++ b/imports/stylesheets/mixins.import.styl
@@ -64,3 +64,19 @@ buttonContent($btn-text, $icon-position)
   margin-{$icon-position} .25em
   text-transform uppercase
   font($body-font)
+
+gradientTopAndBottom()
+  &::before
+  &::after
+    content ''
+    height 20px
+    position absolute
+    left 0
+    right 0
+    z-index 10
+  &::before
+    background linear-gradient(to bottom, white, alpha(white, 0%))
+    top 0
+  &::after
+    background linear-gradient(to bottom, alpha(white, 0%), white)
+    bottom 0

--- a/imports/stylesheets/modals.import.styl
+++ b/imports/stylesheets/modals.import.styl
@@ -15,12 +15,14 @@ $modal-border-radius = 4px
   .close
     padding 5px
 
-.modal-title
-  padding .35em .75em .4em .75em
-  text-transform uppercase
-  font-weight 300
-  font-size 2em
-  color $primary
+.modal-header--title
+  padding 1.25em 40px 1em 25px
+  h4
+    margin 0
+    font-weight 300
+    font-size 2em
+    color $primary
+    text-transform uppercase
 
 .modal-header
 .modal-footer
@@ -29,6 +31,13 @@ $modal-border-radius = 4px
 .modal-footer
   padding-top 1.25em
   padding-bottom 2em
+  .btn + .btn
+    margin-bottom 1em
+    +above(2)
+      margin-bottom 0
+  .btn
+    &:last-of-type
+      margin-bottom 0
 
 .small-text
   font-size .5em


### PR DESCRIPTION
The problem ([documented in this bug](https://www.pivotaltracker.com/story/show/136069771)) was happening because the `modal-open` class was being removed from the body when the _add source_ modal closed but after the _suggested incident report_ modal added it back.

Makes the _suggested incidents report_ modal stretch to the height of the viewport (and gives a min-height) and adds gradients on the top and bottom of the text window to imply additional content beyond.