### PR TITLE
Curator inbox sort incidents after addition

### DIFF
--- a/client/controllers/curatorInbox/curatorSourceDetails.coffee
+++ b/client/controllers/curatorInbox/curatorSourceDetails.coffee
@@ -69,16 +69,17 @@ Template.curatorSourceDetails.onRendered ->
           $title.tooltip('hide').attr('data-original-title', '')
         else
           $title.attr('data-original-title', title)
-      @subscribe 'ArticleIncidentReports', source.url
-      if source.enhancements?.dateOfDiagnosis
-        instance.incidentsLoaded.set(true)
-      else
-        Meteor.call 'getArticleEnhancementsAndUpdate', source, (error, enhancements)=>
-          if error
-            notify('error', error.reason)
-          else
-            source.enhancements = enhancements
+      @subscribe 'ArticleIncidentReports', source.url,
+        onReady: ->
+          if source.enhancements?.dateOfDiagnosis
             instance.incidentsLoaded.set(true)
+          else
+            Meteor.call 'getArticleEnhancementsAndUpdate', source, (error, enhancements) =>
+              if error
+                notify('error', error.reason)
+              else
+                source.enhancements = enhancements
+                instance.incidentsLoaded.set(true)
 
 Template.curatorSourceDetails.onDestroyed ->
   $(window).off('resize')

--- a/client/controllers/curatorInbox/curatorSourceDetails.coffee
+++ b/client/controllers/curatorInbox/curatorSourceDetails.coffee
@@ -69,17 +69,16 @@ Template.curatorSourceDetails.onRendered ->
           $title.tooltip('hide').attr('data-original-title', '')
         else
           $title.attr('data-original-title', title)
-      @subscribe 'ArticleIncidentReports', source.url,
-        onReady: ->
-          if source.enhancements?.dateOfDiagnosis
-            instance.incidentsLoaded.set(true)
+      @subscribe 'ArticleIncidentReports', source.url
+      if source.enhancements?.dateOfDiagnosis
+        instance.incidentsLoaded.set(true)
+      else
+        Meteor.call 'getArticleEnhancementsAndUpdate', source, (error, enhancements) =>
+          if error
+            notify('error', error.reason)
           else
-            Meteor.call 'getArticleEnhancementsAndUpdate', source, (error, enhancements) =>
-              if error
-                notify('error', error.reason)
-              else
-                source.enhancements = enhancements
-                instance.incidentsLoaded.set(true)
+            source.enhancements = enhancements
+            instance.incidentsLoaded.set(true)
 
 Template.curatorSourceDetails.onDestroyed ->
   $(window).off('resize')

--- a/client/controllers/curatorInbox/sourceIncidentReports.coffee
+++ b/client/controllers/curatorInbox/sourceIncidentReports.coffee
@@ -12,6 +12,7 @@ findIncident = (accepted) ->
 Template.sourceIncidentReports.onCreated ->
   @tableContentScrollable = new ReactiveVar(true)
 
+Template.sourceIncidentReports.onRendered ->
   @autorun =>
     selectedAnnotationId = @data.selectedAnnotationId.get()
     return if not selectedAnnotationId

--- a/client/controllers/incidentReports/incidentTable.coffee
+++ b/client/controllers/incidentReports/incidentTable.coffee
@@ -84,7 +84,8 @@ Template.incidentTable.helpers
     instance = Template.instance()
     query = instance.acceptedQuery()
     query.url = instance.data.source.url
-    Incidents.find(query)
+    _.sortBy Incidents.find(query).fetch(), (incident) ->
+      incident.annotations.case[0].textOffsets[0]
 
   allSelected: ->
     instance = Template.instance()
@@ -138,10 +139,11 @@ Template.incidentTable.events
 
   'click table.incident-table tr td.edit': (event, instance) ->
     event.stopPropagation()
-    snippetHtml = buildAnnotatedIncidentSnippet(instance.data.source.enhancements.source.cleanContent.content, @)
+    source = instance.data.source
+    snippetHtml = buildAnnotatedIncidentSnippet(source.enhancements.source.cleanContent.content, @)
     Modal.show 'suggestedIncidentModal',
       edit: true
-      articles: [instance.data.source]
+      articles: [source]
       userEventId: null
       incident: @
       incidentText: Spacebars.SafeString(snippetHtml)

--- a/client/controllers/incidentReports/incidentTable.coffee
+++ b/client/controllers/incidentReports/incidentTable.coffee
@@ -85,7 +85,7 @@ Template.incidentTable.helpers
     query = instance.acceptedQuery()
     query.url = instance.data.source.url
     _.sortBy Incidents.find(query).fetch(), (incident) ->
-      incident.annotations.case[0].textOffsets[0]
+      incident.annotations?.case?[0].textOffsets?[0]
 
   allSelected: ->
     instance = Template.instance()

--- a/client/controllers/incidentReports/suggestedIncidentModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentModal.coffee
@@ -32,7 +32,7 @@ Template.suggestedIncidentModal.onCreated ->
       method = 'editIncidentReport'
       action = 'updated'
 
-    incident.annotations = instance?.incident?.annotations
+    incident.annotations = @data.incident?.annotations
     incident = _.pick(incident, incidentReportSchema.objectKeys())
     Meteor.call method, incident, (error, result) =>
       if error
@@ -87,13 +87,14 @@ Template.suggestedIncidentModal.events
     # Submit the form to trigger validation and to update the 'valid'
     # reactiveVar — its value is based on whether the form's hidden submit
     # button's default is prevented
+    instanceData = instance.data
     $('#add-incident').submit()
     return unless instance.valid.get()
     incident = utils.incidentReportFormToIncident(instance.$("form")[0])
 
     return if not incident
     incident.suggestedFields = instance.incident.suggestedFields.get()
-    incident.userEventId = instance.data.userEventId
+    incident.userEventId = instanceData.userEventId
     incident.accepted = true
     if instance.incidentCollection
       instance.incidentCollection.update instance.incident._id,
@@ -105,5 +106,5 @@ Template.suggestedIncidentModal.events
       notify('success', 'Incident Accepted', 1200)
       stageModals(instance, instance.modals)
     else
-      incident = _.extend({}, instance.data.incident, incident)
+      incident = _.extend({}, instanceData.incident, incident)
       instance.editIncident(incident)

--- a/client/views/curatorInbox/curatorSourceDetails.jade
+++ b/client/views/curatorInbox/curatorSourceDetails.jade
@@ -45,4 +45,4 @@ template(name="curatorSourceDetails")
         if notifying
           .veil
       else
-        +loading message="Processing Document"
+        +loading message="Loading"

--- a/client/views/incidentReports/incidentTable.jade
+++ b/client/views/incidentReports/incidentTable.jade
@@ -9,7 +9,7 @@ template(name="incidentTable")
         button.btn.btn-sm.btn-primary.show-addEvent(
           disabled="{{#unless incidentsSelected}} true {{/unless}}") Add to Event
       button.btn.btn-sm.btn-default.select.on-right(
-        disabled="{{#unless incidents.count}} true {{/unless}}"
+        disabled="{{#unless incidents.length}} true {{/unless}}"
         class="{{#if allSelected}} deselect-all {{else}} select-all {{/if}}")
         if allSelected
           | Deselect All
@@ -20,7 +20,7 @@ template(name="incidentTable")
       selectedIncidents=selectedIncidents
       tableContentScrollable=tableContentScrollable
       source=source)
-  if incidents.count
+  if incidents.length
     .curator-source-details--table-wrapper
       table.table.incident-table(
         class=tableType

--- a/imports/stylesheets/incidents/incidents.import.styl
+++ b/imports/stylesheets/incidents/incidents.import.styl
@@ -1,5 +1,5 @@
 viewingBG()
-  transition background-color .5s ease-in-out
+  transition background-color .2s ease-in-out
   background-color $highlight-primary
   color black
 


### PR DESCRIPTION
I suppose minimongo can't handle sorting like this: `sort: 'annotations.case.0.textOffsets.0': 1` I replaced it with `_.sortBy` to fix the bug where newly added Incidents were ending up at the bottom of the list.
I also noticed we, at some point, started to set the incidents loaded flag before the subscription is ready so I fixed that.
[PT Bug](https://www.pivotaltracker.com/story/show/143314903)