### PR TITLE
Update Suggested IR UI - content on left and right

### DIFF
--- a/imports/stylesheets/forms/suggested.import.styl
+++ b/imports/stylesheets/forms/suggested.import.styl
@@ -40,3 +40,24 @@ $warning-border = darken($warning-bg, 12%)
       position relative
       &:after
         @extend .suggested-block
+
+#suggestedIncidentModal
+  +above(4)
+    .modal-dialog
+      width 90%
+    .modal-header
+      border-color $border-primary-m
+    .modal-body
+      padding 0
+      display flex
+    .annotated-content
+    #add-incident
+      flex 1 1 50%
+    #add-incident
+      padding 0 20px
+    .annotated-content
+      margin 0
+      border 0
+      border-right 1px solid $border-primary-m
+    .snippet--text
+      max-height none

--- a/imports/stylesheets/variables.import.styl
+++ b/imports/stylesheets/variables.import.styl
@@ -25,6 +25,8 @@ $delete = $danger
 
 $border-primary = #C6D1DD
 $border-primary-light = lighten($border-primary, 75%)
+$border-primary-light = $border-primary-l = lighten($border-primary, 75%)
+$border-primary-medium = $border-primary-m = darken($border-primary-l, 5%)
 $border-secondary = lighten($secondary, 30%)
 $border-btn = #95989A
 


### PR DESCRIPTION
Breaks the UI out to a two-pane UI at 992px and above. Snippet on left and form on right:
<img width="1234" alt="screen shot 2017-01-17 at 4 15 17 pm" src="https://cloud.githubusercontent.com/assets/4105343/22040232/2a43796a-dcd0-11e6-97f3-af2bb6b42fb0.png">

[PT story](https://www.pivotaltracker.com/story/show/137783155)