### PR TITLE
Handle GRITS API changes

### DIFF
--- a/imports/ui/annotation.coffee
+++ b/imports/ui/annotation.coffee
@@ -13,7 +13,7 @@ export annotateContent = (content, annotations, options={}) ->
   if not startingIndex
     startingIndex = 0
   if not endingIndex
-    endingIndex = content.length - 1
+    endingIndex = content.length
   lastOffset = startingIndex
   html = ""
   if startingIndex isnt 0
@@ -67,7 +67,7 @@ export annotateContent = (content, annotations, options={}) ->
       html += "<span class='annotation annotation-text #{classNames.join(' ')}' #{attributeText}>"
     lastOffset = offset
   html += Handlebars._escape("#{content.slice(lastOffset, endingIndex)}")
-  if endingIndex < content.length - 1
+  if endingIndex < content.length
     html += "..."
   html
 

--- a/imports/ui/snippets.coffee
+++ b/imports/ui/snippets.coffee
@@ -10,7 +10,7 @@ export getIncidentSnippet = (content, incident, paddingCharaters=100) ->
   startingIndex = textOffsets[0]
   startingIndex = Math.max(startingIndex - paddingCharaters, 0)
   endingIndex = textOffsets[1]
-  endingIndex = Math.min(endingIndex + paddingCharaters, content.length - 1)
+  endingIndex = Math.min(endingIndex + paddingCharaters, content.length)
   annotateContent content, annotation,
     startingIndex: startingIndex
     endingIndex: endingIndex

--- a/imports/utils.coffee
+++ b/imports/utils.coffee
@@ -127,7 +127,7 @@ export UTCOffsets =
   WGST: '-0200'
   WGT: '-0300'
 
-export regexEscape = (s)->
+export regexEscape = (s) ->
   # Based on bobince's regex escape function.
   # source: http://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/3561711#3561711
   s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
@@ -147,11 +147,11 @@ export diseaseOptionsFn = (params, callback) ->
   term = params.term?.trim()
   if not term
     return callback(results: [])
-  Meteor.call 'geonameLookup', term, (error, response)->
+  Meteor.call 'geonameLookup', term, (error, response) ->
     if error
       return callback(error)
     callback(
-      results: response.data.result.map((d)->
+      results: response.data.result.map((d) ->
         if d.synonym != d.label
           text = d.synonym + " | " + d.label
         else
@@ -169,7 +169,7 @@ export diseaseOptionsFn = (params, callback) ->
 
 # Parse text into an array of sentences separated by
 # periods, colons, semi-colons, or double linebreaks.
-export parseSents = (text)->
+export parseSents = (text) ->
   idx = 0
   sents = []
   sentStart = 0
@@ -201,12 +201,12 @@ export getTerritories = (annotationsWithOffsets, sents, options={}) ->
   # Split annotations with multiple offsets
   # and sort by offset.
   annotationsWithSingleOffsets = []
-  annotationsWithOffsets.forEach (annotation)->
-    annotation.textOffsets.forEach (textOffset)->
+  annotationsWithOffsets.forEach (annotation) ->
+    annotation.textOffsets.forEach (textOffset) ->
       splitAnnotation = Object.create(annotation)
       splitAnnotation.textOffsets = [textOffset]
       annotationsWithSingleOffsets.push(splitAnnotation)
-  annotationsWithOffsets = _.sortBy(annotationsWithSingleOffsets, (annotation)->
+  annotationsWithOffsets = _.sortBy(annotationsWithSingleOffsets, (annotation) ->
     annotation.textOffsets[0][0]
   )
   annotationIdx = 0
@@ -239,7 +239,7 @@ export getTerritories = (annotationsWithOffsets, sents, options={}) ->
         territories[territories.length - 1].territoryEnd = sentEnd
   return territories
 
-export createIncidentReportsFromEnhancements = (enhancements, options)->
+export createIncidentReportsFromEnhancements = (enhancements, options) ->
   { countAnnotations, acceptByDefault, articleId, publishDate } = options
   if not publishDate
     publishDate = new Date()
@@ -248,11 +248,11 @@ export createIncidentReportsFromEnhancements = (enhancements, options)->
   locationAnnotations = features.filter (f) -> f.type == 'location'
   datetimeAnnotations = features.filter (f) -> f.type == 'datetime'
   diseaseAnnotations = features.filter (f) ->
-    f.type == 'resolvedKeyword' and f.resolutions.some((r)->
+    f.type == 'resolvedKeyword' and f.resolutions.some((r) ->
       r.entity.type == 'disease'
     )
   speciesAnnotations = features.filter (f) ->
-    f.type == 'resolvedKeyword' and f.resolutions.some((r)->
+    f.type == 'resolvedKeyword' and f.resolutions.some((r) ->
       r.entity.type == 'species'
     )
   if not countAnnotations
@@ -296,7 +296,6 @@ export createIncidentReportsFromEnhancements = (enhancements, options)->
   # Only include the sentence the word appears in for species territories since
   # the species is implicitly human in most of the articles we're analyzing.
   speciesTerritories = getTerritories(speciesAnnotations, sents, sentenceOnly: true)
-  console.log speciesTerritories
   countAnnotations.forEach (countAnnotation) =>
     [start, end] = countAnnotation.textOffsets[0]
     locationTerritory = _.find locTerritories, ({territoryStart, territoryEnd}) ->
@@ -312,7 +311,7 @@ export createIncidentReportsFromEnhancements = (enhancements, options)->
       .pluck('geoname')
       .groupBy('id')
       .values()
-      .map((x)-> x[0])
+      .map((x) -> x[0])
       .value()
     incident =
       locations: locations
@@ -367,11 +366,11 @@ export createIncidentReportsFromEnhancements = (enhancements, options)->
         incident.status = 'suspected'
     incident.articleId = articleId
     # The disease field is set to the last disease mentioned.
-    diseaseTerritory.annotations.forEach (annotation)->
+    diseaseTerritory.annotations.forEach (annotation) ->
       incident.resolvedDisease =
         id: annotation.resolutions[0].entity.id
         text: annotation.resolutions[0].entity.label
-    speciesTerritory.annotations.forEach (annotation)->
+    speciesTerritory.annotations.forEach (annotation) ->
       incident.species =
         id: annotation.resolutions[0].entity.id
         text: annotation.resolutions[0].entity.label
@@ -450,12 +449,12 @@ export debounceCheckTop = _.debounce ($scrollableElement, $toTopButton) ->
     $toTopButton.addClass('off-canvas')
 , 50
 
-export pluralize = (word, count, showCount=true)->
+export pluralize = (word, count, showCount=true) ->
   if Number(count) isnt 1
     word += "s"
   if showCount then "#{count} #{word}" else word
 
-export formatDateRange = (dateRange, readable)->
+export formatDateRange = (dateRange, readable) ->
   dateRange ?= ''
   start = moment.utc(dateRange.start)
   end = moment.utc(dateRange.end)

--- a/server/methods.coffee
+++ b/server/methods.coffee
@@ -22,6 +22,12 @@ speciesDB = new sqlite3.Database(
 )
 
 Meteor.methods
+  geonameLookup: (term) ->
+    check term, String
+    HTTP.get Constants.GRITS_URL + "/api/v1/disease_ontology/lookup",
+      params:
+        q: term
+
   searchSpeciesNames: (term) ->
     if not speciesDB.open
       return []


### PR DESCRIPTION
This makes some updates to the incident report suggestion code to handle some changes to the resolvedKeyword data returned by the GRITS API. This also adds species suggestions and fixes a couple bugs. The annotated content's end offset was off by one and a environment variable defined constant was being used on the client side where it is unavailable.