### PR TITLE
Only sync curated event data

### DIFF
--- a/imports/ui/deletion.coffee
+++ b/imports/ui/deletion.coffee
@@ -1,4 +1,4 @@
-{ notify } = require '/imports/ui/notification'
+import { notify } from '/imports/ui/notification'
 
 module.exports =
   commonPostDeletionTasks: (error, objNameToDelete, modalName=null) ->

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -1,9 +1,9 @@
-Incidents = require '/imports/collections/incidentReports.coffee'
-UserEvents = require '/imports/collections/userEvents.coffee'
-SmartEvents = require '/imports/collections/smartEvents.coffee'
-Articles = require '/imports/collections/articles.coffee'
-Feeds = require '/imports/collections/feeds.coffee'
-{ regexEscape, cleanUrl } = require '/imports/utils'
+import Incidents from '/imports/collections/incidentReports.coffee'
+import UserEvents from '/imports/collections/userEvents.coffee'
+import SmartEvents from '/imports/collections/smartEvents.coffee'
+import Articles from '/imports/collections/articles.coffee'
+import Feeds from '/imports/collections/feeds.coffee'
+import { regexEscape, cleanUrl } from '/imports/utils'
 
 # Incidents
 ReactiveTable.publish 'curatorEventIncidents', Incidents,

--- a/server/startup.coffee
+++ b/server/startup.coffee
@@ -3,6 +3,7 @@ import Incidents from '/imports/collections/incidentReports.coffee'
 import Articles from '/imports/collections/articles.coffee'
 import autoprocessArticles from '/server/autoprocess.coffee'
 import updateDatabase from '/server/updaters.coffee'
+import syncCollection from '/server/oneWaySync.coffee'
 
 Meteor.startup ->
   # Clean-up curatorInboxSourceId when user goes offline
@@ -38,3 +39,10 @@ Meteor.startup ->
 
   if not Meteor.isAppTest
     Meteor.setInterval(autoprocessArticles, 100000)
+
+  # If a remote EIDR-C instance url is provided, periodically pull data from it.
+  if process.env.ONE_WAY_SYNC_URL
+    # Do initial sync on startup
+    Meteor.setTimeout(syncCollection, 1000)
+    # Pull data every 6 hours
+    Meteor.setInterval(syncCollection, 6 * 60 * 60 * 1000)


### PR DESCRIPTION
This updates the one way sync code to only sync data from curated events. The database is becoming too large to sync all the data.