### PR TITLE
Change ir url to string

### DIFF
--- a/.promed-post-enhancer/app.js
+++ b/.promed-post-enhancer/app.js
@@ -135,7 +135,7 @@ const enhance = (target)=>{
     })
     .date(a => new Date(a.publishDate))
     .click(showTooltip);
-    
+
     $(document).click((evt)=>{
       if(evt.target.matches(".drop")) return;
       if(!$(evt.target).closest('.tooltip').length) hideTooltip();

--- a/client/controllers/curatorInbox/curatorSourceDetails.coffee
+++ b/client/controllers/curatorInbox/curatorSourceDetails.coffee
@@ -77,7 +77,7 @@ Template.curatorSourceDetails.onRendered ->
         onReady: =>
           source.url = "http://www.promedmail.org/post/#{sourceId}"
           @incidentCollection = new Meteor.Collection(null)
-          if Incidents.findOne('url.0': $regex: new RegExp("#{sourceId}$"))
+          if Incidents.findOne(url: $regex: new RegExp("#{sourceId}$"))
             for incident in Incidents.find().fetch()
               @incidentCollection.insert(incident)
             @incidentsLoaded.set(true)

--- a/client/controllers/incidentReports/incidentForm.coffee
+++ b/client/controllers/incidentReports/incidentForm.coffee
@@ -46,7 +46,7 @@ Template.incidentForm.onCreated ->
 
     @incidentType.set(type)
 
-    url = @incidentData.url[0]
+    url = @incidentData.url
     if url
       @incidentData.articleSource = _.findWhere(@data.articles,
         url: url

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -219,7 +219,7 @@ Template.suggestedIncidentsModal.events
       userEventId: instance.data.userEventId
       add: true
       incident:
-        url: [instance.data.article.url]
+        url: instance.data.article.url
       offCanvas: 'right'
 
   'click #save-csv': (event, instance) ->

--- a/client/views/incidentReports/incidentReport.jade
+++ b/client/views/incidentReports/incidentReport.jade
@@ -45,11 +45,8 @@ template(name="incidentReport")
             span {{formatDateRange(dateRange)}}
           li.container-flex.no-break
             h6.metadata--title Source:
-            ul.list-unstyled
-              each val in url
-                li
-                  a.ref-link(href="{{formatUrl(val)}}" target="_blank")
-                    span {{formatUrl(val)}}
+            a.ref-link(href="{{formatUrl(url)}}" target="_blank")
+              span {{formatUrl(url)}}
           ul.integrity.metadata.list-unstyled
             if dateRange.cumulative
               li

--- a/imports/schemas/incidentReport.coffee
+++ b/imports/schemas/incidentReport.coffee
@@ -3,7 +3,7 @@ IncidentReportSchema = new SimpleSchema
     type: String
     optional: true
   url:
-    type: [String]
+    type: String
     label: "Source the incident is based on"
   addedByUserName:
     type: String

--- a/methods/articles.coffee
+++ b/methods/articles.coffee
@@ -4,7 +4,7 @@ Meteor.methods
   addEventSource: (source) -> #eventId, url, publishDate, publishDateTZ
     user = Meteor.user()
     if user and Roles.userIsInRole(user._id, ['admin'])
-      if source.url.length
+      if source.url
         insertArticle =
           url: source.url
           title: source.title

--- a/methods/incidentReports.coffee
+++ b/methods/incidentReports.coffee
@@ -244,7 +244,7 @@ Meteor.methods
         ], attributes)
         if suspectedAttributes.length > 0
           incident.status = 'suspected'
-        incident.url = [source.url]
+        incident.url = source.url
         # The disease field is set to the last disease mentioned,
         # document classification, or event disease with overides in that order.
         event = UserEvents.findOne(source?.userEventId)

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -48,7 +48,7 @@ Meteor.publish 'curatorSources', (query) ->
       publishDate: -1
   })
 Meteor.publish 'curatorSourceIncidentReports', (sourceId) ->
-  Incidents.find('url.0': $regex: new RegExp("#{sourceId}$"))
+  Incidents.find(url: $regex: new RegExp("#{sourceId}$"))
 
 Meteor.publish 'eventArticles', (ueId) ->
   Articles.find(

--- a/server/startup.coffee
+++ b/server/startup.coffee
@@ -68,3 +68,8 @@ Meteor.startup ->
       $set:
         deleted: true
         deletedDate: new Date()
+
+  # Store urls on incident reports as strings rather than arrays
+  Incidents.find('url.0': {$exists: true}).forEach (incident) ->
+    Incidents.update _id: incident._id,
+      $set: url: incident.url[0]


### PR DESCRIPTION
Updates the schema of Incident Reports—changes the `url` property from an array to a string.
Updates existing IRs in database and areas were the url is referenced, updated or presented.
[PT Chore](https://www.pivotaltracker.com/story/show/141256773)