### PR TITLE
Curator inbox get article enhancements

### DIFF
--- a/client/controllers/curatorInbox/curatorInbox.coffee
+++ b/client/controllers/curatorInbox/curatorInbox.coffee
@@ -100,7 +100,6 @@ Template.curatorInbox.onRendered ->
         console.log(err)
         return toastr.error(err.reason)
 
-
     calendar = $('#date-picker').data('daterangepicker')
     if calendar
       updateCalendarSelection(calendar, range)

--- a/client/controllers/curatorInbox/curatorSourceDetails.coffee
+++ b/client/controllers/curatorInbox/curatorSourceDetails.coffee
@@ -46,30 +46,33 @@ Template.curatorSourceDetails.onRendered ->
       swippablePane.on 'swiperight', (event) ->
         instance.data.currentPaneInView.set('')
 
-  @autorun =>
-    title = instance.source.get()?.title
-    Meteor.defer =>
-      $title = $('#sourceDetailsTitle')
-      titleEl = $title[0]
-      # Remove title and tooltip if the title is complete & without ellipsis
-      if titleEl.offsetWidth >= titleEl.scrollWidth
-        $title.tooltip('hide').attr('data-original-title', '')
-      else
-        $title.attr('data-original-title', title)
-
   # Create key binding which marks sources as reviewed.
   key 'ctrl + enter, command + enter', (event) =>
     _markReviewed(@)
 
   @autorun =>
+    # When source is selected in the curatorInbox template, `selectedSourceId`,
+    # which is handed down, is updated and triggers this autorun
+    # current source
     sourceId = @data.selectedSourceId.get()
     _getSource(@, sourceId)
 
   @autorun =>
     source = @source.get()
-    @incidentsLoaded.set(false)
-    sourceId = source._sourceId
     if source
+      @incidentsLoaded.set(false)
+      title = source.title
+      sourceId = source._sourceId
+      # Update the source title and its tooltip in the right pane
+      Meteor.defer =>
+        $title = $('#sourceDetailsTitle')
+        titleEl = $title[0]
+        # Remove title and tooltip if the title is complete & without ellipsis
+        if titleEl.offsetWidth >= titleEl.scrollWidth
+          $title.tooltip('hide').attr('data-original-title', '')
+        else
+          $title.attr('data-original-title', title)
+
       @subscribe 'curatorSourceIncidentReports', sourceId,
         onReady: =>
           source.url = "http://www.promedmail.org/post/#{sourceId}"

--- a/client/controllers/curatorInbox/curatorSourceDetails.coffee
+++ b/client/controllers/curatorInbox/curatorSourceDetails.coffee
@@ -78,10 +78,14 @@ Template.curatorSourceDetails.onRendered ->
           else
             Meteor.call 'getArticleEnhancements', source, (error, enhancements) =>
               if error
-                console.log error
+                notify('error', error.reason)
               else
-                Meteor.call 'addIncidentReportsFromEnhancement', enhancements,
-                            source, null, true, (error, result) ->
+                options =
+                  enhancements: enhancements
+                  source: source
+                  acceptByDefault: true
+                  addToCollection: true
+                Meteor.call 'createIncidentReportsFromEnhancements', options, (error, result) =>
                   @incidentsLoaded.set(true)
 
 Template.curatorSourceDetails.helpers

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -91,14 +91,14 @@ Template.suggestedIncidentsModal.onCreated ->
     currentModal:
       element: '#suggestedIncidentsModal'
 
+Template.suggestedIncidentsModal.onRendered ->
   article = @data.article
-  Meteor.call 'getArticleEnhancements', article, (error, result) =>
+  Meteor.call 'getArticleEnhancements', article, (error, enhancements) =>
     if error
       Modal.hide(@)
       toastr.error error.reason
       return
-    Meteor.call 'addIncidentReportsFromEnhancement', result, article,
-                @incidentCollection, @data.acceptByDefault, (error, result) =>
+    Meteor.call 'addIncidentReportsFromEnhancement', enhancements, article, @incidentCollection, @data.acceptByDefault, (error, result) =>
       if error
         notify('error', error.reason)
         return

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -4,69 +4,6 @@ Constants = require '/imports/constants.coffee'
 { notify } = require('/imports/ui/notification')
 { stageModals } = require('/imports/ui/modals')
 
-# A annotation's territory is the sentence containing it,
-# and all the following sentences until the next annotation.
-# Annotations in the same sentence are grouped.
-getTerritories = (annotationsWithOffsets, sents) ->
-  # Split annotations with multiple offsets
-  # and sort by offset.
-  annotationsWithSingleOffsets = []
-  annotationsWithOffsets.forEach (annotation)->
-    annotation.textOffsets.forEach (textOffset)->
-      splitAnnotation = Object.create(annotation)
-      splitAnnotation.textOffsets = [textOffset]
-      annotationsWithSingleOffsets.push(splitAnnotation)
-  annotationsWithOffsets = _.sortBy(annotationsWithSingleOffsets, (annotation)->
-    annotation.textOffsets[0][0]
-  )
-  annotationIdx = 0
-  sentStart = 0
-  sentEnd = 0
-  territories = []
-  sents.forEach (sent) ->
-    sentStart = sentEnd
-    sentEnd = sentEnd + sent.length
-    sentAnnotations = []
-    while annotation = annotationsWithOffsets[annotationIdx]
-      [aStart, aEnd] = annotation.textOffsets[0]
-      if aStart > sentEnd
-        break
-      else
-        sentAnnotations.push annotation
-        annotationIdx++
-    if sentAnnotations.length > 0 or territories.length == 0
-      territories.push
-        annotations: sentAnnotations
-        territoryStart: sentStart
-        territoryEnd: sentEnd
-    else
-      territories[territories.length - 1].territoryEnd = sentEnd
-  return territories
-
-# Parse text into an array of sentences separated by
-# periods, colons, semi-colons, or double linebreaks.
-parseSents = (text)->
-  idx = 0
-  sents = []
-  sentStart = 0
-  while idx < text.length
-    char = text[idx]
-    if char == '\n'
-      [match] = text.slice(idx).match(/^\n+/)
-      idx += match.length
-      if match.length > 1
-        sents[sents.length] = text.slice(sentStart, idx)
-        sentStart = idx
-    else if /^[\.\;\:]/.test(char)
-      idx++
-      sents[sents.length] = text.slice(sentStart, idx)
-      sentStart = idx
-    else
-      idx++
-  if sentStart < idx
-    sents[sents.length] = text.slice(sentStart, idx)
-  return sents
-
 # determines if the user should be prompted before leaving the current modal
 #
 # @param {object} event, the DOM event
@@ -154,172 +91,20 @@ Template.suggestedIncidentsModal.onCreated ->
     currentModal:
       element: '#suggestedIncidentsModal'
 
-  Meteor.call('getArticleEnhancements', @data.article, (error, result) =>
+  article = @data.article
+  Meteor.call 'getArticleEnhancements', article, (error, result) =>
     if error
       Modal.hide(@)
       toastr.error error.reason
       return
-    locationAnnotations = result.features.filter (f) -> f.type == 'location'
-    datetimeAnnotations = result.features.filter (f) -> f.type == 'datetime'
-    diseaseAnnotations = result.features.filter (f) -> f.type == 'diseases'
-    countAnnotations = result.features.filter (f) -> f.type == 'count'
-    geonameIds = locationAnnotations.map((r) -> r.geoname.geonameid)
-    # Query geoname lookup service to get admin names.
-    # The GRITS api reponse only includes admin codes.
-    new Promise((resolve, reject) =>
-      if geonameIds.length == 0
-        resolve([])
+    Meteor.call 'addIncidentReportsFromEnhancement', result, article,
+                @incidentCollection, @data.acceptByDefault, (error, result) =>
+      if error
+        notify('error', error.reason)
+        return
       else
-        HTTP.get(Constants.GRITS_URL + '/api/geoname_lookup/api/geonames', {
-          params:
-            ids: geonameIds
-        }, (error, geonamesResult) =>
-          if error
-            toastr.error error.reason
-            Modal.hide(@)
-            reject()
-          else
-            resolve(geonamesResult.data.docs)
-        )
-    ).then((locations) =>
-      geonamesById = {}
-      locations.forEach (loc) ->
-        geonamesById[loc.id] =
-          id: loc.id
-          name: loc.name
-          admin1Name: loc.admin1Name
-          admin2Name: loc.admin2Name
-          latitude: parseFloat(loc.latitude)
-          longitude: parseFloat(loc.longitude)
-          countryName: loc.countryName
-          population: loc.population
-          featureClass: loc.featureClass
-          featureCode: loc.featureCode
-          alternateNames: loc.alternateNames
-      @loading.set(false)
-      @content.set result.source.cleanContent.content
-      sents = parseSents(result.source.cleanContent.content)
-      locTerritories = getTerritories(locationAnnotations, sents)
-      datetimeAnnotations = datetimeAnnotations
-        .map (timeAnnotation) =>
-          if not (timeAnnotation.timeRange and
-            timeAnnotation.timeRange.begin and
-            timeAnnotation.timeRange.end
-          )
-            return
-          # moment parses 0 based month indecies
-          if timeAnnotation.timeRange.begin.month
-            timeAnnotation.timeRange.begin.month--
-          if timeAnnotation.timeRange.end.month
-            timeAnnotation.timeRange.end.month--
-          timeAnnotation.precision = (
-            Object.keys(timeAnnotation.timeRange.end).length +
-            Object.keys(timeAnnotation.timeRange.end).length
-          )
-          timeAnnotation.beginMoment = moment.utc(
-            timeAnnotation.timeRange.begin
-          )
-          # Round up the to day end
-          timeAnnotation.endMoment = moment.utc(
-            timeAnnotation.timeRange.end
-          ).endOf('day')
-          publishMoment = moment.utc(@data.article.publishDate)
-          if timeAnnotation.beginMoment.isAfter publishMoment, 'day'
-            # Omit future dates
-            return
-          if timeAnnotation.endMoment.isAfter publishMoment, 'day'
-            # Truncate ranges that extend into the future
-            timeAnnotation.endMoment = publishMoment
-          return timeAnnotation
-        .filter (x) -> x
-      dateTerritories = getTerritories(datetimeAnnotations, sents)
-      diseaseTerritories = getTerritories(diseaseAnnotations, sents)
-      countAnnotations.forEach((countAnnotation) =>
-        [start, end] = countAnnotation.textOffsets[0]
-        locationTerritory = _.find locTerritories, ({territoryStart, territoryEnd}) ->
-          return (start <= territoryEnd and start >= territoryStart)
-        dateTerritory = _.find dateTerritories, ({territoryStart, territoryEnd}) ->
-          return (start <= territoryEnd and start >= territoryStart)
-        diseaseTerritory = _.find diseaseTerritories, ({territoryStart, territoryEnd}) ->
-          return (start <= territoryEnd and start >= territoryStart)
-        incident =
-          locations: locationTerritory.annotations.map(({geoname}) ->
-            geonamesById[geoname.geonameid]
-          )
-        maxPrecision = 0
-        # Use the article's date as the default
-        incident.dateRange =
-          start: @data.article.publishDate
-          end: moment(@data.article.publishDate).add(1, 'day')
-          type: 'day'
-        dateTerritory.annotations.forEach (timeAnnotation)->
-          if (timeAnnotation.precision > maxPrecision and
-            timeAnnotation.beginMoment.isValid() and
-            timeAnnotation.endMoment.isValid()
-          )
-            maxPrecision = timeAnnotation.precision
-            incident.dateRange =
-              start: timeAnnotation.beginMoment.toDate()
-              end: timeAnnotation.endMoment.toDate()
-            rangeHours = moment(incident.dateRange.end)
-              .diff(incident.dateRange.start, 'hours')
-            if rangeHours <= 24
-              incident.dateRange.type = 'day'
-            else
-              incident.dateRange.type = 'precise'
-        incident.dateTerritory = dateTerritory
-        incident.locationTerritory = locationTerritory
-        incident.diseaseTerritory = diseaseTerritory
-        incident.countAnnotation = countAnnotation
-        { count, attributes } = countAnnotation
-        if 'death' in attributes
-          incident.deaths = count
-        else if "case" in attributes or "hospitalization" in attributes
-          incident.cases = count
-        else
-          incident.cases = count
-          incident.uncertainCountType = true
-        if @data.acceptByDefault and not incident.uncertainCountType
-          incident.accepted = true
-        # Detect whether count is cumulative
-        if 'incremental' in attributes
-          incident.dateRange.cumulative = false
-        else if 'cumulative' in attributes
-          incident.dateRange.cumulative = true
-        else if incident.dateRange.type == 'day' and count > 300
-          incident.dateRange.cumulative = true
-        suspectedAttributes = _.intersection([
-          'approximate', 'average', 'suspected'
-        ], attributes)
-        if suspectedAttributes.length > 0
-          incident.status = 'suspected'
-        incident.url = [@data.article.url]
-        # The disease field is set to the last disease mentioned,
-        # document classification, or event disease with overides in that order.
-        event = UserEvents.findOne(@data.article?.userEventId)
-        if event?.disease
-          incident.disease = event.disease
-        result.diseases.forEach ({name})->
-          incident.disease = name
-        diseaseTerritory.annotations.forEach ({value})->
-          incident.disease = value
-        incident.suggestedFields = _.intersection(
-          Object.keys(incident),
-          [
-            'disease'
-            'cases'
-            'deaths'
-            'dateRange'
-            'status'
-            if incident.locations.length then 'locations'
-          ]
-        )
-        if incident.dateRange?.cumulative
-          incident.suggestedFields.push('cumulative')
-        @incidentCollection.insert(incident)
-      )
-    )
-  )
+        @loading.set(false)
+        @content.set(result)
 
 Template.suggestedIncidentsModal.onRendered ->
   instance = @

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -92,24 +92,29 @@ Template.suggestedIncidentsModal.onCreated ->
       element: '#suggestedIncidentsModal'
 
 Template.suggestedIncidentsModal.onRendered ->
-  article = @data.article
-  Meteor.call 'getArticleEnhancements', article, (error, enhancements) =>
+  $('#event-source').on 'hidden.bs.modal', ->
+    $('body').addClass('modal-open')
+
+  source = @data.article
+  Meteor.call 'getArticleEnhancements', source, (error, enhancements) =>
     if error
       Modal.hide(@)
       toastr.error error.reason
       return
-    Meteor.call 'addIncidentReportsFromEnhancement', enhancements, article, @incidentCollection, @data.acceptByDefault, (error, result) =>
+    options =
+      enhancements: enhancements
+      source: source
+      acceptByDefault: @data.acceptByDefault
+      addToCollection: false
+    Meteor.call 'createIncidentReportsFromEnhancements', options, (error, result) =>
       if error
         notify('error', error.reason)
         return
       else
+        for incident in result.incidents
+          @incidentCollection.insert(incident)
         @loading.set(false)
-        @content.set(result)
-
-Template.suggestedIncidentsModal.onRendered ->
-  instance = @
-  $('#event-source').on 'hidden.bs.modal', ->
-    $('body').addClass('modal-open')
+        @content.set(result.content)
 
 Template.suggestedIncidentsModal.onDestroyed ->
   $('#suggestedIncidentsModal').off('hide.bs.modal')

--- a/client/controllers/notification.coffee
+++ b/client/controllers/notification.coffee
@@ -21,6 +21,6 @@ Template.notification.helpers
   icon: ->
     switch @type
       when 'success' then 'check-circle'
-      when 'failure', 'warning' then 'exclamation-triangle'
+      when 'failure', 'warning', 'error' then 'exclamation-triangle'
   active: ->
     Template.instance().active?.get()

--- a/client/views/curatorInbox/curatorSourceDetails.jade
+++ b/client/views/curatorInbox/curatorSourceDetails.jade
@@ -20,8 +20,11 @@ template(name="curatorSourceDetails")
           p Preparing next source
       .transition(class="{{#if notifying}} active {{/if}}")
     .curator-source-details-content
-      .curator-source-details-copy-wrapper
-        .curator-source-details-copy= content
-      +curatorEvents selectedSourceId=selectedSourceId
-      if notifying
-        .veil
+      if incidentsLoaded
+        .curator-source-details-copy-wrapper
+          .curator-source-details-copy= content
+        +curatorEvents selectedSourceId=selectedSourceId
+        if notifying
+          .veil
+      else
+        +loading message="Processing Source"

--- a/imports/schemas/incidentReport.coffee
+++ b/imports/schemas/incidentReport.coffee
@@ -25,6 +25,7 @@ IncidentReportSchema = new SimpleSchema
     optional: true
   locations:
     type: [Object]
+    optional: true
   userEventId:
     type: String
     optional: true

--- a/imports/schemas/incidentReport.coffee
+++ b/imports/schemas/incidentReport.coffee
@@ -25,18 +25,21 @@ IncidentReportSchema = new SimpleSchema
     optional: true
   locations:
     type: [Object]
-    minCount: 1
   userEventId:
     type: String
+    optional: true
   dateRange:
     type: Object
   "dateRange.type":
     type: String
     allowedValues: ["day","precise"]
+    optional: true
   "dateRange.start":
     type: Date
+    optional: true
   "dateRange.end":
     type: Date
+    optional: true
   "dateRange.cumulative":
     type: Boolean
     optional: true

--- a/methods/incidentReports.coffee
+++ b/methods/incidentReports.coffee
@@ -1,5 +1,71 @@
 incidentReportSchema = require '/imports/schemas/incidentReport.coffee'
 Incidents = require '/imports/collections/incidentReports.coffee'
+UserEvents = require '/imports/collections/userEvents.coffee'
+Constants = require '/imports/constants.coffee'
+
+# A annotation's territory is the sentence containing it,
+# and all the following sentences until the next annotation.
+# Annotations in the same sentence are grouped.
+getTerritories = (annotationsWithOffsets, sents) ->
+  # Split annotations with multiple offsets
+  # and sort by offset.
+  annotationsWithSingleOffsets = []
+  annotationsWithOffsets.forEach (annotation)->
+    annotation.textOffsets.forEach (textOffset)->
+      splitAnnotation = Object.create(annotation)
+      splitAnnotation.textOffsets = [textOffset]
+      annotationsWithSingleOffsets.push(splitAnnotation)
+  annotationsWithOffsets = _.sortBy(annotationsWithSingleOffsets, (annotation)->
+    annotation.textOffsets[0][0]
+  )
+  annotationIdx = 0
+  sentStart = 0
+  sentEnd = 0
+  territories = []
+  sents.forEach (sent) ->
+    sentStart = sentEnd
+    sentEnd = sentEnd + sent.length
+    sentAnnotations = []
+    while annotation = annotationsWithOffsets[annotationIdx]
+      [aStart, aEnd] = annotation.textOffsets[0]
+      if aStart > sentEnd
+        break
+      else
+        sentAnnotations.push annotation
+        annotationIdx++
+    if sentAnnotations.length > 0 or territories.length == 0
+      territories.push
+        annotations: sentAnnotations
+        territoryStart: sentStart
+        territoryEnd: sentEnd
+    else
+      territories[territories.length - 1].territoryEnd = sentEnd
+  return territories
+
+# Parse text into an array of sentences separated by
+# periods, colons, semi-colons, or double linebreaks.
+parseSents = (text)->
+  idx = 0
+  sents = []
+  sentStart = 0
+  while idx < text.length
+    char = text[idx]
+    if char == '\n'
+      [match] = text.slice(idx).match(/^\n+/)
+      idx += match.length
+      if match.length > 1
+        sents[sents.length] = text.slice(sentStart, idx)
+        sentStart = idx
+    else if /^[\.\;\:]/.test(char)
+      idx++
+      sents[sents.length] = text.slice(sentStart, idx)
+      sentStart = idx
+    else
+      idx++
+  if sentStart < idx
+    sents[sents.length] = text.slice(sentStart, idx)
+  return sents
+
 
 Meteor.methods
   addIncidentReport: (incident) ->
@@ -11,8 +77,8 @@ Meteor.methods
     incident.addedByUserName = user.profile.name
     incident.addedDate = new Date()
     newId = Incidents.insert(incident)
-    Meteor.call("editUserEventLastModified", incident.userEventId)
-    Meteor.call("editUserEventLastIncidentDate", incident.userEventId)
+    # Meteor.call("editUserEventLastModified", incident.userEventId)
+    # Meteor.call("editUserEventLastIncidentDate", incident.userEventId)
     return newId
 
   editIncidentReport: (incident) ->
@@ -39,3 +105,166 @@ Meteor.methods
         deletedDate: new Date()
     Meteor.call("editUserEventLastModified", incident.userEventId)
     Meteor.call("editUserEventLastIncidentDate", incident.userEventId)
+
+  addIncidentReportsFromEnhancement: (enhancements, article, collection, acceptByDefault) ->
+    features = enhancements.features
+    locationAnnotations = features.filter (f) -> f.type == 'location'
+    datetimeAnnotations = features.filter (f) -> f.type == 'datetime'
+    diseaseAnnotations = features.filter (f) -> f.type == 'diseases'
+    countAnnotations = features.filter (f) -> f.type == 'count'
+    geonameIds = locationAnnotations.map((r) -> r.geoname.geonameid)
+    # Query geoname lookup service to get admin names.
+    # The GRITS api reponse only includes admin codes.
+    new Promise((resolve, reject) =>
+      if geonameIds.length == 0
+        resolve([])
+      else
+        HTTP.get Constants.GRITS_URL + '/api/geoname_lookup/api/geonames', {
+          params:
+            ids: geonameIds
+        }, (error, geonamesResult) =>
+          if error
+            toastr.error error.reason
+            Modal.hide(@)
+            reject()
+          else
+            resolve(geonamesResult.data.docs)
+    ).then (locations) =>
+      geonamesById = {}
+      locations.forEach (loc) ->
+        geonamesById[loc.id] =
+          id: loc.id
+          name: loc.name
+          admin1Name: loc.admin1Name
+          admin2Name: loc.admin2Name
+          latitude: parseFloat(loc.latitude)
+          longitude: parseFloat(loc.longitude)
+          countryName: loc.countryName
+          population: loc.population
+          featureClass: loc.featureClass
+          featureCode: loc.featureCode
+          alternateNames: loc.alternateNames
+      sents = parseSents(enhancements.source.cleanContent.content)
+      locTerritories = getTerritories(locationAnnotations, sents)
+      datetimeAnnotations = datetimeAnnotations
+        .map (timeAnnotation) =>
+          if not (timeAnnotation.timeRange and
+            timeAnnotation.timeRange.begin and
+            timeAnnotation.timeRange.end
+          )
+            return
+          # moment parses 0 based month indecies
+          if timeAnnotation.timeRange.begin.month
+            timeAnnotation.timeRange.begin.month--
+          if timeAnnotation.timeRange.end.month
+            timeAnnotation.timeRange.end.month--
+          timeAnnotation.precision = (
+            Object.keys(timeAnnotation.timeRange.end).length +
+            Object.keys(timeAnnotation.timeRange.end).length
+          )
+          timeAnnotation.beginMoment = moment.utc(
+            timeAnnotation.timeRange.begin
+          )
+          # Round up the to day end
+          timeAnnotation.endMoment = moment.utc(
+            timeAnnotation.timeRange.end
+          ).endOf('day')
+          publishMoment = moment.utc(article.publishDate)
+          if timeAnnotation.beginMoment.isAfter publishMoment, 'day'
+            # Omit future dates
+            return
+          if timeAnnotation.endMoment.isAfter publishMoment, 'day'
+            # Truncate ranges that extend into the future
+            timeAnnotation.endMoment = publishMoment
+          return timeAnnotation
+        .filter (x) -> x
+      dateTerritories = getTerritories(datetimeAnnotations, sents)
+      diseaseTerritories = getTerritories(diseaseAnnotations, sents)
+      countAnnotations.forEach (countAnnotation) =>
+        [start, end] = countAnnotation.textOffsets[0]
+        locationTerritory = _.find locTerritories, ({territoryStart, territoryEnd}) ->
+          return (start <= territoryEnd and start >= territoryStart)
+        dateTerritory = _.find dateTerritories, ({territoryStart, territoryEnd}) ->
+          return (start <= territoryEnd and start >= territoryStart)
+        diseaseTerritory = _.find diseaseTerritories, ({territoryStart, territoryEnd}) ->
+          return (start <= territoryEnd and start >= territoryStart)
+        incident =
+          locations: locationTerritory.annotations.map(({geoname}) ->
+            geonamesById[geoname.geonameid]
+          )
+        maxPrecision = 0
+        # Use the article's date as the default
+        incident.dateRange =
+          start: article.publishDate
+          end: moment(article.publishDate).add(1, 'day')
+          type: 'day'
+        dateTerritory.annotations.forEach (timeAnnotation)->
+          if (timeAnnotation.precision > maxPrecision and
+            timeAnnotation.beginMoment.isValid() and
+            timeAnnotation.endMoment.isValid()
+          )
+            maxPrecision = timeAnnotation.precision
+            incident.dateRange =
+              start: timeAnnotation.beginMoment.toDate()
+              end: timeAnnotation.endMoment.toDate()
+            rangeHours = moment(incident.dateRange.end)
+              .diff(incident.dateRange.start, 'hours')
+            if rangeHours <= 24
+              incident.dateRange.type = 'day'
+            else
+              incident.dateRange.type = 'precise'
+        incident.dateTerritory = dateTerritory
+        incident.locationTerritory = locationTerritory
+        incident.diseaseTerritory = diseaseTerritory
+        incident.countAnnotation = countAnnotation
+        { count, attributes } = countAnnotation
+        if 'death' in attributes
+          incident.deaths = count
+        else if "case" in attributes or "hospitalization" in attributes
+          incident.cases = count
+        else
+          incident.cases = count
+          incident.uncertainCountType = true
+        if acceptByDefault and not incident.uncertainCountType
+          incident.accepted = true
+        # Detect whether count is cumulative
+        if 'incremental' in attributes
+          incident.dateRange.cumulative = false
+        else if 'cumulative' in attributes
+          incident.dateRange.cumulative = true
+        else if incident.dateRange.type == 'day' and count > 300
+          incident.dateRange.cumulative = true
+        suspectedAttributes = _.intersection([
+          'approximate', 'average', 'suspected'
+        ], attributes)
+        if suspectedAttributes.length > 0
+          incident.status = 'suspected'
+        incident.url = [article.url]
+        # The disease field is set to the last disease mentioned,
+        # document classification, or event disease with overides in that order.
+        event = UserEvents.findOne(article?.userEventId)
+        if event?.disease
+          incident.disease = event.disease
+        enhancements.diseases.forEach ({name})->
+          incident.disease = name
+        diseaseTerritory.annotations.forEach ({value})->
+          incident.disease = value
+        incident.suggestedFields = _.intersection(
+          Object.keys(incident),
+          [
+            'disease'
+            'cases'
+            'deaths'
+            'dateRange'
+            'status'
+            if incident.locations.length then 'locations'
+          ]
+        )
+        if incident.dateRange?.cumulative
+          incident.suggestedFields.push('cumulative')
+        if collection
+          collection.insert(incident)
+        else
+          _incident = _.pick(incident, incidentReportSchema.objectKeys())
+          Meteor.call('addIncidentReport', _incident)
+      enhancements.source.cleanContent.content

--- a/methods/incidentReports.coffee
+++ b/methods/incidentReports.coffee
@@ -196,7 +196,7 @@ Meteor.methods
         # Use the article's date as the default
         incident.dateRange =
           start: article.publishDate
-          end: moment(article.publishDate).add(1, 'day')
+          end: moment(article.publishDate).add(1, 'day').toDate()
           type: 'day'
         dateTerritory.annotations.forEach (timeAnnotation)->
           if (timeAnnotation.precision > maxPrecision and

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -47,6 +47,8 @@ Meteor.publish 'curatorSources', (query) ->
     sort:
       publishDate: -1
   })
+Meteor.publish 'curatorSourceIncidentReports', (sourceId) ->
+  Incidents.find('url.0': $regex: new RegExp("#{sourceId}$"))
 
 Meteor.publish 'eventArticles', (ueId) ->
   Articles.find(


### PR DESCRIPTION
[PT Story](https://www.pivotaltracker.com/story/show/141164735)

Looks like there is currently no automated process for getting articles from ProMed—they are fetched when the inbox is loaded and added to the `CuratorSources` collection. So to move this along quickly, I've updated the inbox to process articles when they are clicked. The resulting incident reports are added to the collection (I made some fields in the schema optional since now some IRs may not have certain properties). The resulting UX is not really ideal because, I think, the processing time is a little too long for the user to wait. So we should think about automating this in the future.
I moved the logic associated with creating IRs from enhancements to a Meteor method so we can call it from multiple areas.
**This does not make the updates to the IR schema which track status.**