### PR TITLE
Fix species name bug and location filter bug

### DIFF
--- a/client/controllers/events/eventFiltration.coffee
+++ b/client/controllers/events/eventFiltration.coffee
@@ -116,13 +116,11 @@ Template.eventFiltration.onCreated ->
 
 Template.eventFiltration.onRendered ->
   @autorun =>
-    @incidentLocations = _.uniq(
+    incidentLocations = _.uniq(
       _.flatten(EventIncidents.find({}, field: locations: 1).map (incident) ->
         incident.locations
       )
     )
-
-  @autorun =>
     countryLevel = @countryLevel.get()
     @locations.remove({})
     @selectedLocations.remove({})
@@ -131,7 +129,7 @@ Template.eventFiltration.onRendered ->
       if regionData.continentCode
         regionData.countryISOs.forEach (iso) ->
           countryToRegion[iso] = regionData
-    @incidentLocations.forEach (location) =>
+    incidentLocations.forEach (location) =>
       return unless location.countryCode
       location.region = countryToRegion[location.countryCode].name
       return unless location[countryLevel]

--- a/client/views/incidentReports/suggestedIncidentsModal.jade
+++ b/client/views/incidentReports/suggestedIncidentsModal.jade
@@ -63,7 +63,7 @@ template(name="suggestedIncidentsModal")
                         td {{formatDateISO dateRange.end}}
                         td {{formatLocations locations}}
                         td=status
-                        td=species
+                        td=species.text
                         td=incidentProperties
         .modal-footer
           button.btn.btn-default.confirm-close-modal.on-left(type="button" data-dismiss="modal") Close


### PR DESCRIPTION
Prior to this update [Object] was being displayed in the species column of the extract-incidents table and the location filter was not showing all the available locations when initially loaded.