### PR TITLE
Extract incidents fix styles

### DIFF
--- a/client/controllers/curatorInbox/curatorSourceDetails.coffee
+++ b/client/controllers/curatorInbox/curatorSourceDetails.coffee
@@ -28,7 +28,6 @@ Template.curatorSourceDetails.onCreated ->
   @reviewed = new ReactiveVar(false)
   @incidentsLoaded = new ReactiveVar(false)
   @selectedIncidentTab = new ReactiveVar(0)
-  @wideUI = new ReactiveVar(window.innerWidth >= Session.get('WIDE_UI_WIDTH'))
   @addingSourceToEvent = new ReactiveVar(false)
 
 Template.curatorSourceDetails.onRendered ->
@@ -42,17 +41,6 @@ Template.curatorSourceDetails.onRendered ->
       swippablePane = new Hammer($('#touch-stage')[0])
       swippablePane.on 'swiperight', (event) ->
         instance.data.currentPaneInView.set('')
-
-  # Adjust the UI if it is above WIDE_UI_WIDTH
-  $(window).resize =>
-    state = false
-    wideUI = @wideUI.get()
-    if window.innerWidth >= Session.get('WIDE_UI_WIDTH')
-      return if wideUI
-      state = true
-    else if not wideUI
-      state = false
-    @wideUI.set(state)
 
   # Create key binding which marks sources as reviewed.
   key 'ctrl + enter, command + enter', (event) =>
@@ -126,9 +114,6 @@ Template.curatorSourceDetails.helpers
 
   incidentsLoaded: ->
     Template.instance().incidentsLoaded.get()
-
-  wideUI: ->
-    Template.instance().wideUI.get()
 
   selectedIncidentTab: ->
     Template.instance().selectedIncidentTab

--- a/client/controllers/curatorInbox/curatorSourceDetails.coffee
+++ b/client/controllers/curatorInbox/curatorSourceDetails.coffee
@@ -2,7 +2,6 @@ CuratorSources = require '/imports/collections/curatorSources.coffee'
 Incidents = require '/imports/collections/incidentReports.coffee'
 key = require 'keymaster'
 { notify } = require '/imports/ui/notification'
-WIDE_UI_WIDTH = 1500
 
 _markReviewed = (instance, showNext=true) ->
   new Promise (resolve) ->
@@ -29,7 +28,7 @@ Template.curatorSourceDetails.onCreated ->
   @reviewed = new ReactiveVar(false)
   @incidentsLoaded = new ReactiveVar(false)
   @selectedIncidentTab = new ReactiveVar(0)
-  @wideUI = new ReactiveVar(window.innerWidth >= WIDE_UI_WIDTH)
+  @wideUI = new ReactiveVar(window.innerWidth >= Session.get('WIDE_UI_WIDTH'))
   @addingSourceToEvent = new ReactiveVar(false)
 
 Template.curatorSourceDetails.onRendered ->
@@ -48,7 +47,7 @@ Template.curatorSourceDetails.onRendered ->
   $(window).resize =>
     state = false
     wideUI = @wideUI.get()
-    if window.innerWidth >= WIDE_UI_WIDTH
+    if window.innerWidth >= Session.get('WIDE_UI_WIDTH')
       return if wideUI
       state = true
     else if not wideUI

--- a/client/controllers/incidentReports/extractIncidents.coffee
+++ b/client/controllers/incidentReports/extractIncidents.coffee
@@ -41,6 +41,8 @@ Template.extractIncidents.events
       userEventId: null
       showTable: true
       acceptByDefault: true
+      offCanvasStartPosition: 'top'
+      classNames: 'extracted'
       article:
         publishDate: new Date()
         addedDate: new Date()

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -47,7 +47,9 @@ dismissModal = (instance) ->
   stageModals(instance, modal)
 
 sendModalOffStage = (instance) ->
-  modal = modalClasses(instance.modal, 'staged-left', 'off-canvas--right fade')
+  startPosition = instance.data.offCanvasStartPosition
+  startPosition ?= 'right'
+  modal = modalClasses(instance.modal, 'staged-left', "off-canvas--#{startPosition} fade")
   stageModals(instance, modal, false)
 
 Template.suggestedIncidentsModal.onCreated ->
@@ -137,6 +139,9 @@ Template.suggestedIncidentsModal.helpers
     sibling: '.suggested-incidents .modal-body'
     sourceContainer: '.suggested-incidents-wrapper'
 
+  offCanvasStartPosition: ->
+    Template.instance().data.offCanvasStartPosition or 'right'
+
 Template.suggestedIncidentsModal.events
   'hide.bs.modal #suggestedIncidentsModal': (event, instance) ->
     proceed = confirmAbandonChanges(event, instance)
@@ -191,8 +196,8 @@ Template.suggestedIncidentsModal.events
     sendModalOffStage(instance)
     showSuggestedIncidentModal(event, instance)
 
-  'click .annotated-content': (event, instance) ->
+  'click .annotated-content-tab': (event, instance) ->
     instance.annotatedContentVisible.set true
 
-  'click .incident-table': (event, instance) ->
+  'click .incident-table-tab': (event, instance) ->
     instance.annotatedContentVisible.set false

--- a/client/startup.coffee
+++ b/client/startup.coffee
@@ -1,6 +1,4 @@
 Meteor.startup ->
-  Session.set('WIDE_UI_WIDTH', 1500)
-
   $(document)
     .on 'show.bs.modal', ->
       $(@).on 'keyup', (event) ->

--- a/client/startup.coffee
+++ b/client/startup.coffee
@@ -1,4 +1,6 @@
 Meteor.startup ->
+  Session.set('WIDE_UI_WIDTH', 1500)
+
   $(document)
     .on 'show.bs.modal', ->
       $(@).on 'keyup', (event) ->

--- a/client/views/incidentReports/suggestedIncidentsModal.jade
+++ b/client/views/incidentReports/suggestedIncidentsModal.jade
@@ -1,13 +1,15 @@
 template(name="suggestedIncidentsModal")
-  .modal#suggestedIncidentsModal.off-canvas--right.flex.fade(role="dialog")
-    .modal-dialog.suggested-incidents
+  .modal#suggestedIncidentsModal.flex.fade(
+    class="off-canvas--#{offCanvasStartPosition}"
+    role="dialog")
+    .modal-dialog.suggested-incidents(class=classNames)
       .modal-content
         .modal-header
           +modalCloseButton
           .modal-header--title
             h4 Suggested Incident Reports
             span.annotation-count=annotatedCount
-          .container-flex(class="{{#if showTable}} flex-reverse {{/if}}")
+          .container-flex.options-wrapper(class="{{#if showTable}} flex-reverse {{/if}}")
             ul.color-legend.list-unstyled.container-flex.no-break(
               class="{{#if showTable}} with-tabs {{else}} on-left {{/if}}")
               li.color-legend--accepted Accepted
@@ -15,11 +17,11 @@ template(name="suggestedIncidentsModal")
             if showTable
               ul.tabs.tabs-traditional.tabs-secondary.tabs-modal-header.list-unstyled
                 li(class="{{#if annotatedContentVisible}}active{{/if}}")
-                  a.annotated-content Source Text
+                  a.annotated-content-tab Source Text
                 li(class="{{#if tableVisible}}active{{/if}}")
-                  a.incident-table Incident Report Table
+                  a.incident-table-tab Incident Report Table
         .modal-body
-          .suggested-incidents-wrapper.tab-content
+          .suggested-incidents-wrapper
             #suggested-locations-form.form-horizontal(hidden=tableVisible)
               if isLoading
                 +loading(message="Processing Article")

--- a/imports/stylesheets/incidents/incidentTable.import.styl
+++ b/imports/stylesheets/incidents/incidentTable.import.styl
@@ -79,6 +79,3 @@ $tableTypes = {
               cursor pointer
               &::before
                 content $icon
-
-.extract-incidents-table
-  margin -25px

--- a/imports/stylesheets/incidents/incidents.import.styl
+++ b/imports/stylesheets/incidents/incidents.import.styl
@@ -34,12 +34,16 @@ viewingBG()
       viewingBG()
     &:hover
       background-color darken(@background-color, 50%)
+
 .suggested-incidents
   margin 30px
   width calc(100% - 60px)
-  +above(3)
+  +above($break-point--medium-width)
     width 65%
     max-width 800px
+    &.extracted
+      max-width initial
+      width calc(100% - 150px)
   .modal-content
     display flex
     flex-direction column
@@ -66,11 +70,39 @@ viewingBG()
 
   .tabs
     margin-bottom -1px
+    +above($break-point--medium-width)
+      display none
+
+  &.extracted
+    +above($break-point--medium-width)
+      .modal-body
+        display flex
+      .options-wrapper
+        flex-direction row
+
+    .color-legend
+      +above($break-point--medium-width)
+        margin-left 25px
+        margin-bottom 1em
+
+.suggested-incidents-wrapper
+  +above($break-point--medium-width)
+    display flex
+    flex 1 1 auto
+    > div
+      overflow scroll
+      flex 1 1 50%
+      &:first-of-type
+        border-right 1px solid $border-primary
+
+.extract-incidents-table
+  table[hidden]
+    +above($break-point--medium-width)
+      display block
 
 .suggested-annotated-content
   margin 25px
   white-space pre-wrap
-
 
 .annotated-content
   &.snippet

--- a/imports/stylesheets/variables.import.styl
+++ b/imports/stylesheets/variables.import.styl
@@ -90,5 +90,5 @@ $incident-type-colors.rejected = $incident-type-colors.case
 
 // Break points
 $break-point--curator-inbox = 1000px
-$break-point--BSVE = 1200px
+$break-point--medium-width = $break-point--BSVE = 1200px
 $break-point--curator-inbox--x-wide = 1500px


### PR DESCRIPTION
[PT Bug](https://www.pivotaltracker.com/story/show/142938953)

- Fixes styling of Extracted Incidents modal and improves UI — breaks from tabbed interface into side-by-side at 1200px.
- Removes wideUI logic from the curator inbox details controller. Recent changes to the UI have made it unnecessary.