### PR TITLE
Fix ir location autofill bug

### DIFF
--- a/client/controllers/incidentReports/incidentForm.coffee
+++ b/client/controllers/incidentReports/incidentForm.coffee
@@ -160,7 +160,6 @@ Template.incidentForm.events
     _removeSuggestedProperties(instance, ['cumulative'])
 
   'submit form': (event, instance) ->
-    instance.$(event.currentTarget).validator()
     prevented = event.isDefaultPrevented()
     instance.data.valid.set(not prevented)
     if prevented

--- a/client/controllers/incidentReports/incidentForm.coffee
+++ b/client/controllers/incidentReports/incidentForm.coffee
@@ -79,10 +79,6 @@ Template.incidentForm.onRendered ->
     Meteor.defer =>
       @$('#add-incident').validator('update')
 
-  if not @incidentData.locations.length
-    _removeSuggestedProperties(@, ['locations'])
-    @$('#add-incident').validator('validate')
-
 Template.incidentForm.helpers
   incidentData: ->
     Template.instance().incidentData

--- a/client/controllers/incidentReports/incidentForm.coffee
+++ b/client/controllers/incidentReports/incidentForm.coffee
@@ -18,6 +18,10 @@ _selectInput = (event, instance, prop, isCheckbox) ->
     else
       state.set(clickedInput)
 
+_removeSuggestedProperties = (instance, props) ->
+  suggestedFields = instance.suggestedFields
+  suggestedFields.set(_.difference(suggestedFields.get(), props))
+
 Template.incidentForm.onCreated ->
   @incidentStatus = new ReactiveVar('')
   @incidentType = new ReactiveVar('')
@@ -70,10 +74,14 @@ Template.incidentForm.onRendered ->
 
   @$('#add-incident').validator()
   #Update the validator when Blaze adds incident type related inputs
-  @autorun ->
-    instance.incidentType.get()
-    Meteor.defer ->
-      instance.$('#add-incident').validator('update')
+  @autorun =>
+    @incidentType.get()
+    Meteor.defer =>
+      @$('#add-incident').validator('update')
+
+  if not @incidentData.locations.length
+    _removeSuggestedProperties(@, ['locations'])
+    @$('#add-incident').validator('validate')
 
 Template.incidentForm.helpers
   incidentData: ->
@@ -105,12 +113,12 @@ Template.incidentForm.helpers
 
   selectedIncidentType: ->
     switch Template.instance().incidentType.get()
-      when "cases" then "Case"
-      when "deaths" then "Death"
+      when 'cases' then 'Case'
+      when 'deaths' then 'Death'
 
   suggestedField: (fieldName)->
     if fieldName in Template.instance().suggestedFields.get()
-      "suggested"
+      'suggested'
 
   typeIsSelected: ->
     Template.instance().incidentType.get()
@@ -126,18 +134,15 @@ Template.incidentForm.events
     instance.$('#singleDatePicker').data('daterangepicker').clickApply()
 
   'click .status label, keyup .status label': (event, instance) ->
-    suggestedFields = instance.suggestedFields
-    suggestedFields.set(_.without(suggestedFields.get(), 'status'))
+    _removeSuggestedProperties(instance, ['status'])
     _selectInput(event, instance, 'incidentStatus')
 
   'click .type label, keyup .type label': (event, instance) ->
-    suggestedFields = instance.suggestedFields
-    suggestedFields.set(_.without(suggestedFields.get(), 'cases', 'deaths'))
+    _removeSuggestedProperties(instance, ['cases', 'deaths'])
     _selectInput(event, instance, 'incidentType')
 
   'keyup [name="count"]': (event, instance) ->
-    suggestedFields = instance.suggestedFields
-    suggestedFields.set(_.without(suggestedFields.get(), 'cases', 'deaths'))
+    _removeSuggestedProperties(instance, ['cases', 'deaths'])
 
   'click .select2-selection': (event, instance) ->
     # Remove selected empty item
@@ -146,18 +151,16 @@ Template.incidentForm.events
       firstItem.remove()
 
   'mouseup .select2-selection': (event, instance) ->
-    suggestedFields = instance.suggestedFields
-    suggestedFields.set(_.without(suggestedFields.get(), 'locations'))
+    _removeSuggestedProperties(instance, ['locations'])
 
   'mouseup .incident--dates': (event, instance) ->
-    suggestedFields = instance.suggestedFields
-    suggestedFields.set(_.without(suggestedFields.get(), 'dateRange'))
+    _removeSuggestedProperties(instance, ['dateRange'])
 
   'click .cumulative, keyup .cumulative': (event, instance) ->
-    suggestedFields = instance.suggestedFields
-    suggestedFields.set(_.without(suggestedFields.get(), 'cumulative'))
+    _removeSuggestedProperties(instance, ['cumulative'])
 
   'submit form': (event, instance) ->
+    instance.$(event.currentTarget).validator()
     prevented = event.isDefaultPrevented()
     instance.data.valid.set(not prevented)
     if prevented

--- a/client/controllers/incidentReports/incidentModal.coffee
+++ b/client/controllers/incidentReports/incidentModal.coffee
@@ -8,9 +8,6 @@ Template.incidentModal.helpers
   valid: ->
     Template.instance().valid
 
-  formIsValid: ->
-    Template.instance().valid.get()
-
 Template.incidentModal.events
   'click .save-modal, click .save-modal-duplicate': (event, instance) ->
     # Submit the form to trigger validation and to update the 'valid'

--- a/client/controllers/incidentReports/suggestedIndidentModal.coffee
+++ b/client/controllers/incidentReports/suggestedIndidentModal.coffee
@@ -5,12 +5,16 @@ Template.suggestedIncidentModal.onCreated ->
   @incidentCollection = @data.incidentCollection
   @incident = @data.incident or {}
   @incident.suggestedFields = new ReactiveVar(@incident.suggestedFields or [])
+  @valid = new ReactiveVar(false)
 
 Template.suggestedIncidentModal.helpers
   hasSuggestedFields: ->
     Template.instance().incident.suggestedFields.get()
 
   type: -> [ 'case', 'date', 'location' ]
+
+  valid: ->
+    Template.instance().valid
 
 Template.suggestedIncidentModal.events
   'click .reject': (event, instance) ->
@@ -19,6 +23,11 @@ Template.suggestedIncidentModal.events
         accepted: false
 
   'click .save-modal': (event, instance) ->
+    # Submit the form to trigger validation and to update the 'valid'
+    # reactiveVar — its value is based on whether the form's hidden submit
+    # button's default is prevented
+    $('#add-incident').submit()
+    return unless instance.valid.get()
     incident = utils.incidentReportFormToIncident(instance.$("form")[0])
 
     return if not incident

--- a/client/views/incidentReports/suggestedIncidentModal.jade
+++ b/client/views/incidentReports/suggestedIncidentModal.jade
@@ -21,7 +21,8 @@ template(name="suggestedIncidentModal")
             articles=articles
             incident=incident
             edit=true
-            confirmation=true)
+            confirmation=true
+            valid=valid)
         .modal-footer
           button.btn.btn-default.reject(type="button" data-dismiss="modal") Reject
           button.btn.btn-primary.save-modal(type="button") Confirm


### PR DESCRIPTION
I noticed in some circumstances when a location was not determined by the GRITS api, the location field was still marked as autofilled and the user could submit the form.
This PR:
- If there is no location, removes the `location` field from the `suggestedFields` array and runs the validator to mark the field as invalid.
- Refactors the removal of suggestedFields into a function.
- Validates the suggested incident form