### PR TITLE
Add incident modified date, fix unmarked cumulative counts

### DIFF
--- a/imports/schemas/incidentReport.coffee
+++ b/imports/schemas/incidentReport.coffee
@@ -27,6 +27,9 @@ IncidentReportSchema = new SimpleSchema
   modifiedByUserId:
     type: String
     optional: true
+  modifiedDate:
+    type: Date
+    optional: true
   addedDate:
     type: Date
     optional: true

--- a/methods/incidentReports.coffee
+++ b/methods/incidentReports.coffee
@@ -47,6 +47,7 @@ Meteor.methods
 
     updatedIncident.modifiedByUserId = user._id
     updatedIncident.modifiedByUserName = user.profile.name
+    updatedIncident.modifiedDate = new Date()
     res = Incidents.update(updatedIncident._id, updatedIncident, updateOperators)
     if incident.userEventId
       Meteor.call("editUserEventLastModified", incident.userEventId)

--- a/server/autoprocess.coffee
+++ b/server/autoprocess.coffee
@@ -1,7 +1,7 @@
-Articles = require '/imports/collections/articles.coffee'
+import Articles from '/imports/collections/articles.coffee'
 
 busyProcessing = false
-autoprocessArticles = ->
+module.exports = ->
   if busyProcessing
     return
   else
@@ -41,7 +41,3 @@ autoprocessArticles = ->
     console.log "processed #{count} articles"
     busyProcessing = false
   )
-
-Meteor.startup ->
-  if not Meteor.isAppTest
-    Meteor.setInterval(autoprocessArticles, 100000)

--- a/server/startup.coffee
+++ b/server/startup.coffee
@@ -1,12 +1,16 @@
-incidentReportSchema = require '/imports/schemas/incidentReport.coffee'
-Incidents = require '/imports/collections/incidentReports.coffee'
-Articles = require '/imports/collections/articles.coffee'
+import incidentReportSchema from '/imports/schemas/incidentReport.coffee'
+import Incidents from '/imports/collections/incidentReports.coffee'
+import Articles from '/imports/collections/articles.coffee'
+import autoprocessArticles from '/server/autoprocess.coffee'
+import updateDatabase from '/server/updaters.coffee'
 
 Meteor.startup ->
   # Clean-up curatorInboxSourceId when user goes offline
   Meteor.users.find({'status.online': true}).observe
     removed: (user) ->
       Meteor.users.update(user._id, {$set : {'status.curatorInboxSourceId': null}})
+
+  updateDatabase()
 
   # Validate incidents
   if Meteor.isDevelopment
@@ -31,3 +35,6 @@ Meteor.startup ->
         console.log "incidents validated"
         Meteor.clearInterval(interval)
     interval = Meteor.setInterval(validateIncidents, 20000)
+
+  if not Meteor.isAppTest
+    Meteor.setInterval(autoprocessArticles, 100000)


### PR DESCRIPTION
This marks incidents from pre December 2016 events as cumulative if they report more than 50 cases in a day.

This also prevents validation from running during a database update.
