### PR TITLE
Update event incident association

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -53,3 +53,4 @@ new3rs:html2canvas
 tmeasday:acceptance-test-driver
 mizzao:user-status
 eidr:fixtures
+reywood:publish-composite

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -92,6 +92,7 @@ reactive-dict@1.1.8
 reactive-var@1.0.10
 reload@1.1.10
 retry@1.0.8
+reywood:publish-composite@1.4.2
 routepolicy@1.0.11
 service-configuration@1.0.10
 session@1.1.6

--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -14,8 +14,8 @@ Template.articles.onRendered ->
       @incidentsLoaded.set(false)
       @subscribe 'articleIncidents', sourceId, =>
         @incidentsLoaded.set(true)
-      Meteor.defer =>
-        @$('[data-toggle=tooltip]').tooltip delay: show: '300'
+        Meteor.defer =>
+          @$('[data-toggle=tooltip]').tooltip delay: show: '300'
 
 Template.articles.helpers
   getSettings: ->
@@ -64,7 +64,7 @@ Template.articles.helpers
     Template.instance().selectedSource.get()
 
   incidentsForSource: (source) ->
-    Incidents.find(articleId: source._id)
+    Incidents.find(articleId: Template.instance().selectedSource.get()._id)
 
   locationsForSource: (source) ->
     locations = {}
@@ -89,6 +89,10 @@ Template.articles.helpers
     eventIncidentIds = _.pluck(Template.instance().data.userEvent.incidents, 'id')
     @_id in eventIncidentIds
 
+  eventHasArticleIncidents: ->
+    eventIncidentIds = _.pluck(Template.instance().data.userEvent.incidents, 'id')
+    Incidents.find(_id: $in: eventIncidentIds).count()
+
 Template.articles.events
   'click #event-sources-table tbody tr
     , keyup #event-sources-table tbody tr': (event, instance) ->
@@ -102,10 +106,11 @@ Template.articles.events
   'click .open-source-form': (event, instance) ->
     Modal.show 'sourceModal', userEventId: instance.data.userEvent._id
 
-  'click .delete-source': (event, instance) ->
+  'click .delete-source:not(.disabled)': (event, instance) ->
     source = instance.selectedSource.get()
     Modal.show 'deleteConfirmationModal',
       userEventId: instance.data.userEvent._id
+      source: source
       objNameToDelete: 'source'
       objId: source._id
       displayName: source.title

--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -11,7 +11,7 @@ Template.articles.onRendered ->
   @autorun =>
     sourceId = @selectedSourceId.get()
     @incidentsLoaded.set(false)
-    @subscribe 'articleIncidents', sourceId, true, =>
+    @subscribe 'articleIncidents', sourceId, =>
       @incidentsLoaded.set(true)
     Meteor.defer =>
       @$('[data-toggle=tooltip]').tooltip delay: show: '300'

--- a/client/controllers/curatorInbox/curatorSourceDetails.coffee
+++ b/client/controllers/curatorInbox/curatorSourceDetails.coffee
@@ -70,7 +70,7 @@ Template.curatorSourceDetails.onRendered ->
           $title.tooltip('hide').attr('data-original-title', '')
         else
           $title.attr('data-original-title', title)
-      @subscribe 'ArticleIncidentReports', source._id
+      @subscribe 'articleIncidents', source._id
       if source.enhancements?.dateOfDiagnosis
         instance.incidentsLoaded.set(true)
       else

--- a/client/controllers/deleteConfirmation/deleteConfirmationModalBody.coffee
+++ b/client/controllers/deleteConfirmation/deleteConfirmationModalBody.coffee
@@ -6,7 +6,7 @@ Template.deleteConfirmationModalBody.events
     data = instance.data
     id = data.objId
     objNameToDelete = data.objNameToDelete
-    
+
     switch objNameToDelete
       when 'incident'
         Meteor.call 'removeIncident', id, (error) ->
@@ -14,7 +14,7 @@ Template.deleteConfirmationModalBody.events
           unless error
             $('.incident-report--details').closest('tr').fadeOut(-> @.remove())
       when 'source'
-        Meteor.call 'removeEventSource', id, data.userEventId, (error) ->
+        Meteor.call 'removeEventSource', data.source, data.userEventId, (error) ->
           commonPostDeletionTasks(error, objNameToDelete)
       when 'event'
         Meteor.call 'deleteUserEvent', id, (error, result) ->

--- a/client/controllers/deleteConfirmation/deleteConfirmationModalBody.coffee
+++ b/client/controllers/deleteConfirmation/deleteConfirmationModalBody.coffee
@@ -9,7 +9,7 @@ Template.deleteConfirmationModalBody.events
     
     switch objNameToDelete
       when 'incident'
-        Meteor.call 'removeIncidentReport', id, (error) ->
+        Meteor.call 'removeIncident', id, (error) ->
           commonPostDeletionTasks(error, objNameToDelete)
           unless error
             $('.incident-report--details').closest('tr').fadeOut(-> @.remove())

--- a/client/controllers/events/curatedEvent.coffee
+++ b/client/controllers/events/curatedEvent.coffee
@@ -84,7 +84,7 @@ Template.curatedEvent.events
       add: true
 
   'click .open-source-form-in-details': (event, instance) ->
-    Modal.show('sourceModal', userEventId: instance.userEventId)
+    Modal.show('sourceModal', userEventId: instance.data.userEventId)
 
   'click .tabs li a': (event) ->
     event.currentTarget.blur()

--- a/client/controllers/events/curatedEvent.coffee
+++ b/client/controllers/events/curatedEvent.coffee
@@ -1,15 +1,39 @@
 Incidents = require '/imports/collections/incidentReports.coffee'
 UserEvents = require '/imports/collections/userEvents.coffee'
+Articles = require '/imports/collections/articles.coffee'
 #Allow multiple modals or the suggested locations list won't show after the loading modal is hidden
 Modal.allowMultiple = true
 
 Template.curatedEvent.onCreated ->
-  @editState = new ReactiveVar false
+  @editState = new ReactiveVar(false)
+  @loaded = new ReactiveVar(false)
+  userEventId = @data.userEventId
+  @subscribe "userEvent", @data.userEventId, =>
+    userEvent = UserEvents.findOne(userEventId)
+    document.title += ": #{userEvent.eventName}"
+    incidentIds = _.map userEvent.incidents, (incident) ->
+      incident.id
+    @subscribe "eventArticles", userEventId
+    @subscribe 'eventIncidents', incidentIds, =>
+      @loaded.set(true)
 
 Template.curatedEvent.onRendered ->
   new Clipboard '.copy-link'
 
 Template.curatedEvent.helpers
+  userEvent: ->
+    UserEvents.findOne(Template.instance().data.userEventId)
+
+  eventHasArticles: ->
+    Articles.find().count()
+
+  articleData: ->
+    articles: Articles.find()
+    userEvent: UserEvents.findOne(Template.instance().data.userEventId)
+
+  incidents: ->
+    Incidents.find()
+
   isEditing: ->
     Template.instance().editState.get()
 
@@ -21,8 +45,7 @@ Template.curatedEvent.helpers
     Router.current().getParams()._view is 'locations'
 
   deleted: ->
-    userEvent = UserEvents.findOne({_id: Template.instance().data.userEvent._id})
-    userEvent.deleted
+    UserEvents.findOne(Template.instance().data.userEventId)?.deleted
 
   view: ->
     currentView = Router.current().getParams()._view
@@ -31,7 +54,12 @@ Template.curatedEvent.helpers
     'incidentReports'
 
   templateData: ->
-    Template.instance().data
+    userEvent: UserEvents.findOne(Template.instance().data.userEventId)
+    articles: Articles.find()
+    incidents: Incidents.find()
+
+  loaded: ->
+    Template.instance().loaded.get()
 
 Template.curatedEvent.events
   'click .edit-link, click #cancel-edit': (event, instance) ->

--- a/client/controllers/events/curatedEvent.coffee
+++ b/client/controllers/events/curatedEvent.coffee
@@ -19,8 +19,8 @@ Template.curatedEvent.onCreated ->
         incident.id
 
   @autorun =>
-    @subscribe "eventArticles", userEventId
     incidentIds = @incidentIds.get()
+    @subscribe "eventArticles", userEventId, incidentIds
     if incidentIds
       @subscribe 'eventIncidents', incidentIds, =>
         @loaded.set(true)

--- a/client/controllers/events/curatedEvent.coffee
+++ b/client/controllers/events/curatedEvent.coffee
@@ -69,6 +69,9 @@ Template.curatedEvent.helpers
   loaded: ->
     Template.instance().loaded.get()
 
+  documentCount: ->
+    Articles.find().count()
+
 Template.curatedEvent.events
   'click .edit-link, click #cancel-edit': (event, instance) ->
     instance.editState.set(not instance.editState.get())

--- a/client/controllers/events/curatedEvent.coffee
+++ b/client/controllers/events/curatedEvent.coffee
@@ -14,7 +14,7 @@ Template.curatedEvent.onCreated ->
   @autorun =>
     userEvent = UserEvents.findOne(userEventId)
     if userEvent
-      document.title += ": #{userEvent.eventName}"
+      document.title = "Eidr-Connect: #{userEvent.eventName}"
       @incidentIds.set _.map userEvent.incidents, (incident) ->
         incident.id
 
@@ -77,10 +77,9 @@ Template.curatedEvent.events
     instance.editState.set(not instance.editState.get())
 
   'click .open-incident-form-in-details': (event, instance) ->
-    data = instance.data
     Modal.show 'incidentModal',
       articles: Articles.find()
-      userEventId: UserEvents.findOne(instance.data.userEventId)
+      userEventId: instance.data.userEventId
       add: true
 
   'click .open-source-form-in-details': (event, instance) ->

--- a/client/controllers/events/eventsTable.coffee
+++ b/client/controllers/events/eventsTable.coffee
@@ -13,6 +13,12 @@ Template.eventsTable.onCreated ->
       displayName: 'Event Name'
       defaultSortDirection: 1
       sortOrder: 2
+    incidents:
+      description: 'Number of incidents associated with event'
+      displayName: 'Incident Count'
+      sortable: false
+      displayFn: (value, object) ->
+        value?.length or 0
     lastModifiedDate:
       description: 'Date the event was last modified.'
       displayName: 'Last Modified Date'

--- a/client/controllers/events/eventsTable.coffee
+++ b/client/controllers/events/eventsTable.coffee
@@ -44,6 +44,9 @@ Template.eventsTable.helpers
     eventType = instance.data.eventType.get()
     fields = instance.tableOptions.fields
 
+    if eventType is 'smart'
+      fields = _.omit(fields, 'incidents')
+
     id: "#{eventType}-events-table"
     fields: tableFields(fields, instance.tableOptions)
     currentPage: instance.currentPage

--- a/client/controllers/events/eventsTable.coffee
+++ b/client/controllers/events/eventsTable.coffee
@@ -13,18 +13,6 @@ Template.eventsTable.onCreated ->
       displayName: 'Event Name'
       defaultSortDirection: 1
       sortOrder: 2
-    articleCount:
-      description: 'The number of documents associated with the event.'
-      displayName: 'Document Count'
-      defaultSortDirection: 1
-      sortOrder: 3
-      displayFn: (value, object, key) ->
-        new Spacebars.SafeString("<span data-heading='Document Count'>#{value}</span>")
-    createdByUserName:
-      displayName: 'Created By'
-      description: 'User who created the event.'
-      defaultSortDirection: 1
-      sortOrder: 4
     lastModifiedDate:
       description: 'Date the event was last modified.'
       displayName: 'Last Modified Date'
@@ -49,9 +37,6 @@ Template.eventsTable.helpers
     instance = Template.instance()
     eventType = instance.data.eventType.get()
     fields = instance.tableOptions.fields
-
-    if eventType is 'smart'
-      fields = _.omit(fields, 'articleCount')
 
     id: "#{eventType}-events-table"
     fields: tableFields(fields, instance.tableOptions)

--- a/client/controllers/events/summary.coffee
+++ b/client/controllers/events/summary.coffee
@@ -24,9 +24,6 @@ Template.summary.helpers
   formatDate: (date) ->
     moment(date).format('MMM D, YYYY')
 
-  articleCount: ->
-    Template.instance().data.articleCount
-
   copied: ->
     Template.instance().copied.get()
 

--- a/client/controllers/events/summary.coffee
+++ b/client/controllers/events/summary.coffee
@@ -30,9 +30,6 @@ Template.summary.helpers
   collapsed: ->
     Template.instance().collapsed.get()
 
-  incidentCount: ->
-    Template.instance().data.event.incidents?.length or 0
-
 Template.summary.events
   'click .copy-link': (event, instance) ->
     copied = instance.copied

--- a/client/controllers/events/summary.coffee
+++ b/client/controllers/events/summary.coffee
@@ -27,9 +27,6 @@ Template.summary.helpers
   articleCount: ->
     Template.instance().data.articleCount
 
-  caseCount: ->
-    Incidents.find(userEventId: @_id).count()
-
   copied: ->
     Template.instance().copied.get()
 

--- a/client/controllers/events/summary.coffee
+++ b/client/controllers/events/summary.coffee
@@ -30,6 +30,9 @@ Template.summary.helpers
   collapsed: ->
     Template.instance().collapsed.get()
 
+  incidentCount: ->
+    Template.instance().data.event.incidents?.length or 0
+
 Template.summary.events
   'click .copy-link': (event, instance) ->
     copied = instance.copied

--- a/client/controllers/incidentReports/incidentForm.coffee
+++ b/client/controllers/incidentReports/incidentForm.coffee
@@ -136,7 +136,8 @@ Template.incidentForm.helpers
   incidentSnippet: ->
     incident = @incident
     if incident?.annotations
-      articleContent = Articles.findOne(incident.articleId)?.enhancements?.source?.cleanContent.content
+      article = Articles.findOne(@articleId)
+      articleContent = article?.enhancements?.source.cleanContent.content
       if articleContent
         Spacebars.SafeString(getIncidentSnippet(articleContent, incident))
 

--- a/client/controllers/incidentReports/incidentModal.coffee
+++ b/client/controllers/incidentReports/incidentModal.coffee
@@ -84,7 +84,7 @@ Template.incidentModal.events
 
     if @edit
       incident = _.extend({}, @incident, incident)
-      Meteor.call 'editIncidentReport', incident, (error, result) ->
+      Meteor.call 'editIncidentReport', incident, instanceData.userEventId, (error, result) ->
         if not error
           $('.reactive-table tr').removeClass('open')
           $('.reactive-table tr.details').remove()

--- a/client/controllers/incidentReports/incidentModal.coffee
+++ b/client/controllers/incidentReports/incidentModal.coffee
@@ -84,7 +84,7 @@ Template.incidentModal.events
 
     if @edit
       incident = _.extend({}, @incident, incident)
-      Meteor.call 'editIncidentReport', incident, instanceData.userEventId, (error, result) ->
+      Meteor.call 'editIncidentReport', incident, (error, result) ->
         if not error
           $('.reactive-table tr').removeClass('open')
           $('.reactive-table tr.details').remove()

--- a/client/controllers/incidentReports/incidentModal.coffee
+++ b/client/controllers/incidentReports/incidentModal.coffee
@@ -54,7 +54,6 @@ Template.incidentModal.events
 
     if not incident
       return
-    incident.userEventId = instanceData.userEventId
 
     if instance.data.accept or @incident?.accepted
       incident.accepted = true
@@ -65,7 +64,7 @@ Template.incidentModal.events
       incident.annotations.case = [manualAnnotation]
 
     if @add
-      Meteor.call 'addIncidentReport', incident, (error, result) ->
+      Meteor.call 'addIncidentReport', incident, instanceData.userEventId, (error, result) ->
         if not error
           $('.reactive-table tr').removeClass('open')
           $('.reactive-table tr.tr-details').remove()

--- a/client/controllers/incidentReports/incidentReport.coffee
+++ b/client/controllers/incidentReports/incidentReport.coffee
@@ -5,6 +5,12 @@ import { getIncidentSnippet } from '/imports/ui/snippets'
 Template.incidentReport.onCreated ->
   @subscribe 'incidentArticle', @data.articleId
 
+Template.incidentReport.onCreated ->
+  Meteor.defer =>
+    @$('[data-toggle=tooltip]').tooltip
+      delay: show: '200'
+      container: 'body'
+
 Template.incidentReport.helpers
   caseCounts: ->
     @deaths or @cases

--- a/client/controllers/incidentReports/incidentReport.coffee
+++ b/client/controllers/incidentReports/incidentReport.coffee
@@ -23,6 +23,7 @@ Template.incidentReport.helpers
 
   incidentContent: ->
     if @annotations
-      articleContent = Articles.findOne(@articleId)?.enhancements?.source?.cleanContent.content
+      article = Articles.findOne(@articleId)
+      articleContent = article?.enhancements?.source.cleanContent.content
       if articleContent
         Spacebars.SafeString(getIncidentSnippet(articleContent, @))

--- a/client/controllers/incidentReports/incidentReports.coffee
+++ b/client/controllers/incidentReports/incidentReports.coffee
@@ -8,6 +8,7 @@ import { pluralize, formatDateRange, formatLocations } from '/imports/ui/helpers
 import { incidentTypeWithCountAndDisease } from '/imports/utils'
 import Articles from '/imports/collections/articles.coffee'
 import Feeds from '/imports/collections/feeds.coffee'
+{ notify } = require '/imports/ui/notification'
 
 Template.incidentReports.onDestroyed ->
   if @plot
@@ -226,12 +227,13 @@ Template.incidentReports.events
     Modal.show 'incidentModal', incident
 
   'click .reactive-table tbody tr .delete': (event, instance) ->
-    date = moment(@dateRange.start).format("MMM D, YYYY")
-    location = @locations[0].name
-    Modal.show 'deleteConfirmationModal',
-      objNameToDelete: 'incident'
-      objId: @_id
-      displayName: "#{location} on #{date}"
+    Meteor.call 'removeIncidentFromEvent', (error, res) =>
+      if error
+        notify('error', error.reason)
+        return
+      instance.data.incidentIds.remove(id: @_id)
+      instance.$('tr.details').remove()
+      notify('success', 'Incident report removed from event')
 
   # Remove any open incident details elements on pagination
   'click .next-page,

--- a/client/controllers/incidentReports/incidentReports.coffee
+++ b/client/controllers/incidentReports/incidentReports.coffee
@@ -227,12 +227,12 @@ Template.incidentReports.events
     Modal.show 'incidentModal', incident
 
   'click .reactive-table tbody tr .delete': (event, instance) ->
-    Meteor.call 'removeIncidentFromEvent', (error, res) =>
+    Meteor.call 'removeIncidentFromEvent', @_id, (error, res) =>
       if error
         notify('error', error.reason)
         return
-      instance.data.incidentIds.remove(id: @_id)
       instance.$('tr.details').remove()
+      $('.tooltip').remove()
       notify('success', 'Incident report removed from event')
 
   # Remove any open incident details elements on pagination

--- a/client/controllers/incidentReports/suggestedIncidentModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentModal.coffee
@@ -23,7 +23,8 @@ Template.suggestedIncidentModal.onCreated ->
     previousModal:
       element: '#suggestedIncidentsModal'
       add: 'fade'
-  @editIncident = (incident) =>
+
+  @editIncident = (incident, userEventId) =>
     method = 'addIncidentReport'
     action = 'added'
     if @incident._id
@@ -32,7 +33,7 @@ Template.suggestedIncidentModal.onCreated ->
 
     incident.annotations = @data.incident?.annotations
     incident = _.pick(incident, incidentReportSchema.objectKeys())
-    Meteor.call method, incident, (error, result) =>
+    Meteor.call method, incident, userEventId, (error, result) =>
       if error
         return notify('error', error)
       notify('success', "Incident #{action}.")
@@ -101,7 +102,6 @@ Template.suggestedIncidentModal.events
 
     return if not incident
     incident.suggestedFields = instance.incident.suggestedFields.get()
-    incident.userEventId = instanceData.userEventId
     incident.accepted = true
     incident = _.extend({}, instanceData.incident, incident)
     if instanceData.incidentCollection
@@ -116,4 +116,4 @@ Template.suggestedIncidentModal.events
       stageModals(instance, instance.modals)
     else
       incident = _.extend({}, instance.data.incident, incident)
-      instance.editIncident(incident)
+      instance.editIncident(incident, instanceData.userEventId)

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -69,7 +69,7 @@ Template.suggestedIncidentsModal.onCreated ->
 
   if @saveResults
     @autorun =>
-      @subscribe 'ArticleIncidentReports', @data.article._id
+      @subscribe 'articleIncidents', @data.article._id
   else
     @incidentsCollection = new Meteor.Collection(null)
 

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -194,7 +194,7 @@ Template.suggestedIncidentsModal.events
     if count <= 0
       notify('warning', 'No incidents have been confirmed')
       return
-    Meteor.call 'addIncidentReports', incidents, (err, result)->
+    Meteor.call 'addIncidentReports', incidents, instance.data.article._id, (err, result)->
       if err
         toastr.error err.reason
       else

--- a/client/controllers/maps/eventMap.coffee
+++ b/client/controllers/maps/eventMap.coffee
@@ -7,6 +7,7 @@ L.Icon.Default.imagePath = "/packages/fuatsengul_leaflet/images"
 Template.eventMap.onCreated ->
   @query = new ReactiveVar({})
   @pageNum = new ReactiveVar(0)
+  @loading = new ReactiveVar(false)
   @eventsPerPage = 8
   @templateEvents = new ReactiveVar null
   @disablePrev = new ReactiveVar true
@@ -41,10 +42,10 @@ Template.eventMap.onRendered ->
     @query.get()
     @pageNum.set(0)
 
-  @autorun ->
-    query = instance.query.get()
-    currentPage = instance.pageNum.get()
-    eventsPerPage = instance.eventsPerPage
+  @autorun =>
+    query = @query.get()
+    currentPage = @pageNum.get()
+    eventsPerPage = @eventsPerPage
 
     if _.isObject query
       allEvents = UserEvents
@@ -57,7 +58,7 @@ Template.eventMap.onRendered ->
       map.removeLayer instance.mapMarkers
       return
 
-    filteredMapLocations = instance.filteredMapLocations = {}
+    filteredMapLocations = @filteredMapLocations = {}
     templateEvents = []
     eventIndex = startingPosition
 
@@ -73,60 +74,73 @@ Template.eventMap.onRendered ->
             eventName: event.eventName
             lastIncidentDate: event.lastIncidentDate
             rgbColor: rgbColor
+            incidents: event.incidents
           eventIndex += 1
-    instance.templateEvents.set templateEvents
-    instance.disableNext.set if eventIndex < allEvents?.length then false else true
-    instance.disablePrev.set if currentPage is 0 then true else false
-    instance.subscribe('mapIncidents', _.pluck(templateEvents, '_id'))
+    @templateEvents.set templateEvents
+    @disableNext.set if eventIndex < allEvents?.length then false else true
+    @disablePrev.set if currentPage is 0 then true else false
 
   # Update the map markers to reflect user selection of events
-  @autorun ->
+  @autorun =>
     mapLocations = {}
-    templateEvents = instance.templateEvents.get()
-    Incidents.find(
-      userEventId: $in: instance.selectedEvents.find().map (e)-> e._id
-    ).map (incident)->
-      for location in incident.locations
-        latLng = location.latitude + "," + location.longitude
-        if not mapLocations[latLng]
-          mapLocations[latLng] =
-            name: location.name
-            incidents: []
-            events: []
-        mapLocations[latLng].events = _.union(
-          mapLocations[latLng].events, [incident.userEventId])
-        mapLocations[latLng].incidents = _.union(
-          mapLocations[latLng].incidents, [incident])
+    templateEvents = @templateEvents.get()
 
-    map.removeLayer(instance.mapMarkers)
-    markers = instance.mapMarkers = new L.FeatureGroup()
-    for coordinates, location of mapLocations
-      locationEvents = templateEvents.filter (e)->
-        e._id in location.events
-      popupHtml = Blaze.toHTMLWithData(Template.markerPopup, {
-        name: location.name
-        locationEvents: locationEvents.map (event)->
-          eventCopy = _.clone(event)
-          eventCopy.mostRecentIncident = _.chain(location.incidents)
-            .filter (i)-> i.userEventId == event._id
-            .sortBy (i)-> i.dateRange.start
-            .value()[0]
-          eventCopy
-      })
-      marker = L.marker(coordinates.split(","),
-        icon: L.divIcon
-          className: 'map-marker-container'
-          iconSize: null
-          html: MapHelpers.getMarkerHtml(locationEvents)
-      ).bindPopup(popupHtml, closeButton: false)
-      markers.addLayer(marker)
-    map.addLayer(markers)
-    if _.isEmpty(mapLocations)
-      map.setView([10, -0], 3)
-    else
-      map.fitBounds markers.getBounds(),
-        maxZoom: 10
-        padding: [20, 20]
+    # Create an array of the ids of the incidents of the selected events
+    incidentIds = []
+    @selectedEvents.find().fetch().forEach (event) ->
+      incidentIds = _.union(incidentIds, _.pluck(event.incidents, 'id'))
+    incidentIds
+
+    @subscribe 'mapIncidents', incidentIds, =>
+      @selectedEvents.find().forEach (selectedEvent) ->
+        incidentIds = _.pluck selectedEvent.incidents, 'id'
+        Incidents.find(_id: $in: incidentIds).map (incident) =>
+          for location in incident.locations
+            incident.userEventId = selectedEvent._id
+            latLng = location.latitude + "," + location.longitude
+            if not mapLocations[latLng]
+              mapLocations[latLng] =
+                name: location.name
+                incidents: []
+                events: []
+            mapLocations[latLng].events = _.union(
+              mapLocations[latLng].events, [selectedEvent._id])
+            mapLocations[latLng].incidents = _.union(
+              mapLocations[latLng].incidents, [incident])
+
+      map.removeLayer(@mapMarkers)
+      markers = @mapMarkers = new L.FeatureGroup()
+      for coordinates, location of mapLocations
+        locationEvents = templateEvents.filter (e)->
+          e._id in location.events
+        popupHtml = Blaze.toHTMLWithData Template.markerPopup,
+          name: location.name
+          locationEvents: locationEvents.map (event)->
+            eventCopy = _.clone(event)
+            eventCopy.mostRecentIncident = _.chain(location.incidents)
+              .filter (i)-> i.userEventId == event._id
+              .sortBy (i)-> i.dateRange.start
+              .value()[0]
+            eventCopy
+
+        marker = L.marker(coordinates.split(","),
+          icon: L.divIcon
+            className: 'map-marker-container'
+            iconSize: null
+            html: MapHelpers.getMarkerHtml(locationEvents)
+        ).bindPopup(popupHtml, closeButton: false)
+        markers.addLayer(marker)
+      map.addLayer(markers)
+
+      if _.isEmpty(mapLocations)
+        map.setView([10, -0], 3)
+      else
+        map.fitBounds markers.getBounds(),
+          maxZoom: 10
+          padding: [20, 20]
+
+      @loading.set(false)
+
 
 Template.eventMap.helpers
   getQuery: ->
@@ -146,6 +160,12 @@ Template.eventMap.helpers
 
   selectedEvents: ->
     Template.instance().selectedEvents
+
+  incidentsLoaded: ->
+    not Template.instance().loading.get()
+
+  incidentsLoading: ->
+    Template.instance().loading
 
 paginate = (template, direction) ->
   template.pageNum.set template.pageNum.get() + direction

--- a/client/controllers/maps/mapFilters.coffee
+++ b/client/controllers/maps/mapFilters.coffee
@@ -85,18 +85,20 @@ Template.mapFilters.events
     $(e.target).val("")
     setVariables instance, 'on', []
 
-  'click .map-event-list--item': (e, instance) ->
+  'click .map-event-list--item': (event, instance) ->
+    instance.data.loading.set(true)
     selectedEvents = instance.data.selectedEvents
     _id = @_id
     if selectedEvents.findOne(_id: _id)
       selectedEvents.remove(_id: _id)
     else
-      event = _.find(instance.data.templateEvents.get(), (e) -> e._id == _id)
+      userEvent = _.find(instance.data.templateEvents.get(), (e) -> e._id == _id)
       selectedEvents.insert
         _id: _id
         rgbColor: @rgbColor
-        eventName: event.eventName
+        eventName: userEvent.eventName
         selected: true
+        incidents: userEvent.incidents
 
   'click .toggle-calendar-state': (e, instance) ->
     calendarState = instance.calendarState

--- a/client/controllers/maps/mapFilters.coffee
+++ b/client/controllers/maps/mapFilters.coffee
@@ -86,7 +86,6 @@ Template.mapFilters.events
     setVariables instance, 'on', []
 
   'click .map-event-list--item': (event, instance) ->
-    instance.data.loading.set(true)
     selectedEvents = instance.data.selectedEvents
     _id = @_id
     if selectedEvents.findOne(_id: _id)

--- a/client/controllers/sourceModal.coffee
+++ b/client/controllers/sourceModal.coffee
@@ -208,7 +208,7 @@ Template.sourceModal.events
       else
         if enhance and instance.suggest
           notify('success', 'Source successfully added')
-          instance.subscribe 'ArticleIncidentReports', articleId
+          instance.subscribe 'articleIncidents', articleId
           Modal.show 'suggestedIncidentsModal',
             userEventId: userEventId
             article: Articles.findOne(articleId)

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -95,21 +95,9 @@ Router.route "/curator-inbox",
 
 Router.route "/events/curated-events/:_id/:_view?",
   name: 'curated-event'
-  title: ->
-    @data().userEvent.eventName
-  waitOn: ->
-    [
-      Meteor.subscribe "userEvent", @params._id
-      Meteor.subscribe "eventArticles", @params._id
-      Meteor.subscribe "eventIncidents", @params._id
-    ]
   data: ->
-    userEvent: UserEvents.findOne({'_id': @params._id})
-    articles: Articles.find
-      userEventIds: @params._id
-      url: $ne: ''
-      {sort: {publishDate: -1}}
-    incidents: Incidents.find({'userEventId': @params._id}, {sort: {date: -1}})
+    view: @params._view
+    userEventId: @params._id
 
 Router.route "/events/smart-events/:_id/:_view?",
   name: 'smart-event'

--- a/client/views/articles.jade
+++ b/client/views/articles.jade
@@ -49,20 +49,23 @@ template(name="articles")
             li Published on {{formatDate selectedSource.publishDate}}
             li Submitted by {{selectedSource.addedByUserName}} on {{formatDate selectedSource.addedDate}}
         .event-source-summary.container-flex
-          .event-source-summary--item
-            h5 Locations
-            ul.list-unstyled
-              each locationsForSource selectedSource
-                li= this
-              else
-                li No locations
-          .event-source-summary--item
-            h5 Incidents
-            ul.list-unstyled
-              each incidentsForSource selectedSource
-                li {{incidentToText this}}
-              else
-                li No cases
+          if incidentsLoaded
+            .event-source-summary--item
+              h5 Locations
+              ul.list-unstyled
+                each locationsForSource selectedSource
+                  li=this
+                else
+                  li No locations
+            .event-source-summary--item
+              h5 Incidents
+              ul.list-unstyled
+                  each incidentsForSource selectedSource
+                    li(class="{{#if incidentAssociatedWithEvent}} associated {{/if}}") {{incidentToText this}}
+                  else
+                    li No cases
+          else
+            +loading small=true
       else
         h4.make-selection Please select a document
 

--- a/client/views/articles.jade
+++ b/client/views/articles.jade
@@ -30,9 +30,10 @@ template(name="articles")
                 span
                   i.fa.fa-edit(aria-hidden="true")
               li.delete-source.link(
+                  class="{{#if eventHasArticleIncidents}}disabled{{/if}}"
                   data-toggle="tooltip"
                   data-placement="bottom"
-                  title="Remove from Event")
+                  data-original-title="{{#if eventHasArticleIncidents}}This article has implied association through its incidents and cannot be removed {{else}} Remove from Event{{/if}}")
                 span
                   i.fa.fa-trash(aria-hidden="true")
             li.link

--- a/client/views/events/curatedEvent.jade
+++ b/client/views/events/curatedEvent.jade
@@ -7,7 +7,9 @@ template(name="curatedEvent")
             | This event has been deleted
         else
           with userEvent
-            +summary
+            +summary(
+              event=this
+              documentCount=documentCount)
 
       section.event--detailed-info
         if incidents.count

--- a/client/views/events/curatedEvent.jade
+++ b/client/views/events/curatedEvent.jade
@@ -1,26 +1,29 @@
 template(name="curatedEvent")
-  .event
-    section.event--basic-info.container-fluid-padded
-      if deleted
-        h2
-          | This event has been deleted
-      else
-        with userEvent
-          +summary
+  if loaded
+    .event
+      section.event--basic-info.container-fluid-padded
+        if deleted
+          h2
+            | This event has been deleted
+        else
+          with userEvent
+            +summary
 
-    section.event--detailed-info
-      if incidents.count
-        .tabs-wrapper
-          ul.tabs.primary-tabs.container-fluid-padded(role="tablist")
-            li(class="{{#if incidentView}}active{{/if}}" role="presentation")
-              a(href="{{pathFor route='curated-event' _id=userEvent._id _view='incidents'}}") Incident Reports
-            li(class="{{#if locationView}}active{{/if}}" role="presentation")
-              a(href="{{pathFor route='curated-event' _id=userEvent._id _view='locations'}}") Locations
+      section.event--detailed-info
+        if incidents.count
+          .tabs-wrapper
+            ul.tabs.primary-tabs.container-fluid-padded(role="tablist")
+              li(class="{{#if incidentView}}active{{/if}}" role="presentation")
+                a(href="{{pathFor route='curated-event' _id=userEvent._id _view='incidents'}}") Incident Reports
+              li(class="{{#if locationView}}active{{/if}}" role="presentation")
+                a(href="{{pathFor route='curated-event' _id=userEvent._id _view='locations'}}") Locations
 
-        .tab-content
-          .tab-pane.active(role="tabpanel")
-            +Template.dynamic template=view data=templateData
+          .tab-content
+            .tab-pane.active(role="tabpanel")
+              +Template.dynamic template=view data=templateData
 
-    if articles.count
-      section.event--articles
-        +articles
+      if eventHasArticles
+        section.event--articles
+          +articles articleData
+  else
+    +loading

--- a/client/views/events/curatedEvent.jade
+++ b/client/views/events/curatedEvent.jade
@@ -9,6 +9,7 @@ template(name="curatedEvent")
           with userEvent
             +summary(
               event=this
+              incidentCount=incidents.count
               documentCount=documentCount)
 
       section.event--detailed-info

--- a/client/views/events/summary.jade
+++ b/client/views/events/summary.jade
@@ -20,7 +20,7 @@ template(name="summary")
     .event--metadata.container-flex
       .event--metadata--counts.container-flex.no-gutter.no-break
         .count.flex-col
-          span= caseCount
+          span= incidents.length
           h4 Incidents
           if isInRole "admin"
             +addIncidentReport class='-in-details'

--- a/client/views/events/summary.jade
+++ b/client/views/events/summary.jade
@@ -2,13 +2,13 @@ template(name="summary")
   .container-flex
     .event--details
       .event-name-wrap
-        h1.event-name= eventName
+        h1.event-name= event.eventName
         if isInRole "admin"
           +editDetailsButton(target="#edit-event-modal" icon="pencil" editing="name")
 
-      if summary
+      if event.summary
         p.summary(class="{{#if collapsed}}collapsed{{/if}}")
-          span= summary
+          span= event.summary
         if collapsed
           a.expand(tabindex="0") Expand full event summary
       else
@@ -20,12 +20,12 @@ template(name="summary")
     .event--metadata.container-flex
       .event--metadata--counts.container-flex.no-gutter.no-break
         .count.flex-col
-          span= incidents.length
+          span= event.incidents.length
           h4 Incidents
           if isInRole "admin"
             +addIncidentReport class='-in-details'
         .count.flex-col
-          span= articleCount
+          span= documentCount
           h4 Documents
           if isInRole "admin"
             +sourceModalButton class='-in-details'

--- a/client/views/events/summary.jade
+++ b/client/views/events/summary.jade
@@ -20,7 +20,7 @@ template(name="summary")
     .event--metadata.container-flex
       .event--metadata--counts.container-flex.no-gutter.no-break
         .count.flex-col
-          span= event.incidents.length
+          span= incidentCount
           h4 Incidents
           if isInRole "admin"
             +addIncidentReport class='-in-details'

--- a/client/views/incidentReports/incidentReport.jade
+++ b/client/views/incidentReports/incidentReport.jade
@@ -67,7 +67,11 @@ template(name="incidentReport")
 
       if isInRole "admin"
         .incident-report--details--actions.container-flex.no-break
-          a.edit
-            i.fa.fa-edit(aria-hidden="true" title="Edit incident")
-          a.delete
-            i.fa.fa-trash(aria-hidden="true" title="Delete incident")
+          a.edit(
+            title="Edit Incident"
+            data-toggle="tooltip")
+            i.fa.fa-edit(aria-hidden="true")
+          a.delete(
+            title="Remove Incident from Event"
+            data-toggle="tooltip")
+            i.fa.fa-trash(aria-hidden="true")

--- a/client/views/maps/eventMap.jade
+++ b/client/views/maps/eventMap.jade
@@ -6,9 +6,5 @@ template(name="eventMap")
         selectedEvents=selectedEvents
         disablePrev=disablePrev
         disableNext=disableNext
-        query=query
-        loading=incidentsLoading)
+        query=query)
       #event-map
-      unless incidentsLoaded
-        .event-map-loading.veil
-          +loading

--- a/client/views/maps/eventMap.jade
+++ b/client/views/maps/eventMap.jade
@@ -6,5 +6,9 @@ template(name="eventMap")
         selectedEvents=selectedEvents
         disablePrev=disablePrev
         disableNext=disableNext
-        query=query)
+        query=query
+        loading=incidentsLoading)
       #event-map
+      unless incidentsLoaded
+        .event-map-loading.veil
+          +loading

--- a/imports/collections/eventArticles.coffee
+++ b/imports/collections/eventArticles.coffee
@@ -1,0 +1,2 @@
+EventArticles = new Meteor.Collection('eventArticles')
+module.exports = EventArticles

--- a/imports/collections/eventIncidents.coffee
+++ b/imports/collections/eventIncidents.coffee
@@ -1,0 +1,2 @@
+EventIncidents = new Meteor.Collection('eventIncidents')
+module.exports = EventIncidents

--- a/imports/reactiveTable.coffee
+++ b/imports/reactiveTable.coffee
@@ -46,6 +46,7 @@ module.exports =
         isVisible: options.fieldVisibility[fieldName].get()
         sortOrder: options.sortOrder[fieldName].get()
         sortDirection: options.sortDirection[fieldName].get()
+        sortable: field.sortable
 
       if field.displayFn
         tableField.fn = field.displayFn

--- a/imports/reactiveTable.coffee
+++ b/imports/reactiveTable.coffee
@@ -50,6 +50,8 @@ module.exports =
 
       if field.displayFn
         tableField.fn = field.displayFn
+      if field.sortFn
+        tableField.sortFn = field.sortFn
       _fields.push(tableField)
     _fields
 

--- a/imports/schemas/incidentReport.coffee
+++ b/imports/schemas/incidentReport.coffee
@@ -40,9 +40,6 @@ IncidentReportSchema = new SimpleSchema
   locations:
     type: [Object]
     optional: true
-  userEventId:
-    type: String
-    optional: true
   dateRange:
     type: Object
   "dateRange.type":

--- a/imports/schemas/userEvent.coffee
+++ b/imports/schemas/userEvent.coffee
@@ -2,9 +2,6 @@ userEventSchema = new SimpleSchema
   _id:
     type: String
     optional: true
-  articleCount:
-    type: Number
-    optional: true
   createdByUserId:
     type: String
     optional: true

--- a/imports/schemas/userEvent.coffee
+++ b/imports/schemas/userEvent.coffee
@@ -42,5 +42,14 @@ userEventSchema = new SimpleSchema
   displayOnPromed:
     type: Boolean
     optional: true
+  incidents:
+    type: [Object]
+    optional: true
+  'incidents.id':
+    type: String
+  'incidents.associationDate':
+    type: Date
+  'incidents.associationUserId':
+    type: String
 
 module.exports = userEventSchema

--- a/imports/stylesheets/events/sources.import.styl
+++ b/imports/stylesheets/events/sources.import.styl
@@ -87,6 +87,8 @@
       color darken($border-primary, 40%)
 
   .event-source-summary
+    position relative
+    min-height 100px
     ul
       margin 0
       padding 0
@@ -94,6 +96,9 @@
       color lighten($body-text, 30%)
       li
         padding 0 0 1em 0
+        &.associated
+          font-weight bold
+
   .event-source-summary--item
     border-right 1px solid $border-primary-light
     padding 1.5em 1.25em

--- a/imports/stylesheets/events/sources.import.styl
+++ b/imports/stylesheets/events/sources.import.styl
@@ -57,6 +57,13 @@
               color darken($delete, 20%)
         &.edit-source
           padding-left .2em
+        &.disabled
+          cursor default
+          opacity .5
+          &:hover
+            background none
+            span
+              color darken($border-primary, 20%)
       &:not(.link)
         font-size .8em
       &:last-of-type

--- a/imports/stylesheets/maps/eventMap.import.styl
+++ b/imports/stylesheets/maps/eventMap.import.styl
@@ -15,6 +15,7 @@
     top $header-height
 
 #event-map
+.event-map-loading
   full-width()
   left $map-menu-width-small
   width $map-width-small

--- a/imports/stylesheets/notification.import.styl
+++ b/imports/stylesheets/notification.import.styl
@@ -13,6 +13,7 @@
   border 3px solid transparent
   h4
     font-size 1.5em
+    text-align center
   i
     font-size 10em
     text-align center

--- a/imports/stylesheets/tables.import.styl
+++ b/imports/stylesheets/tables.import.styl
@@ -11,6 +11,11 @@
 .table
   border 0
   margin-bottom 0
+  > thead
+    tr
+      th
+        &:not(.sortable)
+          cursor default
   > tbody
     > tr
       > td

--- a/methods/articles.coffee
+++ b/methods/articles.coffee
@@ -16,7 +16,6 @@ Meteor.methods
         # associated - push it
         Articles.update sourceQuery,
           $addToSet: userEventIds: eventId
-        Meteor.call('updateUserEventArticleCount', eventId)
         existingSource._id
       else
         source.userEventIds = [eventId]
@@ -25,8 +24,7 @@ Meteor.methods
         source.addedDate = new Date()
         ArticleSchema.validate(source)
         newId = Articles.insert(source)
-        Meteor.call('editUserEventLastModified', eventId)
-        Meteor.call('updateUserEventArticleCount', eventId)
+        Meteor.call("editUserEventLastModified", eventId)
         return newId
     else
       throw new Meteor.Error('auth',
@@ -62,8 +60,7 @@ Meteor.methods
       Articles.update id,
         $set:
           userEventIds: removed.userEventIds
-      Meteor.call('editUserEventLastModified', userEventId)
-      Meteor.call('updateUserEventArticleCount', userEventId)
+      Meteor.call("editUserEventLastModified", userEventId)
 
   markSourceReviewed: (id, reviewed) ->
     if Roles.userIsInRole(Meteor.userId(), ['curator', 'admin'])

--- a/methods/incidentReports.coffee
+++ b/methods/incidentReports.coffee
@@ -5,12 +5,15 @@ Articles = require '/imports/collections/articles.coffee'
 Constants = require '/imports/constants.coffee'
 { regexEscape } = require '/imports/utils'
 
+checkPermission = (userId) ->
+  if not Roles.userIsInRole(userId, ['admin'])
+    throw new Meteor.Error('auth', 'User does not have permission to create incidents')
+
 Meteor.methods
   addIncidentReport: (incident, userEventId) ->
-    incidentReportSchema.validate(incident)
     user = Meteor.user()
-    if not Roles.userIsInRole(user._id, ['admin'])
-      throw new Meteor.Error("auth", "User does not have permission to create incidents")
+    checkPermission(user._id)
+    incidentReportSchema.validate(incident)
     incident.addedByUserId = user._id
     incident.addedByUserName = user.profile.name
     incident.addedDate = new Date()
@@ -19,63 +22,65 @@ Meteor.methods
       Meteor.call('addIncidentToEvent', userEventId, newId)
     return newId
 
-
   # similar to editIncidentReport, but allows you to set a single field without changing any other existing fields.
   updateIncidentReport: (incident) ->
+    user = Meteor.user()
+    checkPermission(user._id)
     _id = incident._id
     delete incident._id
-    user = Meteor.user()
-    if not Roles.userIsInRole(user._id, ['admin'])
-      throw new Meteor.Error("auth", "User does not have permission to edit incidents")
     incident.modifiedByUserId = user._id
     incident.modifiedByUserName = user.profile.name
     res = Incidents.update({_id: _id}, {$set: incident})
     return incident._id
 
-  editIncidentReport: (incident, userEventId) ->
+  editIncidentReport: (incident) ->
+    user = Meteor.user()
+    checkPermission(user._id)
     incidentReportSchema.validate(incident)
     incidentId = incident._id
-    user = Meteor.user()
-    if not Roles.userIsInRole(user._id, ['admin'])
-      throw new Meteor.Error("auth", "User does not have permission to edit incidents")
     incident.modifiedByUserId = user._id
     incident.modifiedByUserName = user.profile.name
     res = Incidents.update(incidentId, incident)
+    userEventId = UserEvents.findOne('incidents.id': incidentId)._id
     if userEventId
-      Meteor.call("editUserEventLastModified", userEventId)
-      Meteor.call("editUserEventLastIncidentDate", userEventId)
+      Meteor.call('editUserEventLastModified', userEventId)
+      Meteor.call('editUserEventLastIncidentDate', userEventId)
     return incidentId
 
   addIncidentReports: (incidents, userEventId) ->
+    checkPermission(@userId)
     incidents.map (incident)->
-      Meteor.call("addIncidentReport", incident, userEventId)
+      Meteor.call('addIncidentReport', incident, userEventId)
 
   removeIncidentReport: (id) ->
-    if not Roles.userIsInRole(@userId, ['admin'])
-      throw new Meteor.Error("auth", "User does not have permission to edit incidents")
+    checkPermission(@userId)
     incident = Incidents.findOne(id)
     Incidents.update id,
       $set:
         deleted: true,
         deletedDate: new Date()
-    if incident.userEventId
-      Meteor.call("editUserEventLastModified", incident.userEventId)
-      Meteor.call("editUserEventLastIncidentDate", incident.userEventId)
+    userEventId = UserEvents.findOne('incidents.id': incidentId)._id
+    if userEventId
+      Meteor.call('editUserEventLastModified', userEventId)
+      Meteor.call('editUserEventLastIncidentDate', userEventId)
 
   addIncidentToEvent: (userEventId, incidentId) ->
     userId = Meteor.user()._id
-    if not Roles.userIsInRole(userId, ['admin'])
-      throw new Meteor.Error("auth", "User does not have permission to create incidents")
-    unless UserEvents.findOne('incidents.id': incidentId)
+    checkPermission(userId)
+    eventWithIncident = UserEvents.findOne
+      _id: userEventId
+      'incidents.id': incidentId
+    unless eventWithIncident
       UserEvents.update userEventId,
         $addToSet: incidents:
           id: incidentId
           associationDate: new Date()
           associationUserId: userId
-      Meteor.call("editUserEventLastModified", userEventId)
-      Meteor.call("editUserEventLastIncidentDate", userEventId)
+      Meteor.call('editUserEventLastModified', userEventId)
+      Meteor.call('editUserEventLastIncidentDate', userEventId)
 
   addIncidentsToEvent: (incidentIds, userEventId, source) ->
+    checkPermission(@userId)
     existingSource = Articles.findOne(source._id)
     # If document is in collection associate with event, otherwise add to Articles
     # collection and associate

--- a/methods/incidentReports.coffee
+++ b/methods/incidentReports.coffee
@@ -66,8 +66,13 @@ Meteor.methods
 
   removeIncidentFromEvent: (id) ->
     checkPermission(@userId)
+    incidents = UserEvents.findOne('incidents.id': id).incidents
+
+    _incidents = _.filter incidents, (incident) ->
+      incident.id != id
+
     UserEvents.update 'incidents.id': id,
-      $pull: 'incidents.id': id
+      $set: incidents: _incidents
 
   addIncidentToEvent: (userEventId, incidentId) ->
     userId = Meteor.user()._id

--- a/methods/incidentReports.coffee
+++ b/methods/incidentReports.coffee
@@ -52,7 +52,7 @@ Meteor.methods
     incidents.map (incident)->
       Meteor.call('addIncidentReport', incident, userEventId)
 
-  removeIncidentReport: (id) ->
+  removeIncident: (id) ->
     checkPermission(@userId)
     incident = Incidents.findOne(id)
     Incidents.update id,
@@ -63,6 +63,11 @@ Meteor.methods
     if userEventId
       Meteor.call('editUserEventLastModified', userEventId)
       Meteor.call('editUserEventLastIncidentDate', userEventId)
+
+  removeIncidentFromEvent: (id) ->
+    checkPermission(@userId)
+    UserEvents.update 'incidents.id': id,
+      $pull: 'incidents.id': id
 
   addIncidentToEvent: (userEventId, incidentId) ->
     userId = Meteor.user()._id

--- a/methods/userEvents.coffee
+++ b/methods/userEvents.coffee
@@ -24,7 +24,6 @@ Meteor.methods
         creationDate: now
         createdByUserId: user._id
         createdByUserName: user.profile.name
-        articleCount: 0
 
   deleteUserEvent: (id) ->
     if Roles.userIsInRole(Meteor.userId(), ['admin'])
@@ -46,14 +45,6 @@ Meteor.methods
           lastModifiedDate: new Date(),
           lastModifiedByUserId: user._id,
           lastModifiedByUserName: user.profile.name
-
-  updateUserEventArticleCount: (id) ->
-    event = UserEvents.findOne(id)
-    articleCount = Articles.find(userEventIds: id).count()
-    UserEvents.update(id,
-      $set:
-        articleCount: articleCount
-    )
 
   editUserEventLastIncidentDate: (id) ->
     event = UserEvents.findOne(id)

--- a/methods/userEvents.coffee
+++ b/methods/userEvents.coffee
@@ -47,13 +47,11 @@ Meteor.methods
           lastModifiedByUserName: user.profile.name
 
   editUserEventLastIncidentDate: (id) ->
-    event = UserEvents.findOne(id)
-    latestEventIncident = Incidents.findOne({
-      userEventId: event._id
+    incidentIds = _.pluck(UserEvents.findOne(id).incidents, 'id')
+    latestEventIncident = Incidents.findOne
+      _id: $in: incidentIds
       deleted: $in: [null, false]
-    }, {
-      sort: 'dateRange.end': -1
-    })
+      {sort: 'dateRange.end': -1}
     if latestEventIncident
       UserEvents.update id,
         $set:

--- a/packages/_tests/fixtures.coffee
+++ b/packages/_tests/fixtures.coffee
@@ -10,6 +10,41 @@ if Meteor.isAppTest
 
   syncExec = Meteor.wrapAsync(exec)
 
+  testEvent =
+    eventName: 'Test Event 1'
+    summary: 'Test summary'
+
+  testSource =
+    title: 'Test Article',
+    url: 'http://promedmail.org/post/418162'
+    publishDate: new Date()
+    publishDateTZ: 'EST'
+
+  testIncident =
+    species: 'Test Species'
+    cases: 375
+    locations: [
+      id: '5165418'
+      name: 'Ohio'
+      admin1Name: 'Ohio'
+      admin2Name: null
+      latitude: 40.25034
+      longitude: -83.00018
+      countryName: 'United States'
+      population: 11467123
+      featureClass: 'A'
+      featureCode: 'ADM1'
+      alternateNames: [
+        '\'Ohaio'
+        'Buckeye State'
+      ]
+    ]
+    dateRange:
+      start: new Date()
+      end: new Date()
+      cumulative: false
+      type: 'day'
+
   Meteor.methods
     ###
     # load the database from a dump file
@@ -29,46 +64,16 @@ if Meteor.isAppTest
         # Loading test data into database
         Meteor.call 'createTestingAdmin'
         console.log "created admin"
-        userEvent = Meteor.call 'upsertUserEvent',
-          eventName: 'Test Event 1',
-          summary: 'Test summary'
-          (error, userEvent) ->
-            console.log 'UserEvent created', userEvent
-            Meteor.call 'addEventSource',
-              title: 'Test Article',
-              url: 'http://promedmail.org/post/418162'
-              publishDate: new Date()
-              publishDateTZ: 'EST',
-              (error, articleId) ->
-                console.log 'Article created', articleId
-                Meteor.call 'addIncidentReport',
-                  articleId: articleId
-                  species: 'Test Species'
-                  cases: 1
-                  locations: [
-                    id: '5165418'
-                    name: 'Ohio'
-                    admin1Name: 'Ohio'
-                    admin2Name: null
-                    latitude: 40.25034
-                    longitude: -83.00018
-                    countryName: 'United States'
-                    population: 11467123
-                    featureClass: 'A'
-                    featureCode: 'ADM1'
-                    alternateNames: [
-                      '\'Ohaio'
-                      'Buckeye State'
-                    ]
-                  ]
-                  dateRange:
-                    start: new Date()
-                    end: new Date()
-                    cumulative: false
-                    type: 'day'
-                  (error, incidentId) ->
-                    console.log 'Incident created', incidentId
-                    Meteor.call 'addIncidentToEvent', userEvent.insertedId, incidentId
+        Meteor.call 'upsertUserEvent', testEvent, (error, { insertedId }) ->
+          eventId = insertedId
+          console.log 'UserEvent created', eventId
+          testSource.userEventIds = [eventId]
+          Meteor.call 'addEventSource', testSource, eventId, (error, articleId) ->
+            console.log 'Article created', articleId
+            testIncident.articleId = articleId
+            Meteor.call 'addIncidentReport', testIncident, (error, incidentId) ->
+              console.log 'Incident created', incidentId
+              Meteor.call 'addIncidentToEvent', eventId, incidentId
 
       catch error
         console.log "error loading data", error

--- a/packages/_tests/fixtures.coffee
+++ b/packages/_tests/fixtures.coffee
@@ -29,10 +29,10 @@ if Meteor.isAppTest
         # Loading test data into database
         Meteor.call 'createTestingAdmin'
         console.log "created admin"
-        userEvent = Meteor.call 'upsertUserEvent', 
+        userEvent = Meteor.call 'upsertUserEvent',
                     eventName: 'Test Event 1',
                     summary: 'Test summary'
-        article = Meteor.call 'addEventSource', 
+        article = Meteor.call 'addEventSource',
                     title: 'Test Article',
                     url: 'http://promedmail.org/post/418162'
                     publishDate: new Date()
@@ -40,8 +40,7 @@ if Meteor.isAppTest
                     userEvent.insertedId,
                     (error, article) ->
                       console.log "article", error, article
-        incident = Meteor.call 'addIncidentReport', 
-                    userEventId: userEvent.insertedId,
+        incident = Meteor.call 'addIncidentReport',
                     species: 'Test Species',
                     cases: 1,
                     dateRange: {}

--- a/packages/_tests/fixtures.coffee
+++ b/packages/_tests/fixtures.coffee
@@ -30,20 +30,45 @@ if Meteor.isAppTest
         Meteor.call 'createTestingAdmin'
         console.log "created admin"
         userEvent = Meteor.call 'upsertUserEvent',
-                    eventName: 'Test Event 1',
-                    summary: 'Test summary'
-        article = Meteor.call 'addEventSource',
-                    title: 'Test Article',
-                    url: 'http://promedmail.org/post/418162'
-                    publishDate: new Date()
-                    publishDateTZ: 'EST',
-                    userEvent.insertedId,
-                    (error, article) ->
-                      console.log "article", error, article
-        incident = Meteor.call 'addIncidentReport',
-                    species: 'Test Species',
-                    cases: 1,
-                    dateRange: {}
+          eventName: 'Test Event 1',
+          summary: 'Test summary'
+          (error, userEvent) ->
+            console.log 'UserEvent created', userEvent
+            Meteor.call 'addEventSource',
+              title: 'Test Article',
+              url: 'http://promedmail.org/post/418162'
+              publishDate: new Date()
+              publishDateTZ: 'EST',
+              (error, articleId) ->
+                console.log 'Article created', articleId
+                Meteor.call 'addIncidentReport',
+                  articleId: articleId
+                  species: 'Test Species'
+                  cases: 1
+                  locations: [
+                    id: '5165418'
+                    name: 'Ohio'
+                    admin1Name: 'Ohio'
+                    admin2Name: null
+                    latitude: 40.25034
+                    longitude: -83.00018
+                    countryName: 'United States'
+                    population: 11467123
+                    featureClass: 'A'
+                    featureCode: 'ADM1'
+                    alternateNames: [
+                      '\'Ohaio'
+                      'Buckeye State'
+                    ]
+                  ]
+                  dateRange:
+                    start: new Date()
+                    end: new Date()
+                    cumulative: false
+                    type: 'day'
+                  (error, incidentId) ->
+                    console.log 'Incident created', incidentId
+                    Meteor.call 'addIncidentToEvent', userEvent.insertedId, incidentId
 
       catch error
         console.log "error loading data", error

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -6,7 +6,8 @@ Feeds = require '/imports/collections/feeds.coffee'
 { regexEscape, cleanUrl } = require '/imports/utils'
 
 # Incidents
-ReactiveTable.publish 'curatorEventIncidents', Incidents, {deleted: {$in: [null, false]}}
+ReactiveTable.publish 'curatorEventIncidents', Incidents,
+  deleted: {$in: [null, false]}
 Meteor.publish 'eventIncidents', (incidentIds) ->
   Incidents.find
     _id: $in: incidentIds
@@ -36,14 +37,14 @@ Meteor.publish 'mapIncidents', (incidentIds) ->
   })
 
 # User Events
-ReactiveTable.publish('userEvents', UserEvents, {
+ReactiveTable.publish 'userEvents', UserEvents,
   deleted: {$in: [null, false]}
-}, {
-  fields:
-    lastModifiedDate: 1
-    eventName: 1
-    incidents: 1
-})
+  {
+    fields:
+      lastModifiedDate: 1
+      eventName: 1
+      incidents: 1
+  }
 Meteor.publish 'userEvent', (eidID) ->
   UserEvents.find({_id: eidID})
 Meteor.publish 'userEvents', ()->

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -36,7 +36,6 @@ ReactiveTable.publish('userEvents', UserEvents, {
   deleted: {$in: [null, false]}
 }, {
   fields:
-    articleCount: 1
     lastModifiedDate: 1
     eventName: 1
 })

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -7,8 +7,10 @@ Feeds = require '/imports/collections/feeds.coffee'
 
 # Incidents
 ReactiveTable.publish 'curatorEventIncidents', Incidents, {deleted: {$in: [null, false]}}
-Meteor.publish 'eventIncidents', (userEventId) ->
-  Incidents.find({userEventId: userEventId, deleted: {$in: [null, false]}})
+Meteor.publish 'eventIncidents', (incidentIds) ->
+  Incidents.find
+    _id: $in: incidentIds
+    deleted: $in: [null, false]
 Meteor.publish 'smartEventIncidents', (query) ->
   query.deleted = {$in: [null, false]}
   Incidents.find(query)

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -63,11 +63,16 @@ Meteor.publish 'ArticleIncidentReports', (articleId) ->
   Incidents.find articleId: articleId,
     sort: 'annotations.case.0.textOffsets.0': 1
 
-Meteor.publish 'eventArticles', (ueId) ->
-  Articles.find(
-    userEventIds: ueId
+Meteor.publish 'eventArticles', (userEventId, incidentIds) ->
+  incidentArticleIds = _.pluck(
+    Incidents.find(_id: $in: incidentIds, {fields: articleId: 1}).fetch()
+  , 'articleId')
+  Articles.find
+    $or: [
+      {_id: $in: incidentArticleIds}
+      {userEventIds: userEventId}
+    ]
     deleted: {$in: [null, false]}
-  )
 
 Meteor.publish 'articles', (query={}) ->
   query.deleted = {$in: [null, false]}

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -14,9 +14,9 @@ Meteor.publish 'eventIncidents', (incidentIds) ->
 Meteor.publish 'smartEventIncidents', (query) ->
   query.deleted = {$in: [null, false]}
   Incidents.find(query)
-Meteor.publish 'mapIncidents', (userEventIds) ->
+Meteor.publish 'mapIncidents', (incidentIds) ->
   Incidents.find({
-    userEventId: $in: userEventIds
+    _id: $in: incidentIds
     locations: $ne: null
     deleted: $in: [null, false]
   }, {

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -8,10 +8,13 @@ Feeds = require '/imports/collections/feeds.coffee'
 # Incidents
 ReactiveTable.publish 'curatorEventIncidents', Incidents,
   deleted: {$in: [null, false]}
-Meteor.publish 'eventIncidents', (incidentIds) ->
+Meteor.publish 'eventIncidents', (userEventId) ->
+  event = UserEvents.findOne(userEventId)
+  incidentIds = _.pluck(event.incidents, 'id')
   Incidents.find
     _id: $in: incidentIds
     deleted: $in: [null, false]
+
 Meteor.publish 'smartEventIncidents', (query) ->
   query = _.extend query,
     accepted: $in: [null, true]
@@ -67,11 +70,10 @@ Meteor.publish 'articleIncidents', (articleId) ->
   Incidents.find query,
     sort: 'annotations.case.0.textOffsets.0': 1
 
-Meteor.publish 'eventArticles', (userEventId, incidentIds) ->
-  incidents = Incidents.find
-    _id: $in: incidentIds
-    {fields: articleId: 1}
-  incidentArticleIds = _.pluck(incidents.fetch() , 'articleId')
+Meteor.publish 'eventArticles', (userEventId) ->
+  incidentIds = _.pluck(UserEvents.findOne(userEventId).incidents, 'id')
+  incidents = Incidents.find(_id: $in: incidentIds)
+  incidentArticleIds = _.pluck(incidents.fetch(), 'articleId')
   Articles.find
     $or: [
       {_id: $in: incidentArticleIds}

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -8,61 +8,29 @@ Feeds = require '/imports/collections/feeds.coffee'
 # Incidents
 ReactiveTable.publish 'curatorEventIncidents', Incidents,
   deleted: {$in: [null, false]}
-Meteor.publish 'eventIncidents', (userEventId) ->
-  event = UserEvents.findOne(userEventId)
-  incidentIds = _.pluck(event.incidents, 'id')
-  Incidents.find
-    _id: $in: incidentIds
-    deleted: $in: [null, false]
 
 Meteor.publish 'smartEventIncidents', (query) ->
   query = _.extend query,
     accepted: $in: [null, true]
     deleted: $in: [null, false]
   Incidents.find(query)
+
 Meteor.publish 'mapIncidents', (incidentIds) ->
-  Incidents.find({
+  Incidents.find
     _id: $in: incidentIds
     locations: $ne: null
     deleted: $in: [null, false]
-  }, {
-    fields:
-      userEventId: 1
-      'dateRange.start': 1
-      'dateRange.end': 1
-      'dateRange.cumulative': 1
-      locations: 1
-      cases: 1
-      deaths: 1
-      specify: 1
-  })
-
-# User Events
-ReactiveTable.publish 'userEvents', UserEvents,
-  deleted: {$in: [null, false]}
-  {
-    fields:
-      lastModifiedDate: 1
-      eventName: 1
-      incidents: 1
-  }
-Meteor.publish 'userEvent', (eidID) ->
-  UserEvents.find({_id: eidID})
-Meteor.publish 'userEvents', ()->
-  UserEvents.find({
-    deleted: $in: [null, false]
-  }, {
-    field:
-      eventName: 1
-      lastIncidentDate: 1
-  })
-
-# Smart Events
-ReactiveTable.publish 'smartEvents', SmartEvents, {deleted: {$in: [null, false]}}
-Meteor.publish 'smartEvent', (eidID) ->
-  SmartEvents.find({_id: eidID})
-Meteor.publish 'smartEvents', () ->
-  SmartEvents.find({deleted: {$in: [null, false]}})
+    {
+      fields:
+        userEventId: 1
+        'dateRange.start': 1
+        'dateRange.end': 1
+        'dateRange.cumulative': 1
+        locations: 1
+        cases: 1
+        deaths: 1
+        specify: 1
+    }
 
 Meteor.publish 'articleIncidents', (articleId) ->
   check(articleId, Match.Maybe(String))
@@ -70,17 +38,55 @@ Meteor.publish 'articleIncidents', (articleId) ->
   Incidents.find query,
     sort: 'annotations.case.0.textOffsets.0': 1
 
-Meteor.publish 'eventArticles', (userEventId) ->
-  incidentIds = _.pluck(UserEvents.findOne(userEventId).incidents, 'id')
-  incidents = Incidents.find(_id: $in: incidentIds)
-  incidentArticleIds = _.pluck(incidents.fetch(), 'articleId')
-  Articles.find
-    $or: [
-      {_id: $in: incidentArticleIds}
-      {userEventIds: userEventId}
-    ]
-    deleted: {$in: [null, false]}
+# User Events
+ReactiveTable.publish 'userEvents', UserEvents,
+  {deleted: $in: [null, false]},
+  fields:
+    lastModifiedDate: 1
+    eventName: 1
+    incidents: 1
 
+Meteor.publish 'userEvents', () ->
+  UserEvents.find deleted: $in: [null, false],
+    field:
+      eventName: 1
+      lastIncidentDate: 1
+
+Meteor.publishComposite 'userEvent', (eventId) ->
+  find: ->
+    UserEvents.find(_id: eventId)
+  children: [
+    {
+    collectionName: 'eventIncidents'
+    find: (event) ->
+      incidentIds = _.pluck(event.incidents, 'id')
+      Incidents.find
+        _id: $in: incidentIds
+        deleted: $in: [null, false]
+    }
+    {
+    collectionName: 'eventArticles'
+    find: (event) ->
+      incidents = Incidents.find(_id: $in: _.pluck(event.incidents, 'id'))
+      Articles.find
+        $or: [
+          {_id: $in: _.pluck(incidents.fetch(), 'articleId')}
+          {userEventIds: event._id}
+        ]
+        deleted: {$in: [null, false]}
+    }
+  ]
+
+# Smart Events
+ReactiveTable.publish 'smartEvents', SmartEvents, deleted: $in: [null, false]
+
+Meteor.publish 'smartEvent', (eidID) ->
+  SmartEvents.find({_id: eidID})
+
+Meteor.publish 'smartEvents', () ->
+  SmartEvents.find({deleted: {$in: [null, false]}})
+
+# Articles
 Meteor.publish 'articles', (query={}) ->
   query.deleted = {$in: [null, false]}
   Articles.find(query)
@@ -91,6 +97,7 @@ Meteor.publish 'article', (sourceId) ->
 Meteor.publish 'incidentArticle', (articleId) ->
   Articles.find(articleId)
 
+# Feeds
 Meteor.publish 'feeds', ->
   Feeds.find()
 

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -38,6 +38,7 @@ ReactiveTable.publish('userEvents', UserEvents, {
   fields:
     lastModifiedDate: 1
     eventName: 1
+    incidents: 1
 })
 Meteor.publish 'userEvent', (eidID) ->
   UserEvents.find({_id: eidID})

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -11,18 +11,16 @@ ReactiveTable.publish 'curatorEventIncidents', Incidents,
 Meteor.publish 'eventIncidents', (incidentIds) ->
   Incidents.find
     _id: $in: incidentIds
-    accepted: true
     deleted: $in: [null, false]
 Meteor.publish 'smartEventIncidents', (query) ->
   query = _.extend query,
-    deleted: {$in: [null, false]}
-    accepted: true
+    accepted: $in: [null, true]
+    deleted: $in: [null, false]
   Incidents.find(query)
 Meteor.publish 'mapIncidents', (incidentIds) ->
   Incidents.find({
     _id: $in: incidentIds
     locations: $ne: null
-    accepted: true
     deleted: $in: [null, false]
   }, {
     fields:
@@ -63,18 +61,15 @@ Meteor.publish 'smartEvent', (eidID) ->
 Meteor.publish 'smartEvents', () ->
   SmartEvents.find({deleted: {$in: [null, false]}})
 
-Meteor.publish 'articleIncidents', (articleId, onlyAccepted=false) ->
+Meteor.publish 'articleIncidents', (articleId) ->
   check(articleId, Match.Maybe(String))
   query = articleId: articleId
-  if onlyAccepted
-    query.accepted = true
   Incidents.find query,
     sort: 'annotations.case.0.textOffsets.0': 1
 
 Meteor.publish 'eventArticles', (userEventId, incidentIds) ->
   incidents = Incidents.find
     _id: $in: incidentIds
-    accepted: true
     {fields: articleId: 1}
   incidentArticleIds = _.pluck(incidents.fetch() , 'articleId')
   Articles.find

--- a/server/updaters.coffee
+++ b/server/updaters.coffee
@@ -29,6 +29,10 @@ Meteor.startup ->
     Incidents.update _id: incident._id,
       $unset: userEventId: ''
 
+  UserEvents.update {},
+    $unset: articleCount: ''
+    {multi: true}
+
   Incidents.find(disease: $exists: false).forEach (incident) ->
     disease = UserEvents.findOne(incident.userEventId)?.disease
     if disease

--- a/server/updaters.coffee
+++ b/server/updaters.coffee
@@ -19,20 +19,6 @@ Meteor.startup ->
     return
   console.log "Running database update code..."
 
-  Incidents.find(userEventId: $exists: true).forEach (incident) ->
-    incidentData =
-      id: incident._id
-      associationDate: incident.creationDate or new Date
-      associationUserId: incident.addedByUserId or ''
-    UserEvents.update _id: incident.userEventId,
-      $addToSet: incidents: incidentData
-    Incidents.update _id: incident._id,
-      $unset: userEventId: ''
-
-  UserEvents.update {},
-    $unset: articleCount: ''
-    {multi: true}
-
   Incidents.find(disease: $exists: false).forEach (incident) ->
     disease = UserEvents.findOne(incident.userEventId)?.disease
     if disease
@@ -121,6 +107,20 @@ Meteor.startup ->
   Articles.find({userEventIds: $exists: false}).forEach (article) ->
     Articles.update _id: article._id,
       $set: userEventIds: [article.userEventId]
+
+  Incidents.find(userEventId: $exists: true).forEach (incident) ->
+    incidentData =
+      id: incident._id
+      associationDate: incident.creationDate or new Date
+      associationUserId: incident.addedByUserId or ''
+    UserEvents.update _id: incident.userEventId,
+      $addToSet: incidents: incidentData
+    Incidents.update _id: incident._id,
+      $unset: userEventId: ''
+
+  UserEvents.update {},
+    $unset: articleCount: ''
+    {multi: true}
 
   AppMetadata.upsert({property: "dataVersion"}, $set: {value: DATA_VERSION})
   console.log "database update complete"

--- a/tests/features/eventMap.feature
+++ b/tests/features/eventMap.feature
@@ -1,4 +1,4 @@
-@eventMap @dev
+@eventMap
 Feature: Event Map
 
   Background:

--- a/tests/features/eventMap.feature
+++ b/tests/features/eventMap.feature
@@ -1,0 +1,11 @@
+@eventMap @dev
+Feature: Event Map
+
+  Background:
+    Given I am logged in as an admin
+    And I navigate to "/event-map"
+
+  Scenario: View incidents on event map
+    When I click the first event in the list
+    When I click on a map marker
+    Then I should see content "1 case in Ohio"

--- a/tests/features/incident.feature
+++ b/tests/features/incident.feature
@@ -11,6 +11,15 @@ Feature: Incident
     Then I should see a "success" notification
     And I should see a scatter plot group with count "100000001"
 
+  Scenario: Remove an incident report
+    When I navigate to "/events"
+    And I click the first item in the event list
+    Then I should see content "375"
+    And I view details of the first incident
+    Then I should see content "Test Species"
+    Then I remove the first incident
+    Then I should not see content "375"
+
   @ignore
   Scenario: Add suggested source and abandon changes
     When I navigate to "/events"

--- a/tests/features/sources.feature
+++ b/tests/features/sources.feature
@@ -7,7 +7,7 @@ Feature: Documentss
     And I toggle sorting on the "eventName" column
     And I toggle sorting on the "eventName" column
     And I navigate to the first event
-    
+
   Scenario: I add a custom document to an event
     When I click on the add document button
     And I create a document with a title of "Test Document", url of "http://www.promedmail.org/post/2579682", and datetime of now
@@ -21,7 +21,9 @@ Feature: Documentss
     Then I should see content "Updated Title"
 
   Scenario: I delete an existing document
-    When I select the existing document
-    Then I delete the existing document
+    When I view details of the first incident
+    Then I remove the first incident
+    And I select the existing document
+    And I delete the existing document
     And I "confirm" deletion
     Then I should see an empty documents table

--- a/tests/features/step_definitions/curator_inbox_steps.coffee
+++ b/tests/features/step_definitions/curator_inbox_steps.coffee
@@ -45,7 +45,7 @@ do ->
       @client.click('.save-source')
 
     @Then /^I should see the content of the document$/, ->
-      @client.waitForExist('.selectable-content', 5000)
+      @client.waitForExist('.selectable-content')
 
     @Then /^I should see accepted or rejected incidents$/, ->
-      @client.waitForExist('.incident-table tbody tr', 5000)
+      @client.waitForExist('.incident-table tbody tr')

--- a/tests/features/step_definitions/eventMap_steps.coffee
+++ b/tests/features/step_definitions/eventMap_steps.coffee
@@ -1,0 +1,11 @@
+do ->
+  'use strict'
+
+  module.exports = ->
+    url = require('url')
+
+    @Then /^I click the first event in the list$/, ->
+      @client.clickWhenVisible('.map-event-list li:first-child')
+
+    @Then /^I click on a map marker$/, ->
+      @client.clickWhenVisible('.map-marker')

--- a/tests/features/step_definitions/incident_steps.coffee
+++ b/tests/features/step_definitions/incident_steps.coffee
@@ -111,10 +111,10 @@ do ->
       @client.waitForVisible('.suggested-annotated-content')
 
     @Then 'I open the first incident', ->
-      if @client.isVisible('.incident-table-tab')
-        @client.click('.incident-table-tab')
-      @client.clickWhenVisible('.incident-report')
-      @client.waitForVisible('[name="count"]')
+      if client.isVisible('.incident-table-tab')
+        client.click('.incident-table-tab')
+      client.clickWhenVisible('.incident-report')
+      client.waitForVisible('[name="count"]')
 
     @Then 'I set the count to "$count"', (count)->
       @client.setValue('[name="count"]', count)
@@ -126,3 +126,10 @@ do ->
     @Then 'the first incident should have a count of "$count"', (count)->
       text = @client.getText('.incident-report')
       assert.ok(text[0].indexOf(count) > 0)
+
+    @Then 'I view details of the first incident', ->
+      @client.clickWhenVisible('#event-incidents-table tbody tr:first-child')
+
+    @Then 'I remove the first incident', ->
+      @client.clickWhenVisible('.delete')
+      @client.pause(3000)

--- a/tests/features/step_definitions/incident_steps.coffee
+++ b/tests/features/step_definitions/incident_steps.coffee
@@ -24,7 +24,7 @@ do ->
     @When /^I add an incident with count "([^']*)"$/, (count) ->
       if not @client.waitForVisible(firstEvent)
         throw new Error('Event Incidents table is empty')
-      @client.click('button.open-incident-form')
+      @client.click('button.open-incident-form-in-details')
       # article URL
       @client.clickWhenVisible('span[aria-labelledby="select2-articleSource-container"]')
       @client.clickWhenVisible('#select2-articleSource-results li:first-child')


### PR DESCRIPTION
[PT Chore](https://www.pivotaltracker.com/story/show/143506429)

Stores incidents on events like so:
```javascript
  "incidents": [
    {
      "id": "QAbNzThLNd2m7iyzu",
      "associationDate": ISODate("2017-05-12T02:30:34.030Z"),
      "associationUserId": "DwM8KgCMHjKxgpRdj"
    },
    {
      "id": "z6sEaZhedATuJz6AE",
      "associationDate": ISODate("2017-05-12T02:30:34.218Z"),
      "associationUserId": "DwM8KgCMHjKxgpRdj"
    }
  ]
```
I also updated the article list on event pages to show articles with implied association—incidents from the article have been associated with the event, but not the article itself (explicitly).

To prevent inconsistent data with counts I removed the document count from the table. Is this crucial?
