### PR TITLE
Delete IRs of deleted events

### DIFF
--- a/methods/userEvents.coffee
+++ b/methods/userEvents.coffee
@@ -24,10 +24,15 @@ Meteor.methods
 
   deleteUserEvent: (id) ->
     if Roles.userIsInRole(Meteor.userId(), ['admin'])
-      UserEvents.update id,
+      updateOperator =
         $set:
-          deleted: true,
+          deleted: true
           deletedDate: new Date()
+      UserEvents.update id, updateOperator
+      Incidents.update {
+        userEventId: id
+        deleted: $in: [ null, false ]
+      }, updateOperator, multi: true
 
   editUserEventLastModified: (id) ->
     user = Meteor.user()

--- a/server/startup.coffee
+++ b/server/startup.coffee
@@ -61,3 +61,10 @@ Meteor.startup ->
     if disease
       Incidents.update incident._id,
         $set: disease: disease
+
+  # Soft delete incident reports of deleted user events
+  UserEvents.find({deleted: true}, {fields: _id:1}).forEach (event) ->
+    Incidents.update {userEventId: event._id, deleted: {$in: [null, false]}},
+      $set:
+        deleted: true
+        deletedDate: new Date()


### PR DESCRIPTION
This soft deletes IRs associated with deleted user events and deletes them when a user event is deleted to prevent these IRs showing with smart events.