### PR TITLE
filtering out associated events from suggested events

### DIFF
--- a/client/controllers/curatorInbox/curatorSuggestedEvents.coffee
+++ b/client/controllers/curatorInbox/curatorSuggestedEvents.coffee
@@ -64,6 +64,9 @@ Template.suggestedEvents.onCreated ->
         # set the initialEvents to the result and update the reactive array
         @initialEvents = res
         @events.set(res)
+        # filter out associated events from the suggested events
+        associated = @data.associatedEventIdsToArticles?.get()
+        @updateSuggestedEvents(associated)
 
   # reactively compute changes to associatedEventIdsToArticles object and
   # update the suggested events


### PR DESCRIPTION
Right now events that are already associated show under suggested events