### PR TITLE
Update axes when plot data is updated

### DIFF
--- a/imports/charts/ScatterPlot.coffee
+++ b/imports/charts/ScatterPlot.coffee
@@ -71,6 +71,9 @@ class ScatterPlot extends Plot
   ###
   draw: (data) ->
     super(data)
+    # if plot is not zoomed update the axes
+    unless @isZoomed()
+      @axes.update(@getGroupsNodes())
     groups = @groups.selectAll('.group').data(@getGroups(), (d) -> d.id)
     # create
     groups.enter().append((group) -> group.detached())
@@ -122,5 +125,10 @@ class ScatterPlot extends Plot
     if @zoom
       @zoom.reset()
 
+  ###
+  # resetZoom - Checks zoomArea and returns 0 if no current area selected
+  ###
+  isZoomed: ->
+    _.compact(_.values(@zoom.zoomArea)).length
 
 module.exports = ScatterPlot

--- a/imports/charts/Zoom.coffee
+++ b/imports/charts/Zoom.coffee
@@ -16,9 +16,9 @@ class Zoom
 
     @bandPos = [-1, -1];
     @zoomArea =
-      x1: 0,
-      y1: 0,
-      x2: 0,
+      x1: 0
+      y1: 0
+      x2: 0
       y2: 0
     @drag = d3.drag();
     @zoomGroup = plot.container.append('g').attr('class', 'scatterPlot-zoom')
@@ -122,8 +122,19 @@ class Zoom
   # resetZoom - reset the plot zoom back to the original viewBox
   ###
   reset: () ->
+    @resetZoomArea()
     @plot.axes.reset()
     @plot.draw()
+
+  ###
+  # resetZoomArea - Set all zoomArea properties to 0
+  ###
+  resetZoomArea: ->
+    @zoomArea =
+      x1: 0
+      y1: 0
+      x2: 0
+      y2: 0
 
   ###
   # remove - remove the zoom interface from a plot


### PR DESCRIPTION
Fix for [this bug](https://www.pivotaltracker.com/story/show/140577847).
The yMax of the y-axis was not being updated when the data changed (e.g. when the cumulative button was toggled). Now when the plot us updated, the axes are as well. 