### PR TITLE
Improve UX of date filtration in curator inbox

### DIFF
--- a/client/views/curatorInbox/curatorInbox.jade
+++ b/client/views/curatorInbox/curatorInbox.jade
@@ -1,33 +1,32 @@
 template(name="curatorInbox")
   .pane-container.curator-inbox
-    if isReady
-      .curator-inbox-header.pane-head.pane-head-l(
-        class="{{#unless detailsInView }} on-canvas {{/unless}}")
-        h2 Inbox
-        .curator-inbox-options
-          a.option.curator-filter-reviewed-icon.plain-focus(
-            class="{{#unless reviewFilterActive}} active {{/unless}}"
-            data-toggle="tooltip"
-            title="Show/Hide Reviewed"
-            tabindex="0")
-            i.fa.fa-check-circle(aria-hidden="true")
-          a.option.curator-filter-calendar-icon.plain-focus(
-            class="{{#if calendarState}} active {{/if}}"
-            data-toggle="tooltip"
-            title="Filter by Date Range"
-            tabindex="0")
-            i.fa.fa-calendar(aria-hidden="true")
-          +searchInput searchSettings
+    .curator-inbox-header.pane-head.pane-head-l(
+      class="{{#unless detailsInView }} on-canvas {{/unless}}")
+      h2 Inbox
+      .curator-inbox-options
+        a.option.curator-filter-reviewed-icon.plain-focus(
+          class="{{#unless reviewFilterActive}} active {{/unless}}"
+          data-toggle="tooltip"
+          title="Show/Hide Reviewed"
+          tabindex="0")
+          i.fa.fa-check-circle(aria-hidden="true")
+        a.option.curator-filter-calendar-icon.plain-focus(
+          class="{{#if calendarState}} active {{/if}}"
+          data-toggle="tooltip"
+          title="Filter by Date Range"
+          tabindex="0")
+          i.fa.fa-calendar(aria-hidden="true")
+        +searchInput searchSettings
 
-      .curator-inbox-sources.pane.pane-l.curator-inbox--pane(
-        class="{{#if detailsInView}} off{{else}}on{{/if}}-canvas")
-        .curator-inbox-datepicker(class="{{#if calendarState}} active {{/if}}")
-          .text-center
-            #date-picker.inlineRangePicker
-          .text-center
-            a#calendar-btn-apply.btn.btn-primary(href="") Apply
-            a#calendar-btn-reset.btn.btn-primary(href="") Reset
-            a#calendar-btn-cancel.btn.btn-default(href="") Cancel
+    .curator-inbox-sources.pane.pane-l.curator-inbox--pane(
+      class="{{#if detailsInView}} off{{else}}on{{/if}}-canvas")
+      .curator-inbox-datepicker(class="{{#if calendarState}} active {{/if}}")
+        #date-picker.inlineRangePicker
+        .curator-inbox-datepicker--controls.container-flex.central.no-break
+          button#calendar-btn-apply.btn.btn-primary(type="button") Apply
+          if userHasFilteredByDate
+            button#calendar-btn-reset.btn.btn-default(type="button") Reset
+      if isReady
         .curator-inbox-source-list
           each day in days
             +curatorInboxSection(
@@ -37,18 +36,19 @@ template(name="curatorInbox")
               textFilter=textFilter
               selectedSourceId=selectedSourceId
               currentPaneInView=currentPaneInView)
-      #touch-stage.curator-source-details.pane.pane-r.curator-inbox--pane(
-        class="{{#if detailsInView}} on{{else}}off{{/if}}-canvas")
+      else
+        +loading static=true
+    #touch-stage.curator-source-details.pane.pane-r.curator-inbox--pane(
+      class="{{#if detailsInView}} on{{else}}off{{/if}}-canvas")
+      if isReady
         +curatorSourceDetails(
           selectedSourceId=selectedSourceId
           query=query
           currentPaneInView=currentPaneInView)
-      button.btn.btn-primary.btn-wide.back-to-top(
-        class="{{#if detailsInView}} off{{else}}on{{/if}}-canvas"
-        type="button"
-        title="Click to return on the top page."
-        data-toggle="tooltip")
-        i.fa.fa-chevron-circle-up
-        span Back to Top
-    else
-      +loading
+    button.btn.btn-primary.btn-wide.back-to-top(
+      class="{{#if detailsInView}} off{{else}}on{{/if}}-canvas"
+      type="button"
+      title="Click to return on the top page."
+      data-toggle="tooltip")
+      i.fa.fa-chevron-circle-up
+      span Back to Top

--- a/client/views/events/userEvent.jade
+++ b/client/views/events/userEvent.jade
@@ -1,27 +1,26 @@
 template(name="userEvent")
   .event
-    if deleted
-      section.event--basic-info.container-fluid-padded
+    section.event--basic-info.container-fluid-padded
+      if deleted
         h2
           | This event has been deleted
-    else
-      section.event--basic-info.container-fluid-padded
+      else
         with userEvent
           +summary
 
-      section.event--detailed-info
-        if incidents.length
-          .tabs-wrapper
-            ul.tabs.primary-tabs.container-fluid-padded(role="tablist")
-              li(class="{{#if incidentView}}active{{/if}}" role="presentation")
-                a(href="{{pathFor route='user-event' _id=userEvent._id _view='incidents'}}") Incident Reports
-              li(class="{{#if locationView}}active{{/if}}" role="presentation")
-                a(href="{{pathFor route='user-event' _id=userEvent._id _view='locations'}}") Locations
+    section.event--detailed-info
+      if incidents.length
+        .tabs-wrapper
+          ul.tabs.primary-tabs.container-fluid-padded(role="tablist")
+            li(class="{{#if incidentView}}active{{/if}}" role="presentation")
+              a(href="{{pathFor route='user-event' _id=userEvent._id _view='incidents'}}") Incident Reports
+            li(class="{{#if locationView}}active{{/if}}" role="presentation")
+              a(href="{{pathFor route='user-event' _id=userEvent._id _view='locations'}}") Locations
 
-          .tab-content
-            .tab-pane.active(role="tabpanel")
-              +Template.dynamic template=view data=templateData
+        .tab-content
+          .tab-pane.active(role="tabpanel")
+            +Template.dynamic template=view data=templateData
 
-      if articles.length
-        section.event--articles
-          +articles
+    if articles.length
+      section.event--articles
+        +articles

--- a/imports/stylesheets/curatorInbox.import.styl
+++ b/imports/stylesheets/curatorInbox.import.styl
@@ -130,19 +130,40 @@ $pane-switch-speed = .3s
 
 .curator-inbox-datepicker
   display none
-  margin 5px auto 15px
+  margin 1em 0 0
+  padding-bottom 2em
+  border-bottom 2px solid $border-primary-light
   &.active
     display block
   .inlineRangePicker
     position relative
+    margin-bottom 1em
   .daterangepicker
-    display inline-block
-    left auto !important
-    top 8px !important
-    padding 0
-    margin 0 0 5px
+    position static
+    display flex
+    align-items center
+    justify-content center
+    flex-wrap wrap
   .calendar
-    margin 0
+    margin 0 0 1.5em 0
+    &:first-of-type
+      margin-right 1em
+    +above(2)
+      margin-bottom 0
+    .calendar-table
+    .daterangepicker_input
+      padding 0
+  .btn
+    margin-bottom .5em
+    width 80%
+    margin 0 10% 1em 10%
+    +above(2)
+      width auto
+      margin-left 0
+      margin-right .5em
+      &:first-of-type
+        padding-left 2.5em
+        padding-right 2.5em
 
 .curator-inbox-source-list
   .reactive-table-options

--- a/imports/stylesheets/loading.import.styl
+++ b/imports/stylesheets/loading.import.styl
@@ -1,9 +1,9 @@
 .loading
   margin-top 30px
   text-align center
-  position absolute
-  top 2em
   &.centered
+    position absolute
+    top 2em
     top 50%
     left 50%
     transform translate(-50%, -50%)

--- a/imports/stylesheets/panes.import.styl
+++ b/imports/stylesheets/panes.import.styl
@@ -6,12 +6,6 @@
   left 0
   right 0
   z-index $mid-layer
-  .loading
-    loading(false)
-    position absolute
-    top 100px
-    transform translate(-50%, 0)
-    left 50%
 
 .pane
   position absolute

--- a/imports/stylesheets/ui.import.styl
+++ b/imports/stylesheets/ui.import.styl
@@ -7,6 +7,8 @@
 
 .container-flex
   display flex
+  &.column
+    flex-direction column
   &:not(.no-break)
     +below(3)
       flex-direction column


### PR DESCRIPTION
- Fixes [this bug](https://www.pivotaltracker.com/story/show/139570855) causing the UI to hang on loading when the current date is selected for filtration by setting the max date to the publish date of the latest source in the collection
- Shows the default filtration range
- Only shows the reset button when a user has changed the range
- Refactors how we show content when range changes: no longer reload the calendar
- When user selects only one date, the UI updates to reflect single-date selection (lingering range highlighting is removed)
- Shows loading indicator over only the source list — related to [this story](https://www.pivotaltracker.com/story/show/139570825)