### PR TITLE
Make incident report disease fields use values selected from disease ontology

### DIFF
--- a/client/controllers/events/createEventModal.coffee
+++ b/client/controllers/events/createEventModal.coffee
@@ -12,7 +12,6 @@ Template.createEventModal.events
     return if event.isDefaultPrevented() # Form is invalid
     event.preventDefault()
     target = event.target
-    disease = event.target.eventDisease?.value.trim()
     summary = target.eventSummary?.value.trim()
     eventName = target.eventName
     sourceId = instance.data?.sourceId
@@ -20,7 +19,6 @@ Template.createEventModal.events
       source = CuratorSources.findOne(sourceId)
     Meteor.call 'upsertUserEvent',
       eventName: eventName.value.trim()
-      disease: disease
       summary: summary
       displayOnPromed: event.target.promed.checked
     , (error, result) ->

--- a/client/controllers/events/editEventModal.coffee
+++ b/client/controllers/events/editEventModal.coffee
@@ -36,13 +36,11 @@ Template.editEventDetailsModal.events
     event.preventDefault()
     name = event.target.eventName.value.trim()
     summary = event.target.eventSummary.value.trim()
-    disease = event.target.eventDisease?.value.trim()
     if name.length isnt 0
       Meteor.call 'upsertUserEvent',
         _id: @_id
         eventName: name
         summary: summary
-        disease: disease
         displayOnPromed: event.target.promed.checked
       , (error, result) ->
         if not error

--- a/client/controllers/incidentReports/incidentForm.coffee
+++ b/client/controllers/incidentReports/incidentForm.coffee
@@ -1,6 +1,6 @@
 createInlineDateRangePicker = require '/imports/ui/inlineDateRangePicker.coffee'
 validator = require 'bootstrap-validator'
-{ keyboardSelect, removeSuggestedProperties } = require '/imports/utils'
+{ keyboardSelect, removeSuggestedProperties, diseaseOptionsFn } = require '/imports/utils'
 
 _selectInput = (event, instance, prop, isCheckbox) ->
   return if not keyboardSelect(event) and event.type is 'keyup'
@@ -115,6 +115,8 @@ Template.incidentForm.helpers
 
   articleSourceUrl: ->
     Template.instance().data.articles[0]?.url
+
+  diseaseOptionsFn: -> diseaseOptionsFn
 
 Template.incidentForm.events
   'change input[name=daterangepicker_start]': (event, instance) ->

--- a/client/controllers/locationSelect2.coffee
+++ b/client/controllers/locationSelect2.coffee
@@ -14,12 +14,6 @@ incidentsToLocations = (incidents) ->
   # Return
   _.values(locations)
 
-_setRequiredAttr = ->
-  required = false
-  if $('.select2-selection__rendered li').length is 1
-    required = true
-  $('.select2-search__field').attr('required', required)
-
 Template.locationSelect2.onCreated ->
   @required = @data.required
   @required ?= false
@@ -82,11 +76,15 @@ Template.locationSelect2.onRendered ->
   if required
     if initialValues.length > 0
       required = false
-    $('.select2-search__field').attr
+    @$('.select2-search__field').attr
       'required': required
       'data-error': 'Please select a location.'
 
     # Remove required attr when location is selected and add it back when all
     # locations are removed/unselected
-    $input.on 'change', _setRequiredAttr
+    $input.on 'change', =>
+      required = false
+      if @$('.select2-selection__rendered li').length is 1
+        required = true
+      @$('.select2-search__field').attr('required', required)
   $input.val(initialValues.map((x)->x.id)).trigger('change')

--- a/client/controllers/select2.coffee
+++ b/client/controllers/select2.coffee
@@ -27,6 +27,7 @@ Template.select2.onRendered ->
       multiple: @data.multiple
       minimumInputLength: 0
       dataAdapter: CustomDataAdapter
+      placeholder: @data.placeholder or ""
 
     required = @data.required
     if required

--- a/client/controllers/select2.coffee
+++ b/client/controllers/select2.coffee
@@ -1,0 +1,44 @@
+Template.select2.onCreated ->
+  defaultOptionFn = (params, callback)=>
+    callback(results: @data.options or [])
+  # A function that takes parameters for a term being typed calls a callback
+  # with a list of corresponding options.
+  @optionsFn = @data.optionsFn or defaultOptionFn
+
+Template.select2.onRendered ->
+  $input = @$("select")
+  $.fn.select2.amd.require [
+    'select2/data/array', 'select2/utils'
+  ], (ArrayAdapter, Utils) =>
+    CustomDataAdapter = ($element, options) ->
+      CustomDataAdapter.__super__.constructor.call(@, $element, options)
+    Utils.Extend(CustomDataAdapter, ArrayAdapter)
+    CustomDataAdapter.prototype.query = _.debounce(@optionsFn, 600)
+
+    initialValues = []
+    if @data.selected
+      if _.isArray @data.selected
+        initialValues = @data.selected
+      else
+        initialValues = [@data.selected]
+
+    $input.select2
+      data: initialValues
+      multiple: @data.multiple
+      minimumInputLength: 0
+      dataAdapter: CustomDataAdapter
+
+    required = @data.required
+    if required
+      @$('.select2-search__field').attr
+        'required': required
+        'data-error': 'Please select a value.'
+      # Remove required attr when value is selected and add it back when all
+      # values are removed/unselected
+      $input.on 'change', =>
+        required = false
+        if @$('.select2-selection__rendered li').length is 1
+          required = true
+        @$('.select2-search__field').attr('required', required)
+
+    $input.val(initialValues.map((x)->x.id)).trigger('change')

--- a/client/controllers/smartEvents/editSmartEventDetailsModal.coffee
+++ b/client/controllers/smartEvents/editSmartEventDetailsModal.coffee
@@ -3,6 +3,7 @@
 createInlineDateRangePicker = require('/imports/ui/inlineDateRangePicker')
 { updateCalendarSelection } = require('/imports/ui/setRange')
 require('bootstrap-validator')
+{ diseaseOptionsFn } = require '/imports/utils'
 
 Template.editSmartEventDetailsModal.onCreated ->
   @confirmingDeletion = new ReactiveVar(false)
@@ -42,17 +43,26 @@ Template.editSmartEventDetailsModal.helpers
   showCalendar: ->
     Template.instance().addDate.get()
 
+  diseaseOptionsFn: -> diseaseOptionsFn
+
 Template.editSmartEventDetailsModal.events
   'submit #editEvent': (event, instance) ->
     form = event.target
     return if event.isDefaultPrevented() # Form is invalid
     event.preventDefault()
 
+    diseases = $(form)
+    .find('#disease-select2')
+    .select2('data')
+    .map (option)->
+      id: option.id
+      text: option?.item?.label or option.text
+
     smartEvent =
       _id: @_id
       eventName: form.eventName.value.trim()
       summary: form.eventSummary.value.trim()
-      disease: form.eventDisease.value.trim()
+      diseases: diseases
 
     # Locations
     locations = []

--- a/client/controllers/smartEvents/smartEvent.coffee
+++ b/client/controllers/smartEvents/smartEvent.coffee
@@ -18,10 +18,9 @@ Template.smartEvent.onRendered ->
     if event
       eventDateRange = event.dateRange
       locations = event.locations
-      disease = event.disease
       query = {}
-      if disease
-        query.disease = disease
+      if event.diseases and event.diseases.length > 0
+        query['resolvedDisease.id'] = $in: event.diseases.map (x)-> x.id
       if eventDateRange
         query['dateRange.start'] = $lte: eventDateRange.end
         query['dateRange.end'] = $gte: eventDateRange.start

--- a/client/views/events/createEventModal.jade
+++ b/client/views/events/createEventModal.jade
@@ -14,9 +14,6 @@ template(name="createEventModal")
               input#eventName.form-control(type='text', name='eventName' required)
               .help-block.with-errors
             .form-group
-              label Event Disease
-              input.form-control(type="text" name="eventDisease" value=disease)
-            .form-group
               label.control-label(for="eventSummary") Event Summary
               textarea#eventSummary.form-control(name='eventSummary', rows='15')
             .form-group

--- a/client/views/events/editEventDetailsModal.jade
+++ b/client/views/events/editEventDetailsModal.jade
@@ -17,10 +17,6 @@ template(name="editEventDetailsModal")
                 label Event Name
                 input.form-control(type='text' name='eventName' value=eventName required)
                 .help-block.with-errors
-              unless adding
-                .form-group
-                  label Event Disease
-                  input.form-control(type="text" name="eventDisease" value=disease)
               .form-group
                 label Event Summary
                 textarea.form-control(name="eventSummary" rows="15")= summary

--- a/client/views/events/summary.jade
+++ b/client/views/events/summary.jade
@@ -5,13 +5,6 @@ template(name="summary")
         h1.event-name= eventName
         if isInRole "admin"
           +editDetailsButton(target="#edit-event-modal" editing="name")
-      p.disease-name
-        if disease
-          span= disease
-        else
-          span.not-available No disease available.
-          if isInRole "admin"
-            +editDetailsButton(target="#edit-event-modal" editing="disease")
 
       if summary
         p.summary(class="{{#if collapsed}}collapsed{{/if}}")

--- a/client/views/incidentReports/incidentForm.jade
+++ b/client/views/incidentReports/incidentForm.jade
@@ -148,20 +148,23 @@ template(name="incidentForm")
         ) Locations
         +locationSelect2(
           selectId="incident-location-select2"
-          multiple="true"
+          multiple=true
           selected=incidentData.locations
           required=true)
         .help-block.with-errors
 
-      .form-group.form-group--full(class="{{suggestedField 'disease'}}")
+      .form-group.form-group--full(class="{{suggestedField 'resolvedDisease'}}")
         label.control-label.with-info-tooltip(
           data-toggle="tooltip"
           data-placement="right"
           title="The disease that caused the cases or deaths.") Disease
-        input.form-control(
-          type="text"
+        +select2(
           name="disease"
-          value=incidentData.disease)
+          selectId="incident-disease-select2"
+          multiple=false
+          optionsFn=diseaseOptionsFn
+          selected=incidentData.resolvedDisease)
+        .help-block.with-errors
 
       .form-group.form-group--full(class="{{suggestedField 'species'}}")
         label.control-label.with-info-tooltip(

--- a/client/views/incidentReports/incidentForm.jade
+++ b/client/views/incidentReports/incidentForm.jade
@@ -162,6 +162,7 @@ template(name="incidentForm")
           name="disease"
           selectId="incident-disease-select2"
           multiple=false
+          placeholder="Select a disease"
           optionsFn=diseaseOptionsFn
           selected=incidentData.resolvedDisease)
         .help-block.with-errors

--- a/client/views/incidentReports/incidentReport.jade
+++ b/client/views/incidentReports/incidentReport.jade
@@ -36,10 +36,10 @@ template(name="incidentReport")
             li.container-flex.single.no-break
               h6.metadata--title Species:
               span=species
-          if disease
+          if resolvedDisease
             li.container-flex.single.no-break
               h6.metadata--title Disease:
-              span=disease
+              span=resolvedDisease.text
           li.container-flex.single.no-break
             h6.metadata--title Dates:
             span {{formatDateRange(dateRange)}}

--- a/client/views/locationSelect2.jade
+++ b/client/views/locationSelect2.jade
@@ -1,6 +1,7 @@
 template(name="locationSelect2")
-  select.location-select2.form-control.select2(
-    id=selectId
-    name="location"
-    multiple=multiple
-    required=required)
+  span
+    select.location-select2.form-control.select2(
+      id=selectId
+      name="location"
+      multiple=multiple
+      required=required)

--- a/client/views/select2.jade
+++ b/client/views/select2.jade
@@ -1,6 +1,7 @@
 template(name="select2")
-  select.form-control.select2(
-    id=selectId
-    name=name
-    multiple=multiple
-    required=required)
+  span
+    select.form-control.select2(
+      id=selectId
+      name=name
+      multiple=multiple
+      required=required)

--- a/client/views/select2.jade
+++ b/client/views/select2.jade
@@ -1,0 +1,6 @@
+template(name="select2")
+  select.form-control.select2(
+    id=selectId
+    name=name
+    multiple=multiple
+    required=required)

--- a/client/views/smartEvents/editSmartEventDetailsModal.jade
+++ b/client/views/smartEvents/editSmartEventDetailsModal.jade
@@ -28,6 +28,7 @@ template(name="editSmartEventDetailsModal")
                 +select2(
                   name="disease"
                   selectId="disease-select2"
+                  placeholder="Select a disease"
                   multiple=true
                   optionsFn=diseaseOptionsFn
                   selected=diseases)

--- a/client/views/smartEvents/editSmartEventDetailsModal.jade
+++ b/client/views/smartEvents/editSmartEventDetailsModal.jade
@@ -25,7 +25,12 @@ template(name="editSmartEventDetailsModal")
                 .help-block.with-errors
               .form-group
                 label Disease
-                input.form-control(type='text' name='eventDisease' value=disease)
+                +select2(
+                  name="disease"
+                  selectId="disease-select2"
+                  multiple=true
+                  optionsFn=diseaseOptionsFn
+                  selected=diseases)
                 .help-block.with-errors
               .form-group
                 label Locations

--- a/client/views/smartEvents/smartEventSummary.jade
+++ b/client/views/smartEvents/smartEventSummary.jade
@@ -7,8 +7,8 @@ template(name="smartEventSummary")
           +editDetailsButton(target="#smart-event-modal" editing="name" icon="edit")
 
       p.disease-name
-        if disease
-          span= disease
+        if diseases
+          span= disease.text
         else
           span.not-available No disease available.
           if isInRole "admin"

--- a/imports/schemas/incidentReport.coffee
+++ b/imports/schemas/incidentReport.coffee
@@ -53,6 +53,15 @@ IncidentReportSchema = new SimpleSchema
   disease:
     type: String
     optional: true
+  resolvedDisease:
+    type: Object
+    optional: true
+  "resolvedDisease.id":
+    type: String
+    optional: true
+  "resolvedDisease.text":
+    type: String
+    optional: true
   species:
     type: String
     optional: true

--- a/imports/schemas/smartEvent.coffee
+++ b/imports/schemas/smartEvent.coffee
@@ -13,7 +13,13 @@ smartEventSchema = new SimpleSchema
     optional: true
   eventName:
     type: String
-  disease:
+  diseases:
+    type: [Object]
+    optional: true
+  "diseases.$.id":
+    type: String
+    optional: true
+  "diseases.$.text":
     type: String
     optional: true
   lastModifiedByUserId:

--- a/imports/schemas/userEvent.coffee
+++ b/imports/schemas/userEvent.coffee
@@ -16,6 +16,7 @@ userEventSchema = new SimpleSchema(
     optional: true
   disease:
     type: String
+    optional: true
   eventName:
     type: String
   lastIncidentDate:

--- a/imports/utils.coffee
+++ b/imports/utils.coffee
@@ -84,12 +84,10 @@ export incidentReportFormToIncident = (form) ->
     for child in $(form.articleSource).select2('data')
       if child.selected
         incident.url = child.text.trim()
-  console.log 1
   for option in $(form).find('#incident-disease-select2').select2('data')
     incident.resolvedDisease =
       id: option.id
       text: option?.item?.label or option.text
-  console.log $(form).find('#incident-location-select2').select2('data')
   for option in $(form).find('#incident-location-select2').select2('data')
     item = option.item
     if typeof item.alternateNames is 'string'

--- a/imports/utils.coffee
+++ b/imports/utils.coffee
@@ -1,3 +1,4 @@
+Constants = require '/imports/constants.coffee'
 ###
 # cleanUrl - takes an existing url and removes the last match of the applied
 #   regular expressions.
@@ -55,7 +56,6 @@ export incidentReportFormToIncident = (form) ->
 
   incident =
     species: form.species.value
-    disease: form.disease.value
     travelRelated: form.travelRelated.checked
     approximate: form.approximate.checked
     locations: []
@@ -84,9 +84,13 @@ export incidentReportFormToIncident = (form) ->
     for child in $(form.articleSource).select2('data')
       if child.selected
         incident.url = child.text.trim()
-
-  $loc = $(form).find('#incident-location-select2')
-  for option in $loc.select2('data')
+  console.log 1
+  for option in $(form).find('#incident-disease-select2').select2('data')
+    incident.resolvedDisease =
+      id: option.id
+      text: option?.item?.label or option.text
+  console.log $(form).find('#incident-location-select2').select2('data')
+  for option in $(form).find('#incident-location-select2').select2('data')
     item = option.item
     if typeof item.alternateNames is 'string'
       delete item.alternateNames
@@ -129,3 +133,30 @@ export keyboardSelect = (event) ->
 export removeSuggestedProperties = (instance, props) ->
   suggestedFields = instance.suggestedFields
   suggestedFields.set(_.difference(suggestedFields.get(), props))
+
+export diseaseOptionsFn = (params, callback) ->
+  term = params.term?.trim()
+  if not term
+    return callback(results: [])
+  HTTP.get Constants.GRITS_URL + "/api/v1/disease_ontology/lookup", {
+    params:
+      q: term
+  }, (error, response)->
+    if error
+      return callback(error)
+    callback(
+      results: response.data.result.map((d)->
+        if d.synonym != d.label
+          text = d.synonym + " | " + d.label
+        else
+          text = d.label
+        {
+          id: d.uri
+          text: text
+          item: d
+        }
+      ).concat([
+        id: "userSpecifiedDisease:#{term}"
+        text: "Other Disease: #{term}"
+      ])
+    )


### PR DESCRIPTION
This also updates the database to store disease ontology ids and labels instead of free-text values. I am leaving the free-text disease field in the database for now incase we find problems with the automatic mappings of free-text names to disease ontology names.