### PR TITLE
Fix bug where associated suggested events not removed from table

### DIFF
--- a/client/controllers/curatorInbox/curatorEvents.coffee
+++ b/client/controllers/curatorInbox/curatorEvents.coffee
@@ -8,7 +8,7 @@ _getSourceId = (instance) ->
 
 Template.curatorEvents.onCreated ->
   instance = @
-  @suggestedEventsHeaderState = new ReactiveVar true
+  @suggestedEventsHeaderState = new ReactiveVar(true)
   @associatedEventIdsToArticles = new ReactiveVar({})
   @autorun =>
     instance.subscribe "articles",

--- a/client/controllers/curatorInbox/curatorSuggestedEvents.coffee
+++ b/client/controllers/curatorInbox/curatorSuggestedEvents.coffee
@@ -68,9 +68,8 @@ Template.suggestedEvents.onCreated ->
   # reactively compute changes to associatedEventIdsToArticles object and
   # update the suggested events
   @autorun =>
-    if @data.associatedEventIdsToArticles
-      associated = @data.associatedEventIdsToArticles.get()
-      @updateSuggestedEvents(associated)
+    associated = @data.associatedEventIdsToArticles?.get()
+    @updateSuggestedEvents(associated)
 
 Template.suggestedEvents.helpers
   # controls the visiblity of the suggested-events-table and toggles the chevron

--- a/client/views/curatorInbox/curatorEvents.jade
+++ b/client/views/curatorInbox/curatorEvents.jade
@@ -21,7 +21,9 @@ template(name="curatorEvents")
       p.no-events.muted-text Currently no associated events
 
   .suggested-events.curator-events
-    +suggestedEvents selectedSourceId=selectedSourceId associatedEventIdsToArticles=associatedEventIdsToArticles
+    +suggestedEvents(
+      selectedSourceId=selectedSourceId
+      associatedEventIdsToArticles=associatedEventIdsToArticles)
 
   .all-events.curator-events
     .curator-events-header.all-events.toggleable


### PR DESCRIPTION
Looks like at some point the instantiation of the `suggestedEventsHeaderState` reactiveVar made its way into an `@autorun` so it's value was being reset when a collection updated.

[PT Bug](https://www.pivotaltracker.com/story/show/136383865)