### PR TITLE
Show warning if document does not contain text content

### DIFF
--- a/client/controllers/curatorInbox/curatorSourceDetails.coffee
+++ b/client/controllers/curatorInbox/curatorSourceDetails.coffee
@@ -124,6 +124,9 @@ Template.curatorSourceDetails.helpers
   selectedAnnotationId: ->
     Template.instance().selectedAnnotationId
 
+  hasTextContent: ->
+    Template.instance().source.get().enhancements.source?.cleanContent?.content
+
 Template.curatorSourceDetails.events
   'click .toggle-reviewed': (event, instance) ->
     _markReviewed(instance)

--- a/client/views/curatorInbox/curatorSourceDetails.jade
+++ b/client/views/curatorInbox/curatorSourceDetails.jade
@@ -23,32 +23,37 @@ template(name="curatorSourceDetails")
       .transition(class="{{#if notifying}} active {{/if}}")
     .curator-source-details--content
       if incidentsLoaded
-        .curator-source-details--copy-wrapper.curator-source-details--section
-          .curator-source-details--header.curator-source-details--actions.container-flex.no-break
-            button.btn.btn-success.btn-sm.toggle-reviewed(class="{{#if isReviewed}} reviewed {{/if}}")
-              if isReviewed
-                span Reviewed
-              else
-                span Mark Reviewed
-            button.btn.btn-default.btn-sm.add-source-to-event.on-right Add Document to Event
-          if addingSourceToEvent
-            +addToEvent(source=source objNameToAssociate="Document")
-          .curator-source-details--copy
-            +annotatedContent(
-              content=source.enhancements.source.cleanContent.content
-              incidents=incidents
-              relatedElements=relatedElements
+        if hasTextContent
+          .curator-source-details--copy-wrapper.curator-source-details--section
+            .curator-source-details--header.curator-source-details--actions.container-flex.no-break
+              button.btn.btn-success.btn-sm.toggle-reviewed(class="{{#if isReviewed}} reviewed {{/if}}")
+                if isReviewed
+                  span Reviewed
+                else
+                  span Mark Reviewed
+              button.btn.btn-default.btn-sm.add-source-to-event.on-right Add Document to Event
+            if addingSourceToEvent
+              +addToEvent(source=source objNameToAssociate="Document")
+            .curator-source-details--copy
+              +annotatedContent(
+                content=source.enhancements.source.cleanContent.content
+                incidents=incidents
+                relatedElements=relatedElements
+                selectedAnnotationId=selectedAnnotationId
+                source=source)
+          .curator-source-details--incidents-wrapper
+            .curator-source-details--header
+              h2 Incidents
+              button.btn.btn-default.btn-sm.add-incident.on-right Add New Incident
+            +sourceIncidentReports(
+              selectedIncidentTab=selectedIncidentTab
               selectedAnnotationId=selectedAnnotationId
               source=source)
-        .curator-source-details--incidents-wrapper
-          .curator-source-details--header
-            h2 Incidents
-            button.btn.btn-default.btn-sm.add-incident.on-right Add New Incident
-          +sourceIncidentReports(
-            selectedIncidentTab=selectedIncidentTab
-            selectedAnnotationId=selectedAnnotationId
-            source=source)
-        if notifying
-          .veil
+          if notifying
+            .veil
+        else
+          .curator-inbox--warning
+            i.fa.fa-warning
+            h2 This document contains no text content
       else
         +loading message="Loading"

--- a/imports/stylesheets/curatorInbox/curatorInbox.import.styl
+++ b/imports/stylesheets/curatorInbox/curatorInbox.import.styl
@@ -357,3 +357,19 @@
       .page-number
         max-width 65%
         margin-right 1em
+
+.curator-inbox--warning
+  top 50%
+  left 50%
+  centerPosition()
+  min-width 300px
+  padding 3em 4em
+  border 2px solid $warning
+  border-radius 3px
+  text-align center
+  h2
+    font-size 1em
+  i
+    font-size 5em
+    color $warning
+    margin-bottom 15px


### PR DESCRIPTION
One of the issues the proMed folks had I think was related to them trying to view and process a document with an invalid URL (http://www.promedmail.org/post/undefined in this case). Not sure how it happened but I suppose we need to check for this on submission? Or just stay with letting it fail gracefully like this PR does.
I think this is just an initial step—seems like we should allow the curator to edit or delete the document? Maybe both?