### PR TITLE
Remove right margin on single date range picker

### DIFF
--- a/imports/stylesheets/datepicker.import.styl
+++ b/imports/stylesheets/datepicker.import.styl
@@ -44,6 +44,10 @@
 .inlineRangePicker .daterangepicker.single .calendar.left.single
   width 100%
   max-width 550px
+  margin 0
+  .daterangepicker_input
+  .calendar-table
+    padding-right 0
 
 .inlineRangePicker .daterangepicker .calendar
   float none
@@ -187,6 +191,10 @@
           color darken($border-primary, 20%)
     .single
       width auto
+      margin-right 0
+      .daterangepicker_input
+      .calendar-table
+        padding-right 0
     .in-range
     .start-date
       &:not(.off)


### PR DESCRIPTION
Small fix to the single calendar date range picker — centers it in the UI by removing the right margin/padding.