### PR TITLE
Hide rejected incidents table

### DIFF
--- a/client/controllers/curatorInbox/curatorSourceDetails.coffee
+++ b/client/controllers/curatorInbox/curatorSourceDetails.coffee
@@ -124,7 +124,7 @@ Template.curatorSourceDetails.helpers
   selectedAnnotationId: ->
     Template.instance().selectedAnnotationId
 
-  hasTextContent: ->
+  textContent: ->
     Template.instance().source.get().enhancements.source?.cleanContent?.content
 
 Template.curatorSourceDetails.events

--- a/client/controllers/curatorInbox/sourceIncidentReports.coffee
+++ b/client/controllers/curatorInbox/sourceIncidentReports.coffee
@@ -41,8 +41,5 @@ Template.sourceIncidentReports.helpers
   hasAcceptedIncidents: ->
     findIncident(true)
 
-  hasRejectedIncidents: ->
-    findIncident(false)
-
   hasIncidents: ->
     findIncident()

--- a/client/controllers/incidentReports/incidentTable.coffee
+++ b/client/controllers/incidentReports/incidentTable.coffee
@@ -109,7 +109,7 @@ Template.incidentTable.helpers
 
   action: ->
     if Template.instance().accepted
-      'Reject'
+      'Delete'
     else
       'Accept'
 

--- a/client/controllers/incidentReports/suggestedIncidentModal.coffee
+++ b/client/controllers/incidentReports/suggestedIncidentModal.coffee
@@ -73,6 +73,18 @@ Template.suggestedIncidentModal.events
       stageModals(instance, instance.modals)
 
   'click .reject': (event, instance) ->
+    instanceData = instance.data
+    if instanceData.incidentCollection
+      instanceData.incidentCollection.update instance.incident._id,
+        $set:
+          accepted: false
+    else
+      Meteor.call 'updateIncidentReport', {
+        _id: instance.incident._id
+        accepted: false
+      }, (error, result) =>
+        if error
+          toastr.error "Error: " + error
     stageModals(instance, instance.modals)
 
   'click .cancel': (event, instance) ->

--- a/client/views/curatorInbox/curatorSourceDetails.jade
+++ b/client/views/curatorInbox/curatorSourceDetails.jade
@@ -23,7 +23,7 @@ template(name="curatorSourceDetails")
       .transition(class="{{#if notifying}} active {{/if}}")
     .curator-source-details--content
       if incidentsLoaded
-        if hasTextContent
+        if textContent
           .curator-source-details--copy-wrapper.curator-source-details--section
             .curator-source-details--header.curator-source-details--actions.container-flex.no-break
               button.btn.btn-success.btn-sm.toggle-reviewed(class="{{#if isReviewed}} reviewed {{/if}}")
@@ -36,7 +36,7 @@ template(name="curatorSourceDetails")
               +addToEvent(source=source objNameToAssociate="Document")
             .curator-source-details--copy
               +annotatedContent(
-                content=source.enhancements.source.cleanContent.content
+                content=textContent
                 incidents=incidents
                 relatedElements=relatedElements
                 selectedAnnotationId=selectedAnnotationId

--- a/client/views/curatorInbox/sourceIncidentReports.jade
+++ b/client/views/curatorInbox/sourceIncidentReports.jade
@@ -1,25 +1,14 @@
 template(name="sourceIncidentReports")
   .curator-source-details--incidents-container
-    if hasIncidents
-      if hasAcceptedIncidents
-        .curator-source-details--incidents.accepted(
-          class="{{#unless tableContentIsScrollable}} no-scroll {{/unless}}")
-            +incidentTable(
-              source=source
-              scrollToAnnotations=true
-              accepted=true
-              hideTableHeader=true
-              selectedAnnotationId=selectedAnnotationId
-              tableContentScrollable=tableContentScrollable)
-      if hasRejectedIncidents
-        .curator-source-details--incidents.rejected(
-          class="{{#unless tableContentIsScrollable}} no-scroll {{/unless}}")
-              +incidentTable(
-                source=source
-                scrollToAnnotations=true
-                accepted=false
-                hideTableHeader=true
-                selectedAnnotationId=selectedAnnotationId
-                tableContentScrollable=tableContentScrollable)
+    if hasAcceptedIncidents
+      .curator-source-details--incidents.accepted(
+        class="{{#unless tableContentIsScrollable}} no-scroll {{/unless}}")
+          +incidentTable(
+            source=source
+            scrollToAnnotations=true
+            accepted=true
+            hideTableHeader=true
+            selectedAnnotationId=selectedAnnotationId
+            tableContentScrollable=tableContentScrollable)
     else
       +noResults message='No Incidents Found'

--- a/client/views/incidentReports/incidentTable.jade
+++ b/client/views/incidentReports/incidentTable.jade
@@ -1,6 +1,5 @@
 template(name="incidentTable")
   .curator-source-details--sub-header
-    h3(class=tableType)=tableType
     .curator-source-details--actions.container-flex.no-break
       button.btn.btn-sm.action(
         disabled="{{#unless incidentsSelected}} true {{/unless}}"

--- a/client/views/incidentReports/suggestedIncidentModal.jade
+++ b/client/views/incidentReports/suggestedIncidentModal.jade
@@ -34,5 +34,5 @@ template(name="suggestedIncidentModal")
           if edit
             button.btn.btn-default.cancel(type="button") Cancel
           else
-            button.btn.btn-default.reject(type="button") Reject
+            button.btn.btn-default.reject(type="button") Delete
           button.btn.btn-primary.save-modal(type="button")=saveButtonText


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/story/show/145665197

This also fixes a bug where the suggestedIncident modal's reject button wasn't working.