### PR TITLE
Update the position of the y-axis label

### DIFF
--- a/imports/charts/Axes.coffee
+++ b/imports/charts/Axes.coffee
@@ -99,9 +99,13 @@ class Axes
 
     # yScale
     if yDomain
-      @yScale = d3.scaleLinear().domain(yDomain).range([@plot.getHeight(), 0])
+      @yScale = d3.scaleLinear()
+        .domain(yDomain)
+        .range([@plot.getHeight(), 0])
     else
-      @yScale = d3.scaleLinear().domain(@currentMinMax[1]).range([@plot.getHeight(), 0])
+      @yScale = d3.scaleLinear()
+        .domain(@currentMinMax[1])
+        .range([@plot.getHeight(), 0])
 
     # yAxis
     @yAxis = d3.axisLeft()
@@ -136,7 +140,7 @@ class Axes
       @yLabel = @plot.container
         .append('g')
           .attr('class', 'y scatterPlot-axis-label')
-          .attr('transform', "translate(#{@plot.margins.left}, 0)")
+          .attr('transform', "translate(#{@plot.margins.left - 15}, 0)")
         .append('text')
           .attr('transform', 'rotate(-90)')
           .attr('dx', -(@plot.height / 2) + (@plot.margins.top + @plot.margins.bottom) / 2)


### PR DESCRIPTION
I suppose this probably won't be a problem because the bug only occurs when the counts are above 100,000 but I nudged the label to the left a little. If it does become a problem I suppose we could use a solution like this: https://github.com/d3/d3-axis/blob/master/README.md#axis_tickFormat