### PR TITLE
Fix top level locations not combining rates from all sub-locations

### DIFF
--- a/client/controllers/resolvedIncidentsPlot.coffee
+++ b/client/controllers/resolvedIncidentsPlot.coffee
@@ -81,9 +81,12 @@ Template.resolvedIncidentsPlot.onRendered ->
               .map(([subInt, iNext])->
                 onClick = ->
                   concurrentIntervals = groupedLocSubIntervals[subInt.start] or []
+                  componentTree = LocationTree.from(concurrentIntervals.map (x)-> x.location)
+                  concurrentIntervals.forEach (x)->
+                    componentTree.getNodeById(x.location.id).associatedObject = x
                   Modal.show('intervalDetailsModal',
                     interval: subInt
-                    concurrentIntervals: concurrentIntervals
+                    componentTree: componentTree
                     incidents: subInt.incidentIds.map (id)->
                       differentials[id]
                   )

--- a/client/views/intervalDetailsModal.jade
+++ b/client/views/intervalDetailsModal.jade
@@ -1,26 +1,28 @@
 template(name="intervalDetailsModal")
-  .modal.modal-skinny.fade(role="dialog")
+  .modal.fade.interval-details(role="dialog")
     .modal-dialog
       .modal-content
         .modal-header
-          .modal-header--title Interval Details
+          .modal-header--title
+            h4 Interval Details
           +modalCloseButton
-          
         .modal-body
-          div 
-            p Start: {{formatDate interval.start}}
-            p End: {{formatDate interval.end}}
-          hr
+          h5 {{formatDate interval.start}} - {{formatDate interval.end}}
           each componentTree.children
             +componentTreeList
 
 template(name="componentTreeList")
   with associatedObject
-    p Location: {{formatLocation location}}
-    p Count during interval: #{value}
+    ul.list-unstyled
+      li
+        span Location:
+        | {{formatLocation location}}
+      li
+        span Count during interval:
+        | #{value}
     if incidents
-      h4 Source Incidents
-      ul
+      h6 Source Incidents
+      ul.interval-details--source-incidents
         each incidents
           li
             if cumulative

--- a/client/views/intervalDetailsModal.jade
+++ b/client/views/intervalDetailsModal.jade
@@ -10,23 +10,30 @@ template(name="intervalDetailsModal")
           div 
             p Start: {{formatDate interval.start}}
             p End: {{formatDate interval.end}}
-            p Total: {{interval.value}}
           hr
-          h3 Components
-          each concurrentIntervals
-            .incident.panel.panel-default
-              .panel-body
-                p Location: {{formatLocation location}}
-                p Count: #{value}
-                h4 Source Incidents
-                ul
-                  each incidents
-                    li
-                      if cumulative
-                        | Difference between cumulative counts: #{count}
-                        ul
-                          each incident in originalIncidents
-                            li {{incidentToText incident}}
-                      else
-                        each incident in originalIncidents
-                          | {{incidentToText incident}}
+          each componentTree.children
+            +componentTreeList
+
+template(name="componentTreeList")
+  with associatedObject
+    p Location: {{formatLocation location}}
+    p Count during interval: #{value}
+    if incidents
+      h4 Source Incidents
+      ul
+        each incidents
+          li
+            if cumulative
+              | Difference between cumulative counts: #{count}
+              ul
+                each incident in originalIncidents
+                  li {{incidentToText incident}}
+            else
+              each incident in originalIncidents
+                | {{incidentToText incident}}
+  if children
+    h4 Subcomponents
+    each children
+      .incident.panel.panel-default
+        .panel-body
+          +componentTreeList

--- a/client/views/resolvedIncidentsPlot.jade
+++ b/client/views/resolvedIncidentsPlot.jade
@@ -1,12 +1,12 @@
 template(name="resolvedIncidentsPlot")
   .resolved-incidents-plot
-    if isLoading
-      +loading small=true
     .controls
       .btn-group.incident-type-selector(role="group")
         button.btn.btn-default.cases(type="button" class="{{casesActive}}") Case Rate
         button.btn.btn-default.deaths(type="button" class="{{deathsActive}}") Death Rate
       p Rates are derived from incident report data
+    if isLoading
+      +loading small=true
     .chart
     .legend
       each labels

--- a/imports/incidentResolution/LocationTree.test.coffee
+++ b/imports/incidentResolution/LocationTree.test.coffee
@@ -3,6 +3,26 @@ import incidents from './incidents.coffee'
 import LocationTree from './LocationTree.coffee'
 
 describe 'LocationTree', ->
+  it 'deduplicates locations', ->
+    myTree = LocationTree.from([{
+      admin1Name: "Maritime"
+      countryName: "Togolese Republic"
+      featureClass: "P"
+      featureCode: "PPLC"
+      id: "2365267"
+      name: "Lomé"
+    }, {
+      admin1Name: "Maritime"
+      countryName: "Togolese Republic"
+      featureClass: "P"
+      featureCode: "PPLC"
+      id: "2365267"
+      name: "Lomé"
+    }])
+    chai.assert.equal(myTree.children.length, 1)
+    chai.assert.equal(myTree.children[0].value.id, "2365267")
+    chai.assert.equal(myTree.children[0].children.length, 0)
+
   it 'can build location trees from locations', ->
     myTree = LocationTree.from([{
       admin1Name: "Maritime"

--- a/imports/stylesheets/events/event.import.styl
+++ b/imports/stylesheets/events/event.import.styl
@@ -317,6 +317,24 @@ $max-event-details-width = $max-ui-width+300
       font-size 2em
       margin-right .25em
 
+.interval-details
+  h5
+    font-size 1.5em
+  h6
+    font-size 1em
+    margin-top 1em
+    font-weight 600
+  li
+    margin-bottom 4px
+    span
+      font-weight 600
+
+.interval-details--source-incidents
+  padding-left 30px
+  li
+    span
+      font-weight normal
+
 .incident-type-selector
   margin-bottom 1em
   .btn

--- a/imports/stylesheets/events/event.import.styl
+++ b/imports/stylesheets/events/event.import.styl
@@ -291,6 +291,8 @@ $max-event-details-width = $max-ui-width+300
     margin-bottom 1em
 
 .resolved-incidents-plot
+  min-height 200px
+  position relative
   padding 3em 0
   .controls
     text-align center

--- a/tests/features/step_definitions/curator_inbox_steps.coffee
+++ b/tests/features/step_definitions/curator_inbox_steps.coffee
@@ -41,6 +41,9 @@ do ->
         @client.setValue('#content', DOCUMENT_TEXT)
       @client.setValue('#title', 'Test Article')
       @client.clickIfVisible('.add-publish-date .btn')
+      # The publishTime element might be in an invalid state that
+      # prevents setValue from working if this pause is not used.
+      @client.pause(10000)
       @client.setValue('#publishTime', '12:00 PM')
       @client.pause(3000)
       @client.click('.save-source')


### PR DESCRIPTION
In the resolved incident plot the top locations previously used the largest rate from the sub-location if no rate was defined for the top location. This lead to rates being lower than they should be because the rates from disjoint sub-locations should have been combined. This PR fixes the issue by ensuring top location rates are defined in every sub-interval.

This also improves the interval detail view by displaying sub-components hierarchically.