### PR TITLE
Instantiate tooltip for other active users when sourceid changes

### DIFF
--- a/client/controllers/curatorInbox/curatorUserStatus.coffee
+++ b/client/controllers/curatorInbox/curatorUserStatus.coffee
@@ -10,6 +10,7 @@ Template.curatorUserStatus.onRendered ->
   instance = @
   @autorun ->
     instance.otherActiveUser.get()
+    instance.data.selectedSourceId.get()
     Meteor.defer ->
       $('.curator-viewing-status').tooltip
         container: 'body'


### PR DESCRIPTION
Re-instantiate the tooltip when the source changes in addition to the otherActiveUser state.
