### PR TITLE
Do not cover filters when no incidents

### DIFF
--- a/imports/stylesheets/events/eventContent.import.styl
+++ b/imports/stylesheets/events/eventContent.import.styl
@@ -26,6 +26,7 @@
       font-family 'icons'
 
 .event--content
+  position relative
   display flex
   flex 1 1 auto
   flex-direction column


### PR DESCRIPTION
I forgot to position the `event--content` element relatively so the veils will be contained.