### PR TITLE
Sort incidents in curator IR tables by start offset

### DIFF
--- a/client/controllers/curatorInbox/curatorSourceDetails.coffee
+++ b/client/controllers/curatorInbox/curatorSourceDetails.coffee
@@ -107,9 +107,6 @@ Template.curatorSourceDetails.onDestroyed ->
   $(window).off('resize')
 
 Template.curatorSourceDetails.helpers
-  incidents: ->
-    Template.instance().incidentCollection
-
   source: ->
     Template.instance().source.get()
 

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -48,7 +48,8 @@ Meteor.publish 'curatorSources', (query) ->
       publishDate: -1
   })
 Meteor.publish 'curatorSourceIncidentReports', (sourceId) ->
-  Incidents.find(url: $regex: new RegExp("#{sourceId}$"))
+  Incidents.find {url: $regex: new RegExp("#{sourceId}$")},
+    sort: 'annotations.case.0.textOffsets.0': 1
 
 Meteor.publish 'eventArticles', (ueId) ->
   Articles.find(


### PR DESCRIPTION
Sorts the IRs in tables.
Probably should remove [this addition](https://github.com/ecohealthalliance/eidr-connect/blob/b490c53197c8575e6521bd92b3dde6cd01727752/imports/ui/annotation.coffee#L5-L8) in #314 in favor of sorting when we query the collection?
[PT story](https://www.pivotaltracker.com/story/show/142338945)