### PR TITLE
Update createInlineDateTangePicker to abbreviate months

### DIFF
--- a/imports/ui/inlineDateRangePicker.coffee
+++ b/imports/ui/inlineDateRangePicker.coffee
@@ -1,23 +1,28 @@
+trimMonthHeader = ($rangeContainer) ->
+  $rangeContainer.find('.calendar-table').each ->
+    $(@).find('thead tr').last().children().each ->
+      $day = $(@)
+      $day.html($day.html().slice(0,-1))
+
 createInlineDateRangePicker = ($parentElement, options) ->
   parentId = $parentElement.prop("id")
   if !parentId
     # If the parent element doesn't have an id, generate one
-    parentId = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) ->
+    parentId = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace /[xy]/g, (c) ->
       r = Math.random()*16|0
       v = if c is 'x' then r else (r&0x3|0x8)
       return v.toString(16)
-    )
-    $parentElement.prop("id", parentId)
+    $parentElement.prop('id', parentId)
 
   if !options then options = {}
-  allOptions = _.extend({
-    parentEl: "#" + parentId
+  allOptions = _.extend
+    parentEl: '#' + parentId
     template: Blaze.toHTML(Template.inlineDateRangePicker)
     singleDatePicker: options.singleDatePicker
     autoUpdateInput: false
     maxDate: options.maxDate
     minDate: options.minDate
-  }, _.omit(options, 'singleDatePicker'))
+  , _.omit(options, 'singleDatePicker')
 
   if options.startDate and options.endDate
     allOptions.startDate = options.startDate
@@ -27,29 +32,37 @@ createInlineDateRangePicker = ($parentElement, options) ->
     allOptions.autoApply = true
 
   $rangeContainer = $parentElement.daterangepicker(allOptions)
-  picker = $rangeContainer.data("daterangepicker")
+  picker = $rangeContainer.data('daterangepicker')
+
+  # Replace two letter day abbreviations with single-letter
+  $rangeContainer.on 'show.daterangepicker', ->
+    trimMonthHeader($rangeContainer)
+  $rangeContainer.find('.calendar')
+    .off('click.daterangepicker', '.next')
+    .off('click.daterangepicker', '.prev')
+    .on 'click.daterangepicker', '.next', (event) ->
+      picker.clickNext(event)
+      trimMonthHeader($rangeContainer)
+    .on 'click.daterangepicker', '.prev', (event) ->
+      picker.clickPrev(event)
+      trimMonthHeader($rangeContainer)
+
   if options.singleDatePicker
-    $(".singleDatePickerInput").show()
-    picker.clickApply = (e) ->
-      this.setEndDate(this.startDate)
-      this.updateView()
-      this.element.trigger('apply.daterangepicker', this);
+    $('.singleDatePickerInput').show()
+    picker.clickApply = (event) ->
+      @setEndDate(@startDate)
+      @updateView()
+      @element.trigger('apply.daterangepicker', @);
 
   # Prevent the calendar from hiding
   picker.hide = -> @
 
-  $(".inlineRangePicker").off("click.daterangepicker")
-  $(".inlineRangePicker .daterangepicker").removeClass("opensright")
+  $('.inlineRangePicker').off('click.daterangepicker')
+  $('.inlineRangePicker .daterangepicker').removeClass('opensright')
 
   picker.show()
 
-  $(document).off("mousedown.daterangepicker touchend.daterangepicker click.daterangepicker focusin.daterangepicker")
-
-  # Replace two letter day abbreviations with single-letter
-  $rangeContainer.find('.calendar-table').each ->
-    $(@).find('thead tr').last().children().each ->
-      $day = $(@)
-      $day.html($day.html().slice(0,-1))
+  $(document).off('mousedown.daterangepicker touchend.daterangepicker click.daterangepicker focusin.daterangepicker')
 
   picker
 


### PR DESCRIPTION
Before this update, the abbreviation (down to 1 letter) was replaced after the user selected a new month. Modifies the click events of next and prev buttons to abbreviate the months

[PT Bug](https://www.pivotaltracker.com/story/show/136389589)