### PR TITLE
Add 'approximate' property to IRs and display in details

### DIFF
--- a/client/controllers/incidentReports/incidentForm.coffee
+++ b/client/controllers/incidentReports/incidentForm.coffee
@@ -105,6 +105,9 @@ Template.incidentForm.helpers
     if fieldName in Template.instance().suggestedFields.get()
       "suggested"
 
+  typeIsSelected: ->
+    Template.instance().incidentType.get()
+
 Template.incidentForm.events
   'change input[name=daterangepicker_start]': (event, instance) ->
     instance.$('#singleDatePicker').data('daterangepicker').clickApply()

--- a/client/views/incidentReports/incidentForm.jade
+++ b/client/views/incidentReports/incidentForm.jade
@@ -10,7 +10,7 @@ template(name="incidentForm")
         placeholder='Select a source')
       .help-block.with-errors
 
-    .form-group.incident--dates.full-width(class="{{suggestedField 'dateRange'}}")
+    .form-group.incident--dates.full-width.with-tabs(class="{{suggestedField 'dateRange'}}")
       ul.tabs.secondary-tabs(role="tablist")
         li(role="presentation" class="{{dayTabClass}}")
           a(
@@ -78,9 +78,9 @@ template(name="incidentForm")
             checked="{{incidentStatusChecked 'revoked'}}")
           label(for="revoked" tabindex="0") Revoked
 
-    .incident-type-wrapper.form-groups(class="{{#if typeIsSelected}} form-groups--highlighted {{/if}}")
-      .form-group.form-group--full.check-buttons(
-        class="{{suggestedField 'cases'}} {{suggestedField 'deaths'}}")
+    .incident-type-wrapper.form-groups(
+      class="{{#if typeIsSelected}} form-groups--highlighted {{/if}} {{suggestedField 'cases'}} {{suggestedField 'deaths'}}")
+      .form-group.form-group--full.check-buttons
         label.control-label Incident Type
         .container-flex.check-buttons.type.no-break
           .check-button
@@ -116,7 +116,7 @@ template(name="incidentForm")
         .help-block.with-errors
 
       if showCountForm
-        .form-group.form-group--child(class="{{suggestedField 'cases'}} {{suggestedField 'deaths'}}")
+        .form-group.form-group--child
           label.control-label #{selectedIncidentType} Count
           input.form-control(
             name="count"
@@ -142,7 +142,7 @@ template(name="incidentForm")
         .form-group.form-group--child
           label.control-label Integrity
           .container-flex.other-metadata.check-buttons.no-break
-            .check-button(class="{{suggestedField 'cumulative'}}")
+            .check-button
               input(
                 type="checkbox"
                 name="cumulative"
@@ -151,7 +151,7 @@ template(name="incidentForm")
                 checked=incidentData.dateRange.cumulative)
               label.cumulative(for="cumulative" tabindex="0") Cumulative
 
-            .check-button(class="{{suggestedField 'approximate'}}")
+            .check-button
               input(
                 type="checkbox"
                 name="approximate"

--- a/client/views/incidentReports/incidentForm.jade
+++ b/client/views/incidentReports/incidentForm.jade
@@ -1,7 +1,7 @@
 template(name="incidentForm")
 
   form#add-incident(novalidate)
-    .form-group
+    .form-group.form-group--full
       label.control-label Source URL
       +articleSelect2(
         selectId="articleSource"
@@ -32,7 +32,7 @@ template(name="incidentForm")
         #preciseRange.tab-pane(role="tabpanel" class="{{rangeTabClass}}")
           #rangePicker.inlineRangePicker
 
-    .form-group(class="{{suggestedField 'locations'}}")
+    .form-group.form-group--full(class="{{suggestedField 'locations'}}")
       label.control-label Location
       +locationSelect2(
         selectId="incident-location-select2"
@@ -40,14 +40,14 @@ template(name="incidentForm")
         selected=incidentData.locations)
       .help-block.with-errors
 
-    .form-group(class="{{suggestedField 'species'}}")
+    .form-group.form-group--full(class="{{suggestedField 'species'}}")
       label.control-label Species
       input.form-control(
         type="text"
         name="species"
         value=incidentData.species)
 
-    .form-group.check-buttons(class="{{suggestedField 'status'}}")
+    .form-group.form-group--full.check-buttons(class="{{suggestedField 'status'}}")
       label.control-label Status
       .container-flex.check-buttons.status.no-break
         .check-button
@@ -78,65 +78,89 @@ template(name="incidentForm")
             checked="{{incidentStatusChecked 'revoked'}}")
           label(for="revoked" tabindex="0") Revoked
 
-    .form-group.check-buttons(class="{{suggestedField 'cases'}} {{suggestedField 'deaths'}}")
-      label.control-label Incident Type
-      .container-flex.check-buttons.type.no-break
-        .check-button
-          input(
-            type="radio"
-            name="incidentType"
-            id="cases"
-            value="cases"
-            tabindex="-1"
-            checked="{{incidentTypeChecked 'cases'}}"
-            required)
-          label(for="cases" tabindex="0") Cases
-        .check-button
-          input(
-            type="radio"
-            name="incidentType"
-            id="deaths"
-            value="deaths"
-            tabindex="-1"
-            checked="{{incidentTypeChecked 'deaths'}}"
-            required)
-          label(for="deaths" tabindex="0") Deaths
-        .check-button
-          input(
-            type="radio"
-            name="incidentType"
-            id="other"
-            value="other"
-            tabindex="-1"
-            checked="{{incidentTypeChecked 'other'}}"
-            required)
-          label(for="other" tabindex="0") Other
-      .help-block.with-errors
-
-    if showCountForm
-      .form-group(class="{{suggestedField 'cases'}} {{suggestedField 'deaths'}}")
-        label.control-label #{selectedIncidentType} Count
-        input.form-control(
-          name="count"
-          type="number"
-          min="0"
-          value=incidentData.value
-          required
-          tabindex="0")
+    .incident-type-wrapper.form-groups(class="{{#if typeIsSelected}} form-groups--highlighted {{/if}}")
+      .form-group.form-group--full.check-buttons(
+        class="{{suggestedField 'cases'}} {{suggestedField 'deaths'}}")
+        label.control-label Incident Type
+        .container-flex.check-buttons.type.no-break
+          .check-button
+            input(
+              type="radio"
+              name="incidentType"
+              id="cases"
+              value="cases"
+              tabindex="-1"
+              checked="{{incidentTypeChecked 'cases'}}"
+              required)
+            label(for="cases" tabindex="0") Cases
+          .check-button
+            input(
+              type="radio"
+              name="incidentType"
+              id="deaths"
+              value="deaths"
+              tabindex="-1"
+              checked="{{incidentTypeChecked 'deaths'}}"
+              required)
+            label(for="deaths" tabindex="0") Deaths
+          .check-button
+            input(
+              type="radio"
+              name="incidentType"
+              id="other"
+              value="other"
+              tabindex="-1"
+              checked="{{incidentTypeChecked 'other'}}"
+              required)
+            label(for="other" tabindex="0") Other
         .help-block.with-errors
 
-    if showOtherForm
-      .form-group.space-top--1
-        label.control-label Specify Other
-        input.form-control(
-          name="specify"
-          id="specify"
-          type="text"
-          required
-          value=incidentData.value
-          tabindex="0")
+      if showCountForm
+        .form-group.form-group--child(class="{{suggestedField 'cases'}} {{suggestedField 'deaths'}}")
+          label.control-label #{selectedIncidentType} Count
+          input.form-control(
+            name="count"
+            type="number"
+            min="0"
+            value=incidentData.value
+            required
+            tabindex="0")
+          .help-block.with-errors
 
-    .form-group
+      if showOtherForm
+        .form-group.form-group--child
+          label.control-label Specify Other
+          input.form-control(
+            name="specify"
+            id="specify"
+            type="text"
+            required
+            value=incidentData.value
+            tabindex="0")
+
+      if typeIsSelected
+        .form-group.form-group--child
+          label.control-label Integrity
+          .container-flex.other-metadata.check-buttons.no-break
+            .check-button(class="{{suggestedField 'cumulative'}}")
+              input(
+                type="checkbox"
+                name="cumulative"
+                id="cumulative"
+                tabindex="-1"
+                checked=incidentData.dateRange.cumulative)
+              label.cumulative(for="cumulative" tabindex="0") Cumulative
+
+            .check-button(class="{{suggestedField 'approximate'}}")
+              input(
+                type="checkbox"
+                name="approximate"
+                id="approximate"
+                tabindex="-1"
+                checked=incidentData.approximate)
+              label.cumulative(for="approximate" tabindex="0") Approximate
+
+    .form-group.form-group--full
       label.control-label Other Information
       .container-flex.other-metadata.check-buttons.no-break
         .check-button(class="{{suggestedField 'travelRelated'}}")
@@ -147,14 +171,5 @@ template(name="incidentForm")
             tabindex="-1"
             checked=incidentData.travelRelated)
           label.travel-related(for="travelRelated" tabindex="0") Travel Related
-
-        .check-button(class="{{suggestedField 'cumulative'}}")
-          input(
-            type="checkbox"
-            name="cumulative"
-            id="cumulative"
-            tabindex="-1"
-            checked=incidentData.dateRange.cumulative)
-          label.cumulative(for="cumulative" tabindex="0") Cumulative
 
     button.hidden(type="submit" aria-hidden="true")

--- a/client/views/incidentReports/incidentReport.jade
+++ b/client/views/incidentReports/incidentReport.jade
@@ -1,4 +1,3 @@
-
 template(name="incidentReport")
   td(colspan="7")
     .details-container.incident-report--details.container-flex.no-break
@@ -47,6 +46,15 @@ template(name="incidentReport")
                 li
                   a.ref-link(href="{{formatUrl(val)}}" target="_blank")
                     span {{formatUrl(val)}}
+          ul.integrity.metadata.list-unstyled
+            if dateRange.cumulative
+              li
+                i.fa.fa-asterisk(aria-hidden="true")
+                | Cumulative
+            if approximate
+              li
+                i.fa.fa-asterisk(aria-hidden="true")
+                | Approximate
 
       .incident-report--details--actions.container-flex.no-break
         a.edit(aria-label="Edit")

--- a/client/views/sourceModal.jade
+++ b/client/views/sourceModal.jade
@@ -27,7 +27,7 @@ template(name="sourceModal")
                     else
                       .no-results No articles found
 
-            .form-group
+            .form-group.form-group--full
               label.control-label Title
               input#title.form-control.new-title(
                 type="text"
@@ -36,7 +36,7 @@ template(name="sourceModal")
                 required)
               .help-block.with-errors
 
-            .form-group
+            .form-group.form-group--full
               label.control-label Article URL
               if edit
                 p.form-control-static {{url}}
@@ -47,7 +47,7 @@ template(name="sourceModal")
                   required)
               .help-block.with-errors
 
-            .form-group(class="{{#if editing}} date-editing {{/if}}")
+            .form-group.form-group--full(class="{{#if editing}} date-editing {{/if}}")
               label.control-label Publication Date
               .modal-block.full-width
                 #publishDate.datePicker.inlineRangePicker

--- a/imports/schemas/incidentReport.coffee
+++ b/imports/schemas/incidentReport.coffee
@@ -1,4 +1,4 @@
-IncidentReportSchema = new SimpleSchema(
+IncidentReportSchema = new SimpleSchema
   _id:
     type: String
     optional: true
@@ -41,6 +41,9 @@ IncidentReportSchema = new SimpleSchema(
     type: Boolean
     optional: true
   travelRelated:
+    type: Boolean
+    optional: true
+  approximate:
     type: Boolean
     optional: true
   species:
@@ -86,5 +89,5 @@ IncidentReportSchema = new SimpleSchema(
   deletedDate:
     type: Date
     optional: true
-)
+
 module.exports = IncidentReportSchema

--- a/imports/stylesheets/events/incidentDetails.import.styl
+++ b/imports/stylesheets/events/incidentDetails.import.styl
@@ -11,8 +11,6 @@
 .incident-report--details--important
   display flex
   flex-direction column
-  padding-top 1em
-  padding-bottom 1em
   flex-direction row
   align-items center
   margin-right 0
@@ -38,7 +36,6 @@
 .incident-report--details--metadata
   margin-left 0
   margin-right 0
-  align-self flex-start
   +above(2)
     margin-right 3em
   &.bordered
@@ -48,6 +45,12 @@
   ul
     &:last-of-type
       margin-bottom 0
+    .integrity
+      margin-top 1.25em
+      li
+        font-size .9em
+        display inline-block
+        padding-right 1em
 
 .incident-report--details--actions
   flex-direction row

--- a/imports/stylesheets/forms/forms.import.styl
+++ b/imports/stylesheets/forms/forms.import.styl
@@ -33,6 +33,35 @@ input
 
 .form-group
   margin-bottom 1.75em
+  border-top 1px solid transparent
+  border-bottom 1px solid transparent
   label
     margin-bottom .5em
     color $d-gray
+
+.form-group--child
+  margin-left 1em
+
+.form-group--full
+  margin-right -20px
+  margin-left -20px
+  padding 5px 20px
+  margin-bottom 10px
+
+.form-groups
+  margin-right -20px
+  margin-left -20px
+  padding-left 20px
+  padding-right 20px
+  border-top 1px solid transparent
+  border-bottom 1px solid transparent
+  .form-group
+    margin-bottom .5em
+    &:first-of-type
+      margin-bottom 0
+
+.form-groups--highlighted
+  margin-bottom 15px
+  padding-bottom 10px
+  background $block-BG
+  border-color $border-primary

--- a/imports/stylesheets/forms/suggested.import.styl
+++ b/imports/stylesheets/forms/suggested.import.styl
@@ -1,12 +1,6 @@
 $warning-bg = lighten($warning, 90%)
 $warning-border = darken($warning-bg, 12%)
 
-autofillBG($bordered=true)
-  background $warning-bg
-  if $bordered
-    border-bottom 1px solid $warning-border
-    border-top 1px solid $warning-border
-
 .suggested
   position relative
   &:not(.full-width)

--- a/imports/stylesheets/forms/suggested.import.styl
+++ b/imports/stylesheets/forms/suggested.import.styl
@@ -1,6 +1,15 @@
 $warning-bg = lighten($warning, 90%)
 $warning-border = darken($warning-bg, 12%)
 
+
+.suggested-block
+  content '\f0d0'
+  position absolute
+  right .5em
+  top .5em
+  font(FontAwesome)
+  color darken($warning-bg, 40%)
+
 .suggested
   position relative
   &:not(.full-width)
@@ -22,14 +31,12 @@ $warning-border = darken($warning-bg, 12%)
   .form-control:last-of-type
   .select2-container--default
     margin-bottom .5em
-  &::after
-    content '\f0d0'
-    position absolute
-    right .5em
-    top .25em
-    font(FontAwesome)
-    color darken($warning-bg, 40%)
-  &.incident--dates
-    &:after
-      top 2.5em
-      right 1.5em
+
+  &:not(.with-tabs)
+    &::after
+      @extend .suggested-block
+  &.with-tabs
+    .tab-content
+      position relative
+      &:after
+        @extend .suggested-block

--- a/imports/stylesheets/incidents/incidentForm.import.styl
+++ b/imports/stylesheets/incidents/incidentForm.import.styl
@@ -8,11 +8,6 @@
       max-width 200px
 
   .form-group
-    &:not(.incident--dates)
-      margin-right -20px
-      margin-left -20px
-      padding 5px 20px
-      margin-bottom 10px
     &.incident--dates
       margin-right -35px
       margin-left -35px

--- a/imports/stylesheets/mixins.import.styl
+++ b/imports/stylesheets/mixins.import.styl
@@ -92,3 +92,9 @@ gradientBottom($height=20px, $color=white)
     z-index $top-layer
     background linear-gradient(to bottom, alpha($color, 0) 0%, $color 100%)
     pointer-events none
+
+autofillBG($bordered=true)
+  background $warning-bg
+  if $bordered
+    border-bottom 1px solid $warning-border
+    border-top 1px solid $warning-border

--- a/imports/stylesheets/pillSelector.import.styl
+++ b/imports/stylesheets/pillSelector.import.styl
@@ -15,7 +15,7 @@
   cursor pointer
   padding 1em 1em
   display block
-  color $m-gray
+  color $primary
   font-size .9em
   line-height 1
   +above(2)

--- a/imports/stylesheets/sources.import.styl
+++ b/imports/stylesheets/sources.import.styl
@@ -37,5 +37,9 @@
   .date-editing
     margin-bottom -11px
   .form-group
+    margin-bottom 1
     p
       margin 0
+  .modal-block
+    .form-group
+      margin-bottom 0

--- a/imports/stylesheets/validator.import.styl
+++ b/imports/stylesheets/validator.import.styl
@@ -34,6 +34,9 @@
     color white
 
 .help-block
+  &:empty
+    display none
+    margin 0
   &.with-errors
     ul
       font-size .9em

--- a/imports/utils.coffee
+++ b/imports/utils.coffee
@@ -42,14 +42,14 @@ checkIncidentTypeValue = (form, input) ->
 export incidentReportFormToIncident = (form) ->
   $form = $(form)
   $articleSelect = $(form.articleSource)
-  if $form.find("#singleDate").hasClass("active")
-    rangeType = "day"
-    $pickerContainer = $form.find("#singleDatePicker")
+  if $form.find('#singleDate').hasClass('active')
+    rangeType = 'day'
+    $pickerContainer = $form.find('#singleDatePicker')
   else
-    rangeType = "precise"
-    $pickerContainer = $form.find("#rangePicker")
+    rangeType = 'precise'
+    $pickerContainer = $form.find('#rangePicker')
 
-  picker = $pickerContainer.data("daterangepicker")
+  picker = $pickerContainer.data('daterangepicker')
 
   incidentType = $form.find('input[name="incidentType"]:checked').val()
   incidentStatus = $form.find('input[name="incidentStatus"]:checked').val()
@@ -57,6 +57,7 @@ export incidentReportFormToIncident = (form) ->
   incident =
     species: form.species.value
     travelRelated: form.travelRelated.checked
+    approximate: form.approximate.checked
     locations: []
     status: incidentStatus
     dateRange:
@@ -76,14 +77,14 @@ export incidentReportFormToIncident = (form) ->
       toastr.error("Unknown incident type [#{incidentType}]")
       return
 
-  for child in $articleSelect.select2("data")
+  for child in $articleSelect.select2('data')
     if child.selected
       incident.url = [child.text.trim()]
 
-  $loc = $(form).find("#incident-location-select2")
-  for option in $loc.select2("data")
+  $loc = $(form).find('#incident-location-select2')
+  for option in $loc.select2('data')
     item = option.item
-    if typeof item.alternateNames is "string"
+    if typeof item.alternateNames is 'string'
       delete item.alternateNames
     incident.locations.push(item)
   return incident


### PR DESCRIPTION
I grouped the IR type inputs and the child inputs appear when a type is selected. I added a grouping of checkboxes called "Integrity" which includes `cumulative` and `approximate` (`cumulative` was included in "Additional information"). Not sure if its an appropriate title, let me know what you think.
![screen shot 2017-01-11 at 1 41 27 pm](https://cloud.githubusercontent.com/assets/4105343/21861643/b0532f5e-d803-11e6-858c-4281681e76d3.png)

If `cumulative` or `approximate` are selected, they appear in the IR details UI like so:
![screen shot 2017-01-11 at 1 37 23 pm](https://cloud.githubusercontent.com/assets/4105343/21861608/991ab190-d803-11e6-84b5-a6442e0192df.png)
