### PR TITLE
Highlight all annotated incident report text with yellow color

### DIFF
--- a/imports/stylesheets/incidents/incidents.import.styl
+++ b/imports/stylesheets/incidents/incidents.import.styl
@@ -1,5 +1,9 @@
 @import 'incidentForm.import'
 
+viewingBG()
+  transition background-color .5s ease-in-out
+  background-color $highlight-yellow
+
 .annotation-text
   padding-left .2em
   padding-right .2em
@@ -13,14 +17,15 @@
   cursor pointer
   background-color: $incident-type-colors.case
   &.viewing
-    transition background-color .5s ease-in-out
-    background-color $highlight-yellow
+    viewingBG()
   &:hover
     background-color darken(@background-color, 30%)
     color white
   &.uncertain
     background-color transparent
     text-decoration underline
+    &.viewing
+      viewingBG()
     &:hover
       background-color: darken($incident-type-colors.uncertain, 5%)
       color $body-text
@@ -28,6 +33,8 @@
   &.accepted
     background-color: $incident-type-colors.date
     text-decoration none
+    &.viewing
+      viewingBG()
     &:hover
       background-color darken(@background-color, 50%)
 .suggested-incidents


### PR DESCRIPTION
The `background` applied to each type were overriding the viewing background given with the `viewing` class.