### PR TITLE
changing path that revision.txt is copied to

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ USER root
 # Add the application files
 ADD supervisor-eidr-connect.conf /etc/supervisor/conf.d/eidr-connect.conf
 ADD run.sh /run.sh
-RUN cd /eidr-connect && git rev-parse HEAD > /revision.txt
+RUN cd /eidr-connect && git rev-parse HEAD > /home/meteor/build/bundle/revision.txt
 
 # Prepare for production
 LABEL app="eidr-connect"


### PR DESCRIPTION
Since we are using `fs.readFile path.join(process.env.PWD, 'revision.txt')` to read the txt file we need to put the file in the working directory rather than `/`