### PR TITLE
Implement IR editing in curator inbox

### DIFF
--- a/client/controllers/incidentReports/incidentForm.coffee
+++ b/client/controllers/incidentReports/incidentForm.coffee
@@ -110,7 +110,7 @@ Template.incidentForm.helpers
       when 'deaths' then 'Death'
 
   suggestedField: (fieldName)->
-    if fieldName in Template.instance().suggestedFields.get()
+    if fieldName in Template.instance().suggestedFields?.get()
       'suggested'
 
   typeIsSelected: ->

--- a/client/controllers/incidentReports/incidentModal.coffee
+++ b/client/controllers/incidentReports/incidentModal.coffee
@@ -47,6 +47,9 @@ Template.incidentModal.events
     incident = utils.incidentReportFormToIncident(form)
     instanceData = instance.data
 
+    updateEvent = instanceData.updateEvent
+    updateEvent ?= true
+
     if not incident
       return
     incident.userEventId = instanceData.userEventId
@@ -74,7 +77,7 @@ Template.incidentModal.events
       incident.addedByUserId = @incident.addedByUserId
       incident.addedByUserName = @incident.addedByUserName
       incident.addedDate = @incident.addedDate
-      Meteor.call 'editIncidentReport', incident, (error, result) ->
+      Meteor.call 'editIncidentReport', incident, updateEvent, (error, result) ->
         if not error
           $('.reactive-table tr').removeClass('open')
           $('.reactive-table tr.details').remove()

--- a/client/controllers/incidentReports/incidentTable.coffee
+++ b/client/controllers/incidentReports/incidentTable.coffee
@@ -82,3 +82,13 @@ Template.incidentTable.events
     if not instance.data.scrollToAnnotations
       return
     instance.stopScrollingInterval()
+
+  'click .incident-table tbody tr': (event, instance) ->
+    event.stopPropagation()
+    source = instance.data.source
+    Modal.show 'incidentModal',
+      articles: [source]
+      userEventId: null
+      edit: true
+      incident: @
+      updateEvent: false

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -122,7 +122,10 @@ Template.suggestedIncidentsModal.onDestroyed ->
 
 Template.suggestedIncidentsModal.helpers
   showTable: ->
-    Template.instance().data.showTable
+    incidents = Template.instance().incidentCollection.find
+      accepted: true
+      specify: $exists: false
+    Template.instance().data.showTable and incidents.count()
 
   incidents: ->
     Template.instance().incidentCollection.find

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -23,7 +23,7 @@ confirmAbandonChanges = (event, instance) ->
     true
 
 showSuggestedIncidentModal = (event, instance)->
-  incident = instance.incidentCollection.findOne($(event.target).data("incident-id"))
+  incident = instance.incidentCollection.findOne($(event.currentTarget).data("incident-id"))
   content = Template.instance().content.get()
   displayCharacters = 150
   incidentAnnotations = [incident.countAnnotation]
@@ -216,7 +216,8 @@ Template.suggestedIncidentsModal.events
     if table.length
       table.tableExport(type: fileType)
 
-  'click .count': (event, instance) ->
+  'click .incident-report': (event, instance) ->
+    sendModalOffStage(instance)
     showSuggestedIncidentModal(event, instance)
 
   'click .annotated-content': (event, instance) ->

--- a/client/views/curatorInbox/curatorSourceDetails.jade
+++ b/client/views/curatorInbox/curatorSourceDetails.jade
@@ -24,7 +24,10 @@ template(name="curatorSourceDetails")
         .curator-source-details--copy-wrapper
           .curator-source-details--copy= annotatedContent
         .curator-source-details--table
-          +incidentTable incidents=incidents scrollToAnnotations=true
+          +incidentTable(
+            incidents=incidents
+            scrollToAnnotations=true
+            source=source)
         if notifying
           .veil
       else

--- a/client/views/incidentReports/extractedIncidents.jade
+++ b/client/views/incidentReports/extractedIncidents.jade
@@ -1,0 +1,37 @@
+template(name="extractedIncidents")
+  table.table.featured.incident-table(
+    hidden=annotatedContentVisible
+    data-tableexport-display="always")
+    thead
+      tr
+        th
+        th.count-header Type
+        th.count-header Value
+        th Start Date
+        th End Date
+        th.locations-header Locations
+        th Status
+        th Species
+        th Properties
+    tbody
+      each incidents
+        tr
+          td
+            span.select(class="{{#if selected}} selected {{/if}}")
+          if cases
+            td Case Count
+            td=cases
+          else if deaths
+            td Death Count
+            td=deaths
+          else
+            td Other
+            td=specify
+          td
+            unless dateRange.cumulative
+              | {{formatDateISO dateRange.start}}
+          td {{formatDateISO dateRange.end}}
+          td {{formatLocations locations}}
+          td=status
+          td=species
+          td=incidentProperties

--- a/client/views/incidentReports/incidentForm.jade
+++ b/client/views/incidentReports/incidentForm.jade
@@ -10,9 +10,8 @@ template(name="incidentForm")
             data-placement="right"
             title="URL of the article where the incident was reported."
           ) Source URL
-          if incidentData.articleSource
-            p
-              a(href="{{formatUrl(incidentData.articleSource)}}" target="_blank")=incidentData.articleSource
+          if incident.url
+            input.form-control(readonly value=incident.url name="articleSourceUrl")
           else
             +articleSelect2(
               selectId="articleSource"

--- a/client/views/incidentReports/incidentTable.jade
+++ b/client/views/incidentReports/incidentTable.jade
@@ -8,7 +8,7 @@ template(name="incidentTable")
         | Deslect All
       else
         | Select All
-  table.table.incident-table(
+  table.table.featured.incident-table(
     hidden=annotatedContentVisible
     data-tableexport-display="always")
     thead
@@ -19,9 +19,6 @@ template(name="incidentTable")
         th Start Date
         th End Date
         th.locations-header Locations
-        th Status
-        th Species
-        th Properties
     tbody
       each incidents
         tr
@@ -29,18 +26,15 @@ template(name="incidentTable")
             span.select(class="{{#if selected}} selected {{/if}}")
           if cases
             td Case Count
-            td.count(data-incident-id=_id)=cases
+            td=cases
           else if deaths
             td Death Count
-            td.count(data-incident-id=_id)=deaths
+            td=deaths
           else
             td Other
-            td.count(data-incident-id=_id)=specify
+            td=specify
           td
             unless dateRange.cumulative
               | {{formatDateISO dateRange.start}}
           td {{formatDateISO dateRange.end}}
           td {{formatLocations locations}}
-          td=status
-          td=species
-          td=incidentProperties

--- a/client/views/incidentReports/suggestedIncidentsModal.jade
+++ b/client/views/incidentReports/suggestedIncidentsModal.jade
@@ -29,7 +29,40 @@ template(name="suggestedIncidentsModal")
                 p.annotated-content(
                   class="{{#unless incidentsFound}} space-top-4 {{/unless}}")=annotatedContent
             if showTable
-              +extractedIncidents incidents=incidents annotatedContentVisible=annotatedContentVisible
+              .extract-incidents-table
+                table.table.featured.incident-table(
+                  hidden=annotatedContentVisible
+                  data-tableexport-display="always")
+                  thead
+                    tr
+                      th.count-header Type
+                      th.count-header Value
+                      th Start Date
+                      th End Date
+                      th.locations-header Locations
+                      th Status
+                      th Species
+                      th Properties
+                  tbody
+                    each incidents
+                      tr.incident-report(data-incident-id=_id)
+                        if cases
+                          td Case Count
+                          td=cases
+                        else if deaths
+                          td Death Count
+                          td=deaths
+                        else
+                          td Other
+                          td=specify
+                        td
+                          unless dateRange.cumulative
+                            | {{formatDateISO dateRange.start}}
+                        td {{formatDateISO dateRange.end}}
+                        td {{formatLocations locations}}
+                        td=status
+                        td=species
+                        td=incidentProperties
         .modal-footer
           button.btn.btn-default.confirm-close-modal(type="button" data-dismiss="modal") Close
           if showTable

--- a/client/views/incidentReports/suggestedIncidentsModal.jade
+++ b/client/views/incidentReports/suggestedIncidentsModal.jade
@@ -29,7 +29,7 @@ template(name="suggestedIncidentsModal")
                 p.annotated-content(
                   class="{{#unless incidentsFound}} space-top-4 {{/unless}}")=annotatedContent
             if showTable
-              +incidentTable incidents=incidents annotatedContentVisible=annotatedContentVisible
+              +extractedIncidents incidents=incidents annotatedContentVisible=annotatedContentVisible
         .modal-footer
           button.btn.btn-default.confirm-close-modal(type="button" data-dismiss="modal") Close
           if showTable

--- a/imports/stylesheets/curatorInbox.import.styl
+++ b/imports/stylesheets/curatorInbox.import.styl
@@ -2,7 +2,6 @@ $header-BG = $border-primary-light
 $pane-switch-speed = .3s
 $break-point--curator-inbox--x-wide = 1500px
 
-
 .curator-heading
   color $primary
   font-weight 400

--- a/imports/stylesheets/incidents/incidents.import.styl
+++ b/imports/stylesheets/incidents/incidents.import.styl
@@ -44,7 +44,6 @@
   .modal-body
     flex 1 1 auto
     padding 0
-    gradientTopAndBottom()
   .modal-header
   .modal-footer
     flex 0 0 auto
@@ -155,6 +154,9 @@
       color $highlight
       &::before
         content '\f111' // fa-circle
+
+.extract-incidents-table
+  margin -25px
 
 .submit-page
   margin-top 30px

--- a/imports/utils.coffee
+++ b/imports/utils.coffee
@@ -79,11 +79,11 @@ export incidentReportFormToIncident = (form) ->
 
   articleSourceUrl = form.articleSourceUrl
   if articleSourceUrl
-    incident.url = [articleSourceUrl.value]
+    incident.url = articleSourceUrl.value
   else
     for child in $(form.articleSource).select2('data')
       if child.selected
-        incident.url = [child.text.trim()]
+        incident.url = child.text.trim()
 
   $loc = $(form).find('#incident-location-select2')
   for option in $loc.select2('data')


### PR DESCRIPTION
[PT Story](https://www.pivotaltracker.com/story/show/141164797)

This is currently not reactive since we are using a local collection created when the source is processed (because I wanted to ease into adding all IRs into the db — IRs are currently not added to the db in the event page flow until they are confirmed.) Maybe we update the curator inbox IR table to use the incidents collection while implementing a future story or add a chore to do so.