### PR TITLE
Fix incident modal content repositioning 147827315

### DIFF
--- a/imports/stylesheets/forms/suggested.import.styl
+++ b/imports/stylesheets/forms/suggested.import.styl
@@ -93,6 +93,7 @@ $warning-border = darken($warning-bg, 12%)
       flex 1 1 50%
       max-width 50%
       overflow-y scroll
+      will-change transform
     #add-incident
     .annotated-content
       margin 0

--- a/imports/stylesheets/forms/suggested.import.styl
+++ b/imports/stylesheets/forms/suggested.import.styl
@@ -59,7 +59,8 @@ $warning-border = darken($warning-bg, 12%)
   #add-incident
     .control-label.featured
       border-bottom-width 1px
-
+  .modal-body
+    align-items stretch
   .modal-dialog
     width 90%
   .check-buttons


### PR DESCRIPTION
This took a good bit of digging. Applies `will-change: transform` to scrollable elements within the `suggestedIncidentModal` which tells the browser to expect changes to these elements.