### PR TITLE
Fix updating datetime when clicking suggested source

### DIFF
--- a/client/controllers/sourceModal.coffee
+++ b/client/controllers/sourceModal.coffee
@@ -80,7 +80,8 @@ Template.sourceModal.helpers
       'save-modal'
 
   title: ->
-    Template.instance().selectedArticle.get().subject
+    article = Template.instance().selectedArticle.get()
+    article.title or article.subject
 
   url: ->
     Template.instance().selectedArticle.get().url

--- a/client/controllers/sourceModal.coffee
+++ b/client/controllers/sourceModal.coffee
@@ -54,6 +54,12 @@ Template.sourceModal.onRendered ->
 
   @$('#add-source').validator()
 
+  @autorun =>
+    article = @selectedArticle.get()
+    if article.subject
+      # Trigger input event on url field so datetime is updated
+      @$('#article').trigger('input')
+
 Template.sourceModal.helpers
   timezones: ->
     timezones = []
@@ -74,7 +80,10 @@ Template.sourceModal.helpers
       'save-modal'
 
   title: ->
-    Template.instance().selectedArticle.get().title
+    Template.instance().selectedArticle.get().subject
+
+  url: ->
+    Template.instance().selectedArticle.get().url
 
   suggestedArticles: ->
     Template.instance().suggestedArticles.find()
@@ -167,7 +176,7 @@ Template.sourceModal.events
 
   'input #article': (event, instance) ->
     value = event.currentTarget.value.trim()
-    match = instance.proMEDRegEx.exec(value)
+    match = /promedmail\.org\/post\/(\d+)/ig.exec(value)
     if match
       articleId = Number(match[1])
       Meteor.call 'retrieveProMedArticleDate', articleId, (error, result) ->
@@ -186,11 +195,6 @@ Template.sourceModal.events
   'click #suggested-articles li': (event, instance) ->
     event.preventDefault()
     instance.selectedArticle.set(@)
-    articleInput = instance.find('#article')
-    articleInput.value = @url
-    $(articleInput).trigger('input')
-    titleInput = instance.find('#title')
-    titleInput.value = @subject
 
   'submit form': (event, instance) ->
     instance.formValid.set(not event.isDefaultPrevented())

--- a/client/views/sourceModal.jade
+++ b/client/views/sourceModal.jade
@@ -32,7 +32,7 @@ template(name="sourceModal")
               input#title.form-control.new-title(
                 type="text"
                 name="title"
-                value="{{title}}"
+                value=title
                 required)
               .help-block.with-errors
 
@@ -43,6 +43,7 @@ template(name="sourceModal")
               else
                 input#article.form-control.new-article(
                   type="url"
+                  value=url
                   name="article"
                   required)
               .help-block.with-errors


### PR DESCRIPTION
For some reason setting the promed regex as a variable caused the `exec` function to alternately return null even when everything matched (Any ideas why this would be happening? The same behavior occurs in the console).
I also refactored the click event of suggested articles - removed the jquery code and update values of the fields using helpers.