### PR TITLE
Fix size of incident report date tabs in safari <= 9.x.x

### DIFF
--- a/imports/stylesheets/incidents/incidentForm.import.styl
+++ b/imports/stylesheets/incidents/incidentForm.import.styl
@@ -44,7 +44,7 @@
       background white
       margin-right .25em
       +above(2)
-        flex 0
+        flex 0 0 auto
       &:first-of-type
         border-top-left-radius 4px
       &:last-of-type


### PR DESCRIPTION
The tabs had no width due to me initially using `flex 0` (my bad). Changed it to `flex 0 0 auto` which allows the elements to establish their widths naturally without growing into available space.