### PR TITLE
Remove existing incident type props when incident types changes

### DIFF
--- a/client/controllers/incidentReports/annotatedContent.coffee
+++ b/client/controllers/incidentReports/annotatedContent.coffee
@@ -71,7 +71,7 @@ Template.annotatedContent.events
           source.enhancements.source.cleanContent.content, incident
         )
         Modal.show 'suggestedIncidentModal',
-          articles: [source]
+          articleId: source._id
           incident: incident
           incidentText: Spacebars.SafeString(snippetHtml)
           offCanvasStartPosition: 'top'

--- a/client/controllers/incidentReports/incidentModal.coffee
+++ b/client/controllers/incidentReports/incidentModal.coffee
@@ -83,20 +83,8 @@ Template.incidentModal.events
         instance.submitting.set(false)
 
     if @edit
-      _incident = _.extend({}, @incident, incident)
-
-      # Remove existing type props if user changes incident type
-      fieldsToRemove = []
-      if incident.cases
-        fieldsToRemove = ['deaths', 'specify']
-      else if incident.deaths
-        fieldsToRemove = ['cases', 'specify']
-      else if incident.specify
-        fieldsToRemove = ['cases', 'deaths']
-      fieldsToRemove.forEach (field) ->
-        delete _incident[field]
-
-      Meteor.call 'updateIncidentReport', _incident, fieldsToRemove, (error, result) ->
+      incident._id = @incident._id
+      Meteor.call 'editIncidentReport', incident, (error, result) ->
         if not error
           $('.reactive-table tr').removeClass('open')
           $('.reactive-table tr.details').remove()

--- a/client/controllers/incidentReports/incidentModal.coffee
+++ b/client/controllers/incidentReports/incidentModal.coffee
@@ -83,8 +83,20 @@ Template.incidentModal.events
         instance.submitting.set(false)
 
     if @edit
-      incident = _.extend({}, @incident, incident)
-      Meteor.call 'editIncidentReport', incident, (error, result) ->
+      _incident = _.extend({}, @incident, incident)
+
+      # Remove existing type props if user changes incident type
+      fieldsToRemove = []
+      if incident.cases
+        fieldsToRemove = ['deaths', 'specify']
+      else if incident.deaths
+        fieldsToRemove = ['cases', 'specify']
+      else if incident.specify
+        fieldsToRemove = ['cases', 'deaths']
+      fieldsToRemove.forEach (field) ->
+        delete _incident[field]
+
+      Meteor.call 'updateIncidentReport', _incident, fieldsToRemove, (error, result) ->
         if not error
           $('.reactive-table tr').removeClass('open')
           $('.reactive-table tr.details').remove()

--- a/client/controllers/incidentReports/incidentReports.coffee
+++ b/client/controllers/incidentReports/incidentReports.coffee
@@ -220,7 +220,6 @@ Template.incidentReports.events
   'click .reactive-table tbody tr .edit': (event, instance) ->
     instanceData = instance.data
     incident =
-      articles: instanceData.articles
       userEventId: instanceData.userEvent._id
       edit: true
       incident: @

--- a/client/controllers/incidentReports/incidentTable.coffee
+++ b/client/controllers/incidentReports/incidentTable.coffee
@@ -158,10 +158,10 @@ Template.incidentTable.events
     source = instance.data.source
     snippetHtml = buildAnnotatedIncidentSnippet(source.enhancements.source.cleanContent.content, @, false)
     Modal.show 'suggestedIncidentModal',
-      articles: [source]
-      userEventId: null
       incident: @
       incidentText: Spacebars.SafeString(snippetHtml)
+      articleId: source._id
+      userEventId: null
       offCanvasStartPosition: 'top'
       showBackdrop: true
 

--- a/client/controllers/incidentReports/incidentTable.coffee
+++ b/client/controllers/incidentReports/incidentTable.coffee
@@ -172,9 +172,9 @@ Template.incidentTable.events
       accept = false
     selectedIncidents = instance.selectedIncidents
     selectedIncidents.find(instance.acceptedQuery()).forEach (incident) ->
-      incident = _id: incident.id
+      incident = incident
       incident.accepted = accept
-      Meteor.call 'updateIncidentReport', incident, (error, result) ->
+      Meteor.call 'editIncidentReport', incident, (error, result) ->
         if error
           notify('error', 'There was a problem updating your incidents.')
           return

--- a/client/controllers/incidentReports/newIncidentFromSelection.coffee
+++ b/client/controllers/incidentReports/newIncidentFromSelection.coffee
@@ -73,7 +73,7 @@ Template.newIncidentFromSelection.events
       source.enhancements.source.cleanContent.content, incident
     )
     Modal.show 'suggestedIncidentModal',
-      articles: [source]
+      articleId: source._id
       incident: incident
       incidentText: Spacebars.SafeString(snippetHtml)
       offCanvasStartPosition: 'top'

--- a/client/controllers/incidentReports/suggestedIncidentModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentModal.coffee
@@ -80,10 +80,9 @@ Template.suggestedIncidentModal.events
         $set:
           accepted: false
     else
-      Meteor.call 'updateIncidentReport', {
-        _id: instance.incident._id
-        accepted: false
-      }, (error, result) =>
+      incident = isntance.incident
+      incident.accepted = false
+      Meteor.call 'editIncidentReport', instance, (error, result) =>
         if error
           toastr.error "Error: " + error
     stageModals(instance, instance.modals)

--- a/client/controllers/incidentReports/suggestedIncidentModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentModal.coffee
@@ -31,8 +31,7 @@ Template.suggestedIncidentModal.onCreated ->
       method = 'editIncidentReport'
       action = 'updated'
 
-    incident.annotations = @data.incident?.annotations
-    incident = _.pick(incident, incidentReportSchema.objectKeys())
+    # incident.annotations = @data.incident?.annotations
     Meteor.call method, incident, userEventId, (error, result) =>
       if error
         return notify('error', error)
@@ -80,7 +79,7 @@ Template.suggestedIncidentModal.events
         $set:
           accepted: false
     else
-      incident = isntance.incident
+      incident = instance.incident
       incident.accepted = false
       Meteor.call 'editIncidentReport', instance, (error, result) =>
         if error
@@ -100,10 +99,11 @@ Template.suggestedIncidentModal.events
     incident = utils.incidentReportFormToIncident(instance.$("form")[0])
 
     return if not incident
-    incident.suggestedFields = instance.incident.suggestedFields.get()
     incident.accepted = true
-    incident = _.extend({}, instanceData.incident, incident)
+    incident._id = instanceData.incident._id
     if instanceData.incidentCollection
+      incident = _.extend({}, instanceData.incident, incident)
+      incident.suggestedFields = instance.incident.suggestedFields.get()
       delete incident._id
       instanceData.incidentCollection.update instance.incident._id,
         $unset:
@@ -114,5 +114,4 @@ Template.suggestedIncidentModal.events
       notify('success', 'Incident Accepted', 1200)
       stageModals(instance, instance.modals)
     else
-      incident = _.extend({}, instance.data.incident, incident)
       instance.editIncident(incident, instanceData.userEventId)

--- a/client/controllers/incidentReports/suggestedIncidentModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentModal.coffee
@@ -74,17 +74,19 @@ Template.suggestedIncidentModal.events
 
   'click .reject': (event, instance) ->
     instanceData = instance.data
+    incident = instance.incident
+    incidentId = incident._id
     if instanceData.incidentCollection
-      instanceData.incidentCollection.update instance.incident._id,
+      instanceData.incidentCollection.update incidentId,
         $set:
           accepted: false
     else
-      incident = instance.incident
-      incident.accepted = false
-      Meteor.call 'editIncidentReport', instance, (error, result) =>
-        if error
-          toastr.error "Error: " + error
-    stageModals(instance, instance.modals)
+      stageModals(instance, instance.modals)
+      console.log instance.incident
+      Modal.show 'deleteConfirmationModal',
+        objNameToDelete: 'incident'
+        objId: incidentId
+        displayName: incident.annotations.case[0].text
 
   'click .cancel': (event, instance) ->
     stageModals(instance, instance.modals)

--- a/client/controllers/incidentReports/suggestedIncidentsModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentsModal.coffee
@@ -35,7 +35,7 @@ showSuggestedIncidentModal = (event, instance)->
   snippetHtml = buildAnnotatedIncidentSnippet(content, incident, false)
 
   Modal.show 'suggestedIncidentModal',
-    articles: [instance.data.article]
+    articleId: instance.data.articleId
     userEventId: instance.data.userEventId
     incidentCollection: instance.collection()
     incident: incident

--- a/client/views/downloadCSVModal.jade
+++ b/client/views/downloadCSVModal.jade
@@ -20,5 +20,5 @@ template(name="downloadCSVModal")
                   each columns
                     td {{getField row name}}
         .modal-footer
-          button.btn.btn-default.confirm-close-modal(type="button" data-dismiss="modal") Close
+          button.btn.btn-default.confirm-close-modal.on-left(type="button" data-dismiss="modal") Close
           button.btn.btn-default.download-csv(type="button" data-type="csv") Download CSV

--- a/client/views/events/createEventModal.jade
+++ b/client/views/events/createEventModal.jade
@@ -26,5 +26,5 @@ template(name="createEventModal")
                   tabindex="-1")
                 label(for="promed" tabindex="0") Display this event on promedmail.org?
           .modal-footer
-            button.btn.btn-default(type="button" data-dismiss="modal") Cancel
+            button.btn.btn-default.on-left(type="button" data-dismiss="modal") Cancel
             button#add-event-btn.btn.btn-primary(type="submit") Create Event#{associationMessage}

--- a/client/views/events/editEventDetailsModal.jade
+++ b/client/views/events/editEventDetailsModal.jade
@@ -39,9 +39,10 @@ template(name="editEventDetailsModal")
 
           unless confirmingDeletion
             .modal-footer
-              unless adding
-                button.btn.btn-danger.delete-event.pull-left(type="button") Delete Event
-              button.btn.btn-default(type="button" data-dismiss="modal") Cancel
+              .on-left
+                unless adding
+                  button.btn.btn-danger.delete-event.on-left(type="button") Delete Event
+                button.btn.btn-default(type="button" data-dismiss="modal") Cancel
               button.btn.btn-success.btn-wide.save-modal(type="submit")
                 if saveActionMessage
                   {{saveActionMessage}}

--- a/client/views/incidentReports/incidentModal.jade
+++ b/client/views/incidentReports/incidentModal.jade
@@ -24,7 +24,7 @@ template(name="incidentModal")
             +incidentForm incident=incident articles=articles valid=valid
 
         .modal-footer
-          button.btn.btn-default(type="button" data-dismiss="modal") Close
+          button.btn.btn-default.on-left(type="button" data-dismiss="modal") Cancel
           if add
             button.btn.btn-primary.save-incident-duplicate(type="button"
             disabled="{{#if submitting}} true {{/if}}") Save then Duplicate

--- a/client/views/incidentReports/suggestedIncidentModal.jade
+++ b/client/views/incidentReports/suggestedIncidentModal.jade
@@ -31,8 +31,7 @@ template(name="suggestedIncidentModal")
             confirmation=true
             valid=valid)
         .modal-footer
-          if edit
+          .on-left
             button.btn.btn-default.cancel(type="button") Cancel
-          else
-            button.btn.btn-default.reject(type="button") Delete
+            button.btn.btn-danger.reject(type="button") Delete
           button.btn.btn-primary.save-modal(type="button")=saveButtonText

--- a/client/views/incidentReports/suggestedIncidentsModal.jade
+++ b/client/views/incidentReports/suggestedIncidentsModal.jade
@@ -66,7 +66,7 @@ template(name="suggestedIncidentsModal")
                         td=species
                         td=incidentProperties
         .modal-footer
-          button.btn.btn-default.confirm-close-modal(type="button" data-dismiss="modal") Close
+          button.btn.btn-default.confirm-close-modal.on-left(type="button" data-dismiss="modal") Close
           if showTable
             button.btn.btn-default#save-csv(type="button" data-type="csv") Download CSV
           if saveResults

--- a/client/views/smartEvents/editSmartEventDetailsModal.jade
+++ b/client/views/smartEvents/editSmartEventDetailsModal.jade
@@ -53,9 +53,10 @@ template(name="editSmartEventDetailsModal")
 
           unless confirmingDeletion
             .modal-footer
-              unless adding
-                button.btn.btn-danger.delete-event.pull-left(type="button") Delete Event
-              button.btn.btn-default(type="button" data-dismiss="modal") Cancel
+              .on-left
+                unless adding
+                  button.btn.btn-danger.delete-event(type="button") Delete Event
+                button.btn.btn-default(type="button" data-dismiss="modal") Cancel
               button.btn.btn-success.btn-wide.save-modal(type="submit")
                 if saveActionMessage
                   {{saveActionMessage}}

--- a/client/views/sourceModal.jade
+++ b/client/views/sourceModal.jade
@@ -107,5 +107,5 @@ template(name="sourceModal")
                     label(for="enhance" tabindex="0") Suggest incidents
 
         .modal-footer
-          button.btn.btn-default(type="button" data-dismiss="modal") Close
+          button.btn.btn-default.on-left(type="button" data-dismiss="modal") Cancel
           button.btn.btn-primary(type="button" class=saveButtonClass) Save

--- a/imports/stylesheets/modals/modals.import.styl
+++ b/imports/stylesheets/modals/modals.import.styl
@@ -19,6 +19,7 @@ $modal-transition-time-opacity = .25s
     .modal-header
     .modal-footer
       flex 0 0 auto
+
   &.wide
     .modal-dialog
       width 95%
@@ -116,6 +117,8 @@ $modal-transition-time-opacity = .25s
   border-color $border-primary
 
 .modal-footer
+  display flex
+  justify-content flex-end
   white-space nowrap
   padding-top 1.25em
   padding-bottom 2em

--- a/imports/stylesheets/ui.import.styl
+++ b/imports/stylesheets/ui.import.styl
@@ -43,13 +43,14 @@
   &:last-of-type
     margin-right 0
     border-right 0
-  &.on-left
-    margin-right auto
-  &.on-right
-    margin-left auto
   &.items-right
     display flex
     justify-content flex-end
+
+.on-left
+  margin-right auto
+.on-right
+  margin-left auto
 
 .flex-row
   flex-direction column

--- a/methods/incidentReports.coffee
+++ b/methods/incidentReports.coffee
@@ -22,21 +22,6 @@ Meteor.methods
       Meteor.call('addIncidentToEvent', userEventId, newId)
     return newId
 
-  # similar to editIncidentReport, but allows you to set a single field without changing any other existing fields.
-  updateIncidentReport: (incident, fieldsToRemove=[]) ->
-    user = Meteor.user()
-    checkPermission(user._id)
-    _id = incident._id
-    delete incident._id
-    incident.modifiedByUserId = user._id
-    incident.modifiedByUserName = user.profile.name
-    res = Incidents.update _id: _id,
-      $set: incident
-    if incident.userEventId
-      Meteor.call("editUserEventLastModified", incident.userEventId)
-      Meteor.call("editUserEventLastIncidentDate", incident.userEventId)
-    return incident._id
-
   editIncidentReport: (incident) ->
     user = Meteor.user()
     checkPermission(user._id)

--- a/methods/incidentReports.coffee
+++ b/methods/incidentReports.coffee
@@ -35,8 +35,11 @@ Meteor.methods
       fieldsToRemove = cases: true, specify: true
     else if incident.specify
       fieldsToRemove = cases: true, deaths: true
+    unless incident.status
+      fieldsToRemove.status = true
+
     existingIncident = Incidents.findOne(incident._id)
-    updatedIncident = _.extend(existingIncident, incident)
+    updatedIncident = _.extend({}, existingIncident, incident)
     updateOperators = {}
     if fieldsToRemove
       updateOperators = $unset: fieldsToRemove

--- a/methods/incidentReports.coffee
+++ b/methods/incidentReports.coffee
@@ -66,7 +66,7 @@ Meteor.methods
       $set:
         deleted: true,
         deletedDate: new Date()
-    userEventId = UserEvents.findOne('incidents.id': incidentId)._id
+    userEventId = UserEvents.findOne('incidents.id': id)?._id
     if userEventId
       Meteor.call('editUserEventLastModified', userEventId)
       Meteor.call('editUserEventLastIncidentDate', userEventId)

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -34,7 +34,9 @@ Meteor.publish 'mapIncidents', (incidentIds) ->
 
 Meteor.publish 'articleIncidents', (articleId) ->
   check(articleId, Match.Maybe(String))
-  query = articleId: articleId
+  query =
+    articleId: articleId
+    deleted: $in: [null, false]
   Incidents.find query,
     sort: 'annotations.case.0.textOffsets.0': 1
 

--- a/tests/features/incident.feature
+++ b/tests/features/incident.feature
@@ -11,14 +11,17 @@ Feature: Incident
     Then I should see a "success" notification
     And I should see a scatter plot group with count "100000001"
 
-  Scenario: Remove an incident report
+  Scenario: Edit an incident report
     When I navigate to "/events"
     And I click the first item in the event list
-    Then I should see content "375"
-    And I view details of the first incident
-    Then I should see content "Test Species"
-    Then I remove the first incident
-    Then I should not see content "375"
+    And I click the first incident
+    When I open the edit incident report modal
+    Then I change the incident "location" to "Earth"
+    And I change the incident "deaths" to "1000"
+    Then I save the incident
+    Then I should not see content "357"
+    And I should see content "1000"
+    And I should see content "Earth"
 
   @ignore
   Scenario: Add suggested source and abandon changes

--- a/tests/features/step_definitions/incident_steps.coffee
+++ b/tests/features/step_definitions/incident_steps.coffee
@@ -41,6 +41,34 @@ do ->
       # Submit
       @client.click('button.save-incident[type="button"]')
 
+    @When /^I click the first incident$/, ->
+      @client.click('#event-incidents-table tbody tr:first-child')
+
+    @When /^I open the edit incident report modal$/, ->
+      @client.clickWhenVisible('.incident-report--details--actions .edit i')
+      @client.waitForVisible('.incident-report.modal')
+
+    @When /^I save the incident$/, ->
+      @browser.scroll(0, 1000)
+      @client.click('.save-incident')
+
+    @When /^I change the incident "([^']*)" to "([^']*)"$/, (propertyName, value) ->
+      types = ['deaths', 'cases', 'other']
+      if propertyName in types
+        @client.click("label[for='#{propertyName}']")
+        @client.pause()
+        if propertyName is 'other'
+          @client.waitForVisible('[name="other"]')
+          @client.setValue('[name="other"]', value)
+        else
+          @client.waitForVisible('[name="count"]')
+          @client.setValue('[name="count"]', value)
+      else if propertyName is 'location'
+        @client.setValue('input.select2-search__field', value)
+        @client.clickWhenVisible('.select2-results__option--highlighted')
+      else
+        @client.setValue("[name='#{propertyName}']", value)
+
     @When /^I should see a scatter plot group with count "([^']*)"$/, (count) ->
       @client.pause(2000)
       selector = "[id*=\":#{count}:false\"]"


### PR DESCRIPTION
[Fixes this bug](https://www.pivotaltracker.com/story/show/145504331)
Looks like there are 19 incidents that have both `cases` and `deaths` properties but most, if not all, instances have the same value. This will cause issues if the incidents are edited in the future. We may want to review these incidents and manually change the type?