### PR TITLE
Fix unaccepted incidents showing in doc details 146606131

### DIFF
--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -67,7 +67,9 @@ Template.articles.helpers
     source.title or source.url or (source.content?.slice(0,30) + "...")
 
   incidentsForSource: (source) ->
-    Incidents.find(articleId: Template.instance().selectedSourceId.get())
+    Incidents.find
+      articleId: Template.instance().selectedSourceId.get()
+      accepted: true
 
   locationsForSource: (source) ->
     locations = {}

--- a/client/controllers/articles.coffee
+++ b/client/controllers/articles.coffee
@@ -66,16 +66,17 @@ Template.articles.helpers
     source = EventArticles.findOne(Template.instance().selectedSourceId.get())
     source.title or source.url or (source.content?.slice(0,30) + "...")
 
-  incidentsForSource: (source) ->
+  incidentsForDocument: (source) ->
     Incidents.find
       articleId: Template.instance().selectedSourceId.get()
       accepted: true
 
-  locationsForSource: (source) ->
+  locationsForDocument: ->
+    articleId = Template.instance().selectedSourceId.get()
     locations = {}
     Incidents
       .find
-        articleId: source._id
+        articleId: articleId
       .forEach (incident) ->
         for location in incident.locations
           locations[location.id] = location.name

--- a/client/views/articles.jade
+++ b/client/views/articles.jade
@@ -53,16 +53,20 @@ template(name="articles")
         .event-source-summary.container-flex
           if incidentsLoaded
             .event-source-summary--item
-              h5 Locations
+              h5
+                | Locations
+                span.count (#{locationsForDocument.length})
               ul.list-unstyled
-                each locationsForSource selectedSource
+                each locationsForDocument
                   li=this
                 else
                   li No locations
             .event-source-summary--item
-              h5 Incidents
+              h5
+                | Incidents
+                span.count (#{incidentsForDocument.count})
               ul.list-unstyled
-                  each incidentsForSource selectedSource
+                  each incidentsForDocument
                     li(class="{{#if incidentAssociatedWithEvent}} associated {{/if}}") {{incidentToText this}}
                   else
                     li No cases

--- a/client/views/curatorInbox/curatorSourceDetails.jade
+++ b/client/views/curatorInbox/curatorSourceDetails.jade
@@ -45,7 +45,9 @@ template(name="curatorSourceDetails")
           .curator-source-details--incidents-wrapper
             .curator-source-details--incidents-headers
               .curator-source-details--header
-                h2 Incidents
+                h2
+                  | Incidents
+                  span.count (#{incidents.count})
                 button.btn.btn-default.btn-sm.add-incident.on-right Add New Incident
               +sourceIncidentReportsHeader(
                 selectedIncidents=selectedIncidents

--- a/imports/stylesheets/curatorInbox/headers.import.styl
+++ b/imports/stylesheets/curatorInbox/headers.import.styl
@@ -253,6 +253,9 @@
     margin-right 2em
     font-weight 600
     letter-spacing .02em
+  .count
+    color darken($border-primary, 20%)
+    font-weight normal
 
 .curator-source-details--header
   min-height $curator-pane-head-height

--- a/imports/stylesheets/events/sources.import.styl
+++ b/imports/stylesheets/events/sources.import.styl
@@ -109,13 +109,17 @@
   .event-source-summary--item
     border-right 1px solid $border-primary-light
     padding 1.5em 1.25em
-    min-width 20%
+    min-width 175px
     +below(2)
       padding-bottom 0
-
     &:last-of-type
       margin 0
       border 0
+    .count
+      color darken($border-primary, 50%)
+      font-size 90%
+      font-weight 400
+      letter-spacing .03em
 
 #document-text-modal
   .modal-dialog

--- a/imports/stylesheets/globals.import.styl
+++ b/imports/stylesheets/globals.import.styl
@@ -29,12 +29,14 @@ h1
 h2
 h3
 h4
+h5
   letter-spacing .01em
 
 h1
 h2
 h3
 h4
+h5
   color $primary-dark
   font-weight 700
 


### PR DESCRIPTION
[PT Bug](https://www.pivotaltracker.com/story/show/146606131)
Also adds counts for document locations and incidents in document details and incident count in inbox document details.

I also updated the wording of a few helpers from source to document to I wonder if we should start renaming references to documents in the code? We refer to them as _documents_, _articles_ and _sources_. 😕