### PR TITLE
Fix bugs related to location not having name

### DIFF
--- a/client/controllers/incidentReports/incidentSecondaryDetails.coffee
+++ b/client/controllers/incidentReports/incidentSecondaryDetails.coffee
@@ -14,7 +14,14 @@ Template.incidentSecondaryDetails.helpers
     firstLocation?.countryName or firstLocation?.name
 
   hasAdditionalInfo: ->
-    @locations.length > 1 or formatLocation(@locations[0]).split(',').length > 1
+    if @locations.length > 1
+      1
+    else if formatLocation(@locations[0])?.split(',').length > 1
+      1
+    else if @incidentEvents.length
+      1
+    else
+      0
 
   associatedEventCount: ->
     Template.instance().data.incidentEvents.length

--- a/client/views/incidentReports/incidentSecondaryDetails.jade
+++ b/client/views/incidentReports/incidentSecondaryDetails.jade
@@ -20,14 +20,15 @@ template(name="incidentSecondaryDetails")
               span No associated events
         else
           span= associatedEventCount
-      li.locations
-        if detailsOpen
-          i.fa.fa-globe
-          ul.list-unstyled
-            each locations
-              li {{formatLocation this}}
-        else
-          span= firstLocationName
+      if locations
+        li.locations
+          if detailsOpen
+            i.fa.fa-globe
+            ul.list-unstyled
+              each locations
+                li {{formatLocation this}}
+          else
+            span= firstLocationName
       li.date
         if detailsOpen
           i.fa.fa-calendar

--- a/imports/stylesheets/incidents/incidentList.import.styl
+++ b/imports/stylesheets/incidents/incidentList.import.styl
@@ -2,7 +2,6 @@ $disabled = darken($l-gray, 20%)
 
 .incident-list
   h3
-    padding-top 2px
     text-transform none
     color $primary-dark
   .incident
@@ -33,9 +32,9 @@ $disabled = darken($l-gray, 20%)
       background alpha($secondary, 8%)
 
 .incident--select
-  align-items flex-start
+  align-items center
   cursor pointer
-  padding .4em $page-padding .5em
+  padding-left $page-padding
   &:hover
     color $primary-dark
     h3
@@ -55,7 +54,8 @@ $disabled = darken($l-gray, 20%)
   transition .1s ease-in-out
 
 .incident--main-details
-  align-items flex-start
+  align-items center
+  margin-bottom .5em
   .actions
     margin-left auto
     li
@@ -71,6 +71,10 @@ $disabled = darken($l-gray, 20%)
         transform scale(.9)
         color $primary-dark
 
+.incident--secondary-details
+  margin-left $page-padding + 10px
+  align-items center
+
 .curator-inbox--add-event-container
 .incident--secondary-details
   color $m-gray
@@ -83,14 +87,13 @@ $disabled = darken($l-gray, 20%)
       color $primary-dark
       &:hover
         color $primary-dark
-  > i
-    margin-right 5px
   > ul
     align-items center
     width 100%
+    margin-left 8px
     > li
       display flex
-      align-items flex-start
+      align-items stretch
       font-size .85em
       margin-right .4em
       li:not(:last-of-type)
@@ -109,11 +112,14 @@ $disabled = darken($l-gray, 20%)
       i
         padding-top 1px
         font-size 120%
-        margin-right .5em
+      span
+        align-items center
       &.events
         span
           font-size 110%
           padding-top 1px
+        i
+          margin-right 5px
       &.locations
         max-width 45%
         span
@@ -151,8 +157,9 @@ $disabled = darken($l-gray, 20%)
             display none
   .toggle-details
     font-size 1.15em
-    padding-left 1em
-    padding-right .5em
+    padding-top 2px
+    padding-left 2px
+    padding-right 2px
     align-self flex-start
     transition .1s ease-in-out
     &:hover
@@ -175,7 +182,7 @@ $disabled = darken($l-gray, 20%)
     cursor default
     color $disabled
     .toggle-details
-      color $disabled
+      color lighten($disabled, 50%)
       pointer-events none
 
 .curator-inbox--add-event-container

--- a/imports/utils.coffee
+++ b/imports/utils.coffee
@@ -465,7 +465,9 @@ export formatDateRange = (dateRange, readable)->
   else
     startFormated + " - " + endFormated
 
-export formatLocation = ({name, admin2Name, admin1Name, countryName}) ->
+export formatLocation = (locations) ->
+  return unless locations
+  {name, admin2Name, admin1Name, countryName} = locations
   _.chain([name, admin2Name, admin1Name, countryName])
     .compact()
     .uniq()


### PR DESCRIPTION
There was an edge case where if a location did not have a name property, an error would be thrown and a phantom space would appear in the UI.
Also fixes an issue which disabled the incident detail toggle when the incident had events but no locations.

[PT Bug](https://www.pivotaltracker.com/story/show/148483127)