### PR TITLE
Add species filter to Event pages and smart events

### DIFF
--- a/client/controllers/curatorInbox/curatorInbox.coffee
+++ b/client/controllers/curatorInbox/curatorInbox.coffee
@@ -119,7 +119,7 @@ Template.curatorInbox.onRendered ->
 
     @query.set(query)
 
-    Meteor.call 'fetchPromedPosts', 100, range, (err) ->
+    Meteor.call 'fetchPromedPosts', range, (err) ->
       if err
         notify('error', err.reason)
         return

--- a/client/controllers/events/smartEvent/editSmartEventDetailsModal.coffee
+++ b/client/controllers/events/smartEvent/editSmartEventDetailsModal.coffee
@@ -2,12 +2,16 @@ import { dismissModal } from '/imports/ui/modals'
 import notify from '/imports/ui/notification'
 import createInlineDateRangePicker from '/imports/ui/inlineDateRangePicker'
 import { updateCalendarSelection } from '/imports/ui/setRange'
-import { diseaseOptionsFn, formatLocation } from '/imports/utils'
+import {
+  diseaseOptionsFn,
+  speciesOptionsFn,
+  formatLocation } from '/imports/utils'
 
 Template.editSmartEventDetailsModal.onCreated ->
   @confirmingDeletion = new ReactiveVar(false)
   @addDate = new ReactiveVar(false)
   @locations = new ReactiveVar([])
+  @species = new ReactiveVar([])
 
 Template.editSmartEventDetailsModal.onRendered ->
   if @data.event?.dateRange
@@ -19,6 +23,9 @@ Template.editSmartEventDetailsModal.onRendered ->
       text: formatLocation(loc)
       item: loc
     )
+
+  if @data.event?.species
+    @species.set(@data.event.species)
 
   @autorun =>
     if @addDate.get()
@@ -64,6 +71,10 @@ Template.editSmartEventDetailsModal.helpers
 
   diseaseOptionsFn: -> diseaseOptionsFn
 
+  speciesOptionsFn: -> speciesOptionsFn
+
+  species: -> Template.instance().species
+
   locations: -> Template.instance().locations
 
 Template.editSmartEventDetailsModal.events
@@ -73,16 +84,19 @@ Template.editSmartEventDetailsModal.events
     event.preventDefault()
 
     diseases = $(form)
-    .find('#disease-select2')
-    .select2('data')
-    .map (option)->
-      id: option.id
-      text: option?.item?.label or option.text
+      .find('#disease-select2')
+      .select2('data')
+      .map (option)->
+        id: option.id
+        text: option?.item?.label or option.text
 
     smartEvent =
       eventName: form.eventName.value.trim()
       summary: form.eventSummary.value.trim()
       diseases: diseases
+      species: instance.species.get().map (option) ->
+        id: option.id
+        text: option.item?.completeName or option.text
 
     if @event?._id
       smartEvent._id = @event?._id

--- a/client/controllers/incidentReports/incidentForm.coffee
+++ b/client/controllers/incidentReports/incidentForm.coffee
@@ -4,7 +4,8 @@ import {
   formatLocation,
   keyboardSelect,
   removeSuggestedProperties,
-  diseaseOptionsFn } from '/imports/utils'
+  diseaseOptionsFn,
+  speciesOptionsFn } from '/imports/utils'
 import { getIncidentSnippet } from '/imports/ui/snippets'
 import notify from '/imports/ui/notification'
 
@@ -156,29 +157,7 @@ Template.incidentForm.helpers
 
   diseaseOptionsFn: -> diseaseOptionsFn
 
-  speciesOptionsFn: ->
-    return (params, callback) ->
-      term = params.term?.trim()
-      if not term
-        return callback(results: [])
-      Meteor.call 'searchSpeciesNames', term, (error, results) ->
-        if error
-          notify('error', error.reason)
-        callback(
-          results: results.map((item) ->
-            text = item.completeName
-            if (new RegExp(term, "i")).test(item.vernacularName)
-              text = item.vernacularName + " | " + item.completeName
-            {
-              id: 'tsn:' + item.tsn
-              text: text
-              item: item
-            }
-          ).concat([
-            id: "userSpecifiedSpecies:#{term}"
-            text: "Other Species: #{term}"
-          ])
-        )
+  speciesOptionsFn: -> speciesOptionsFn
 
   document: ->
     incident = Template.instance().data.incident

--- a/client/views/events/autoEvent/autoEventDetails.jade
+++ b/client/views/events/autoEvent/autoEventDetails.jade
@@ -16,6 +16,12 @@ template(name="autoEventDetails")
           ul
             each event.diseases
               li=text
+      if event.species
+        .criteria
+          h4 Species:
+          ul
+            each event.species
+              li=text
       if event.dateRange
         .criteria
           h4 Date Range:

--- a/client/views/events/eventDetails.jade
+++ b/client/views/events/eventDetails.jade
@@ -24,6 +24,12 @@ template(name="eventDetails")
             ul
               each event.diseases
                 li=text
+        if event.species
+          .criteria
+            h4 Species:
+            ul
+              each event.species
+                li=text
         if event.dateRange
           .criteria
             h4 Date Range:

--- a/client/views/events/eventFiltration.jade
+++ b/client/views/events/eventFiltration.jade
@@ -43,8 +43,8 @@ template(name="eventFiltration")
       each locationLevels
         option(value=prop)=name
 
-    .location-list--wrapper
-      ul.list-unstyled.location-list
+    .option-list--wrapper
+      ul.list-unstyled.option-list.location-list
         each locations
           li
             i.fa(class="fa-{{#if locationSelected}}check-circle{{else}}circle-o{{/if}}")
@@ -53,8 +53,22 @@ template(name="eventFiltration")
           p.emphasized No locations
 
     .actions
-      a.select-all(class="{{#if allLocationsSelected}}disabled{{/if}}") Select All
-      a.deselect-all(class="{{#if noEventsSelected}}disabled{{/if}}") Deselect All
+      a.deselect-all(class="{{#if noLocationsSelected}}disabled{{/if}}") Deselect All
+
+  section.filtration--property.species
+    h3 Species
+
+    .option-list--wrapper
+      ul.list-unstyled.species-list.option-list
+        each speciesList
+          li
+            i.fa(class="fa-{{#if speciesSelected}}check-circle{{else}}circle-o{{/if}}")
+            span=label
+        else
+          p.emphasized No species
+
+    .actions
+      a.deselect-all(class="{{#if noSpeciesSelected}}disabled{{/if}}") Deselect All
 
   section.filtration--property.other-properties
     h3 Other Properties

--- a/client/views/events/smartEvent/editSmartEventDetailsModal.jade
+++ b/client/views/events/smartEvent/editSmartEventDetailsModal.jade
@@ -53,7 +53,14 @@ template(name="editSmartEventDetailsModal")
               .form-group
                 label Summary
                 textarea.form-control(name="eventSummary" rows="15")= event.summary
-
+              .form-group
+                label Species
+                +select2(
+                  name="species"
+                  selectId="species-select2"
+                  multiple=true
+                  optionsFn=speciesOptionsFn
+                  values=species)
           unless confirmingDeletion
             .modal-footer
               .on-left

--- a/imports/schemas/smartEvent.coffee
+++ b/imports/schemas/smartEvent.coffee
@@ -24,6 +24,15 @@ smartEventSchema = new SimpleSchema
   "diseases.$.text":
     type: String
     optional: true
+  species:
+    type: [Object]
+    optional: true
+  "species.$.id":
+    type: String
+    optional: true
+  "species.$.text":
+    type: String
+    optional: true
   lastModifiedByUserId:
     type: String
     optional: true

--- a/imports/stylesheets/events/eventFiltration.import.styl
+++ b/imports/stylesheets/events/eventFiltration.import.styl
@@ -40,24 +40,24 @@
       z-index $cosmos-layer
       border-top 0
 
-  &.locations
-    .actions
-      display flex
-      justify-content flex-end
-      a
-        padding 0 .2em
-        font-size .9em
-        &:first-of-type
-          padding-right .5em
-          border-right 1px solid $border-primary
-        &:last-of-type
-          padding-left .5em
+  .actions
+    display flex
+    justify-content flex-end
+    a
+      padding 0 .2em
+      font-size .9em
+      &:first-of-type
+        padding-right .5em
+      &:nth-of-type(2)
+        border-left 1px solid $border-primary
+      &:last-of-type
+        padding-left .5em
 
-  .location-list--wrapper
+  .option-list--wrapper
     gradientTopAndBottom()
     position relative
 
-  .location-list
+  .option-list
     max-height 25vh
     overflow-x scroll
     padding .75em .5em 1em .5em

--- a/imports/utils.coffee
+++ b/imports/utils.coffee
@@ -136,6 +136,9 @@ export UTCOffsets =
   WGST: '-0200'
   WGT: '-0300'
 
+export capitalize = (s) ->
+  s.charAt(0).toUpperCase() + s.substring(1)
+
 export regexEscape = (s) ->
   # Based on bobince's regex escape function.
   # source: http://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/3561711#3561711

--- a/imports/utils.coffee
+++ b/imports/utils.coffee
@@ -176,6 +176,29 @@ export diseaseOptionsFn = (params, callback) ->
       ])
     )
 
+export speciesOptionsFn = (params, callback) ->
+  term = params.term?.trim()
+  if not term
+    return callback(results: [])
+  Meteor.call 'searchSpeciesNames', term, (error, results) ->
+    if error
+      notify('error', error.reason)
+    callback(
+      results: results.map((item) ->
+        text = item.completeName
+        if (new RegExp(term, "i")).test(item.vernacularName)
+          text = item.vernacularName + " | " + item.completeName
+        {
+          id: 'tsn:' + item.tsn
+          text: text
+          item: item
+        }
+      ).concat([
+        id: "userSpecifiedSpecies:#{term}"
+        text: "Other Species: #{term}"
+      ])
+    )
+
 export incidentTypeWithCountAndDisease = (incident) ->
   text = ''
   cases = incident.cases

--- a/methods/promedPosts.coffee
+++ b/methods/promedPosts.coffee
@@ -4,7 +4,7 @@ if Meteor.isServer
   Feeds = require '/imports/collections/feeds.coffee'
 
   Meteor.methods
-    fetchPromedPosts: (limit, range) ->
+    fetchPromedPosts: (range) ->
       @unblock
       endDate = range?.endDate || new Date()
       startDate = moment(endDate).subtract(2, 'weeks').toDate()

--- a/server/autoprocess.coffee
+++ b/server/autoprocess.coffee
@@ -8,7 +8,11 @@ module.exports = ->
     busyProcessing = true
   count = 0
   batch = Articles.find({
-    enhancements: $exists: false
+    $or: [
+      enhancements: $exists: false
+    ,
+      'enhancements.diagnoserVersion': $lt: '0.4.2'
+    ]
   }, {
     limit: 20
     sort:
@@ -29,6 +33,7 @@ module.exports = ->
     Meteor.call('getArticleEnhancementsAndUpdate', article._id, {
       hideLogs: true
       priority: false
+      reprocess: true
     }, (error)->
       if error
         console.log article

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -6,6 +6,8 @@ import Articles from '/imports/collections/articles.coffee'
 import Feeds from '/imports/collections/feeds.coffee'
 import regionToCountries from '/imports/regionToCountries.json'
 
+INCIDENT_LIMIT = 10000
+
 Meteor.publish 'mapIncidents', (incidentIds) ->
   Incidents.find
     _id: $in: incidentIds
@@ -64,6 +66,7 @@ Meteor.publishComposite 'userEvent', (eventId) ->
         Incidents.find
           _id: $in: incidentIds
           deleted: $in: [null, false]
+        , limit: INCIDENT_LIMIT
     }, {
       collectionName: 'articles'
       find: (event) ->
@@ -118,6 +121,8 @@ eventToIncidentQuery = (event) ->
     return result
   if locationQueries.length > 0
     query['$or'] = locationQueries
+  if event.species and event.species.length > 0
+    query['species.id'] = $in: event.species.map (x) -> x.id
   query
 
 Meteor.publishComposite 'smartEvent', (eventId) ->
@@ -136,7 +141,7 @@ Meteor.publishComposite 'smartEvent', (eventId) ->
     }, {
       collectionName: 'eventIncidents'
       find: (event) ->
-        Incidents.find(eventToIncidentQuery(event))
+        Incidents.find(eventToIncidentQuery(event), limit: INCIDENT_LIMIT)
     }
   ]
 
@@ -147,7 +152,7 @@ Meteor.publishComposite 'autoEvent', (eventId) ->
     {
       collectionName: 'eventIncidents'
       find: (event) ->
-        Incidents.find(eventToIncidentQuery(event))
+        Incidents.find(eventToIncidentQuery(event), limit: INCIDENT_LIMIT)
     }
   ]
 

--- a/server/startup.coffee
+++ b/server/startup.coffee
@@ -50,3 +50,11 @@ Meteor.startup ->
 
   Meteor.setInterval updateAutoEvents, 60 * 60 * 1000
   updateAutoEvents()
+
+  Meteor.setInterval ->
+    # Pull in the latest ProMED posts for processing.
+    Meteor.call('fetchPromedPosts',
+      startDate: moment().subtract(2, 'days').toDate()
+      endDate: new Date()
+    )
+  , 5 * 60 * 60 * 1000


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/story/show/150920423

This also places a limit on the number of incidents that can be published, and removes the "Select All" locations button from the filter panel because the "Deselect All" button has an equivalent effect on the filter.