### PR TITLE
Style autofilled source form inputs

### DIFF
--- a/client/controllers/incidentReports/incidentForm.coffee
+++ b/client/controllers/incidentReports/incidentForm.coffee
@@ -1,6 +1,6 @@
 createInlineDateRangePicker = require '/imports/ui/inlineDateRangePicker.coffee'
 validator = require 'bootstrap-validator'
-{ keyboardSelect } = require '/imports/utils'
+{ keyboardSelect, removeSuggestedProperties } = require '/imports/utils'
 
 _selectInput = (event, instance, prop, isCheckbox) ->
   return if not keyboardSelect(event) and event.type is 'keyup'
@@ -14,10 +14,6 @@ _selectInput = (event, instance, prop, isCheckbox) ->
       state.set(null)
     else
       state.set(clickedInput)
-
-_removeSuggestedProperties = (instance, props) ->
-  suggestedFields = instance.suggestedFields
-  suggestedFields.set(_.difference(suggestedFields.get(), props))
 
 Template.incidentForm.onCreated ->
   @incidentStatus = new ReactiveVar('')
@@ -127,15 +123,15 @@ Template.incidentForm.events
     instance.$('#singleDatePicker').data('daterangepicker').clickApply()
 
   'click .status label, keyup .status label': (event, instance) ->
-    _removeSuggestedProperties(instance, ['status'])
+    removeSuggestedProperties(instance, ['status'])
     _selectInput(event, instance, 'incidentStatus')
 
   'click .type label, keyup .type label': (event, instance) ->
-    _removeSuggestedProperties(instance, ['cases', 'deaths'])
+    removeSuggestedProperties(instance, ['cases', 'deaths'])
     _selectInput(event, instance, 'incidentType')
 
   'keyup [name="count"]': (event, instance) ->
-    _removeSuggestedProperties(instance, ['cases', 'deaths'])
+    removeSuggestedProperties(instance, ['cases', 'deaths'])
 
   'click .select2-selection': (event, instance) ->
     # Remove selected empty item
@@ -144,13 +140,13 @@ Template.incidentForm.events
       firstItem.remove()
 
   'mouseup .select2-selection': (event, instance) ->
-    _removeSuggestedProperties(instance, ['locations'])
+    removeSuggestedProperties(instance, ['locations'])
 
   'mouseup .incident--dates': (event, instance) ->
-    _removeSuggestedProperties(instance, ['dateRange'])
+    removeSuggestedProperties(instance, ['dateRange'])
 
   'click .cumulative, keyup .cumulative': (event, instance) ->
-    _removeSuggestedProperties(instance, ['cumulative'])
+    removeSuggestedProperties(instance, ['cumulative'])
 
   'submit form': (event, instance) ->
     prevented = event.isDefaultPrevented()

--- a/client/views/sourceModal.jade
+++ b/client/views/sourceModal.jade
@@ -27,7 +27,7 @@ template(name="sourceModal")
                     else
                       .no-results No articles found
 
-            .form-group.form-group--full
+            .form-group.form-group--full(class="{{suggested 'title'}}")
               label.control-label Title
               input#title.form-control.new-title(
                 type="text"
@@ -36,7 +36,7 @@ template(name="sourceModal")
                 required)
               .help-block.with-errors
 
-            .form-group.form-group--full
+            .form-group.form-group--full(class="{{suggested 'url'}}")
               label.control-label Article URL
               if edit
                 p.form-control-static {{url}}
@@ -51,10 +51,10 @@ template(name="sourceModal")
             .form-group.form-group--full(class="{{#if editing}} date-editing {{/if}}")
               label.control-label Publication Date
               .modal-block.full-width
-                #publishDate.datePicker.inlineRangePicker
+                #publishDate.datePicker.inlineRangePicker(class="{{suggested 'date'}}")
                 .clearfix.time
                   .col-sm-6
-                    .form-group
+                    .form-group(class="{{suggested 'time'}}")
                       .input-group
                         span.input-group-addon
                           i.fa.fa-clock-o
@@ -66,7 +66,7 @@ template(name="sourceModal")
                           data-error="Please select a time.")
                       .help-block.with-errors
                   .col-sm-6
-                    .form-group
+                    .form-group(class="{{suggested 'time'}}")
                       .input-group.with-select
                         span.input-group-addon
                           i.fa.fa-globe

--- a/imports/stylesheets/datepicker.import.styl
+++ b/imports/stylesheets/datepicker.import.styl
@@ -70,6 +70,10 @@ $today-highlight = lighten($highlight, 70%)
   bottom 4px
   right 4px
 
+.daterangepicker .input-mini
+  border-color $border-primary
+  box-shadow none
+
 .calendar-wrapper
   .date-picker-container
     position relative
@@ -215,6 +219,3 @@ $today-highlight = lighten($highlight, 70%)
         border 0
     .today.active
       background $secondary
-    input
-      border-color $border-primary
-      box-shadow none

--- a/imports/stylesheets/forms/suggested.import.styl
+++ b/imports/stylesheets/forms/suggested.import.styl
@@ -46,6 +46,14 @@ $warning-border = darken($warning-bg, 12%)
     +below(3)
       flex-direction column
 
+.suggested-minimal
+  .input-group-addon
+  input
+  select
+    background $warning-bg
+    border-color darken($warning-border, 10%) !important // Overide bootstrap
+    color $primary-dark
+
 #suggestedIncidentModal
   +above(4)
     .modal-dialog

--- a/imports/stylesheets/sources.import.styl
+++ b/imports/stylesheets/sources.import.styl
@@ -15,8 +15,8 @@
     &:hover
       background darken($block-BG, 3%)
     &.active
-      color $secondary-dark
       background darken($block-BG, 3%)
+      color $primary-dark
   .no-results
     margin-bottom 1.25em
     &::before

--- a/imports/utils.coffee
+++ b/imports/utils.coffee
@@ -124,3 +124,7 @@ export regexEscape = (s)->
 export keyboardSelect = (event) ->
   keyCode = event.keyCode
   keyCode in [13, 32]
+
+export removeSuggestedProperties = (instance, props) ->
+  suggestedFields = instance.suggestedFields
+  suggestedFields.set(_.difference(suggestedFields.get(), props))


### PR DESCRIPTION
This applies a variant of existing autofill styles to the source form. I thought that since the autofill occurs after a user action (clicking a suggested article) we can reduce the visual indication—just change the border and background of the inputs:
![screen shot 2017-01-23 at 11 01 33 am](https://cloud.githubusercontent.com/assets/4105343/22211556/5af1390a-e15b-11e6-8712-4acc1c1019a7.png)
