### PR TITLE
Add incident to incident marker area if not in array

### DIFF
--- a/client/controllers/events/eventAffectedAreas.coffee
+++ b/client/controllers/events/eventAffectedAreas.coffee
@@ -154,6 +154,8 @@ Template.eventAffectedAreas.onRendered ->
       incident.locations.forEach (location) ->
         key = "#{location.latitude},#{location.longitude}"
         incidentsByLatLng[key] = (incidentsByLatLng[key] or []).concat(incident)
+    for key, incidents of incidentsByLatLng
+      incidentsByLatLng[key] = _.uniq(incidents, false, (x) -> x._id)
     if @markerLayer.get()
       markerLayerGroup = L.layerGroup()
       for key, incidents of incidentsByLatLng


### PR DESCRIPTION
Not sure if this is necessary?...it only seems to be a problem on [this event](https://eidr-connect.eha.io/events/curated-events/gfnPs88SBb3aaBeeA).