### PR TITLE
Update loading indicator of resolved plot - add veil

### DIFF
--- a/client/views/events/eventResolvedIncidents.jade
+++ b/client/views/events/eventResolvedIncidents.jade
@@ -15,14 +15,16 @@ template(name="eventResolvedIncidents")
           | Cumulative Deaths
 
   .resolved-incidents-plot
-    if isLoading
-      +loading small=true
-    .chart
-    .legend
-      each labels
-        label
-          span=name
-          i.fa.fa-circle(style="color:{{color}};")
+    .chart-wrapper
+      if isLoading
+        +loading small=true
+        .veil
+      .chart
+      .legend
+        each labels
+          label
+            span=name
+            i.fa.fa-circle(style="color:{{color}};")
     p
       | The cases in this plot were inferred from incident report data.
       | Incidents with overlapping locations and time intervals were combined

--- a/imports/stylesheets/events/resolvedIncidents.import.styl
+++ b/imports/stylesheets/events/resolvedIncidents.import.styl
@@ -29,6 +29,12 @@
       font-size 2em
       margin-right .25em
 
+.chart-wrapper
+  position relative
+  .loading
+    top 35%
+    z-index $modal-layer
+
 .interval-details
   h5
     font-size 1.5em


### PR DESCRIPTION
Small update to the resolved incidents plot that adds a veil and brings the loading animation to the front in space.

[PT Bug](https://www.pivotaltracker.com/story/show/149273195)