### PR TITLE
Fix flickering user indicator badge

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -37,7 +37,7 @@ eidr:fixtures@0.0.1
 ejson@1.0.12
 email@1.1.17_1
 fastclick@1.0.12
-fortawesome:fontawesome@4.6.3
+fortawesome:fontawesome@4.7.0
 fuatsengul:leaflet@1.0.1
 geojson-utils@1.0.9
 hot-code-push@1.0.4

--- a/client/controllers/curatorInbox/curatorUserStatus.coffee
+++ b/client/controllers/curatorInbox/curatorUserStatus.coffee
@@ -1,4 +1,5 @@
 Template.curatorUserStatus.onCreated ->
+  @hasOnlineUsers = new ReactiveVar false
   @userStatusHandle = @subscribe('userStatus')
   @autorun =>
     Meteor.call 'updateCuratorUserStatus', @data.selectedSourceId.get(), (err, res) =>
@@ -15,19 +16,16 @@ userCount = (sourceId) ->
 
 Template.curatorUserStatus.helpers
   hasOnlineUsers: () ->
-    hasOnlineUsers = false
-    count = 0
     instance = Template.instance()
     if instance.userStatusHandle.ready()
       sourceId = instance.data.selectedSourceId.get()
-      count = userCount(sourceId)
-    if count > 0
-      hasOnlineUsers = true
-    hasOnlineUsers
+      userCount(sourceId)
+
   usersOnlineCount: () ->
     instance = Template.instance()
     sourceId = instance.data.selectedSourceId.get()
     userCount(sourceId)
+
   usersOnlineMessage: () ->
     instance = Template.instance()
     sourceId = instance.data.selectedSourceId.get()

--- a/client/controllers/curatorInbox/curatorUserStatus.coffee
+++ b/client/controllers/curatorInbox/curatorUserStatus.coffee
@@ -1,6 +1,6 @@
 Template.curatorUserStatus.onCreated ->
   @userStatusHandle = @subscribe('userStatus')
-  @onlineUserCount = new ReactiveVar 0
+  @otherActiveUser = new ReactiveVar null
   @autorun =>
     Meteor.call 'updateCuratorUserStatus', @data.selectedSourceId.get(), (err, res) =>
       if err
@@ -9,7 +9,7 @@ Template.curatorUserStatus.onCreated ->
 Template.curatorUserStatus.onRendered ->
   instance = @
   @autorun ->
-    instance.onlineUserCount.get()
+    instance.otherActiveUser.get()
     Meteor.defer ->
       $('.curator-viewing-status').tooltip
         container: 'body'
@@ -23,11 +23,11 @@ Template.curatorUserStatus.onDestroyed ->
 Template.curatorUserStatus.helpers
   hasOnlineUsers: ->
     instance = Template.instance()
-    if instance.userStatusHandle.ready()
-      # Count users currently viewing the selected source minus the current
-      count = Meteor.users.find(
-        'status.online': true
-        'status.curatorInboxSourceId': instance.data.selectedSourceId.get()
-      ).count() - 1
-      instance.onlineUserCount.set(count)
-      count
+    # Find other users viewing the source selected by the current user
+    otherUser = Meteor.users.findOne
+      'status.online': true
+      'status.curatorInboxSourceId': instance.data.selectedSourceId.get()
+      _id: $ne: Meteor.userId()
+    if otherUser
+      instance.otherActiveUser.set(otherUser._id)
+      true

--- a/client/views/curatorInbox/curatorEvents.jade
+++ b/client/views/curatorInbox/curatorEvents.jade
@@ -2,7 +2,6 @@ template(name="curatorEvents")
   .associated-events.curator-events
     .curator-events-header
       h3 Associated Events
-      +curatorUserStatus selectedSourceId=selectedSourceId
       .curator-events--options
         button.btn.btn-primary.btn-sm.btn-wide.add-new-event
           i.fa.fa-plus-circle

--- a/client/views/curatorInbox/curatorInbox.jade
+++ b/client/views/curatorInbox/curatorInbox.jade
@@ -59,6 +59,7 @@ template(name="curatorInboxSection")
 template(name="curatorSourceDetails")
   with source
     .curator-inbox-header.curator-source-details-header(class="{{#if isReviewed}} reviewed {{/if}}")
+      +curatorUserStatus selectedSourceId=selectedSourceId
       h2(id="sourceDetailsTitle" data-toggle="tooltip" title=getSourceDetailsTitle data-placement="bottom")= title
       .curator-source-details-options
         .controls

--- a/client/views/curatorInbox/curatorUserStatus.jade
+++ b/client/views/curatorInbox/curatorUserStatus.jade
@@ -1,5 +1,5 @@
 template(name="curatorUserStatus")
   if hasOnlineUsers
-    i.curator-viewing-status.fa.fa-eye(
+    i.curator-viewing-status.fa.fa-user-circle(
       title="Currently there are other curators viewing this source"
       data-toggle="tooltip")

--- a/client/views/curatorInbox/curatorUserStatus.jade
+++ b/client/views/curatorInbox/curatorUserStatus.jade
@@ -1,3 +1,5 @@
 template(name="curatorUserStatus")
   if hasOnlineUsers
-    span.badge(style="margin-left: 5px" title="#{usersOnlineMessage}") {{usersOnlineCount}}
+    i.curator-viewing-status.fa.fa-eye(
+      title="Currently there are other curators viewing this source"
+      data-toggle="tooltip")

--- a/imports/stylesheets/curator.import.styl
+++ b/imports/stylesheets/curator.import.styl
@@ -513,3 +513,10 @@ $header-BG = $border-primary-light
   text-align center
   i
     font-size 5em
+
+.curator-viewing-status
+  position absolute
+  font-size 1.2em
+  left .05em
+  transform rotate(-90deg)
+  color darken($danger, 20%)

--- a/imports/stylesheets/curator.import.styl
+++ b/imports/stylesheets/curator.import.styl
@@ -220,11 +220,12 @@ $header-BG = $border-primary-light
   .btn
     transition .3s
     &.toggle-reviewed
+      padding .45em 1em
       background lighten($positive, 90%)
-      padding .45em 1.75em
       color darken($positive, 40%)
-      padding-left 3em
-      padding-right 3em
+      +above(4)
+        padding-left 3em
+        padding-right 3em
       &:hover
       &:focus
         background darken(@background, 10%)
@@ -516,7 +517,6 @@ $header-BG = $border-primary-light
 
 .curator-viewing-status
   position absolute
-  font-size 1.2em
-  left .05em
-  transform rotate(-90deg)
-  color darken($danger, 20%)
+  font-size 1.1em
+  left .225em
+  color $danger

--- a/methods/userStatus.coffee
+++ b/methods/userStatus.coffee
@@ -1,9 +1,5 @@
-
 Meteor.methods
   updateCuratorUserStatus: (sourceId) ->
-    user = Meteor.user()
-    if user
-      Meteor.users.update(user, {$set : {'status.curatorInboxSourceId': sourceId}})
-      return true
-    else
-      return false
+    Meteor.users.update Meteor.userId(),
+      $set:
+        'status.curatorInboxSourceId': sourceId


### PR DESCRIPTION
Also rethinks the indicator, changes it from a count badge to an eye icon and relocates it to next to the source title.
I think explicitly showing the count is less important than indicating there are other curators actively viewing the same source.
Also ensure the tooltip shows when the template/view is destroyed and added back.

[PT Bug](https://www.pivotaltracker.com/story/show/136513111)