### PR TITLE
Outlier removal and supplemental incident improvements

### DIFF
--- a/imports/incidentResolution/LocationTree.coffee
+++ b/imports/incidentResolution/LocationTree.coffee
@@ -94,6 +94,13 @@ export default class LocationTree
       result = result.concat(subTree.locations())
     return result
 
+  makeIdToParentMap: (sofar=null) ->
+    result = sofar or {}
+    @children.map (child) =>
+      result = child.makeIdToParentMap(result)
+      result[child.value.id] = @
+    return result
+
   toJSON: (transformationFunction=(x) -> x) ->
     transformationFunction(
       value: @value

--- a/imports/incidentResolution/convertAllIncidentsToDifferentials.coffee
+++ b/imports/incidentResolution/convertAllIncidentsToDifferentials.coffee
@@ -55,6 +55,7 @@ class DifferentialIncident
     # so that a report of cases distributed in 3 states won't result in
     # a count of triple that for the country.
     @rate = @count / @duration / @locations.length
+    @diseaseId = @originalIncidents[0].resolvedDisease.id
     return @
   truncated: (dateRange) ->
     newStartDate = new Date(@startDate)
@@ -78,6 +79,21 @@ class DifferentialIncident
 # created by taking the difference in counts between two subsequent cumulative
 # reports in the same location.
 convertAllIncidentsToDifferentials = (incidents, replaceRegionsWithCountries=true) ->
+  result = []
+  diseases = _.chain(incidents)
+    .map (x) -> x.resolvedDisease.id
+    .uniq()
+    .value()
+  diseases.forEach (disease) ->
+    diseaseMatch = (x) -> x.resolvedDisease.id == disease
+    result = result.concat(
+      convertAllIncidentsToDifferentialsSingleDisease(
+        incidents.filter(diseaseMatch),
+        replaceRegionsWithCountries)
+    )
+  return result
+
+convertAllIncidentsToDifferentialsSingleDisease = (incidents, replaceRegionsWithCountries) ->
   cumulativeIncidents = []
   differentialIncidents = []
   # Replace regions with contained country geonames

--- a/imports/incidentResolution/convertAllIncidentsToDifferentials.coffee
+++ b/imports/incidentResolution/convertAllIncidentsToDifferentials.coffee
@@ -55,7 +55,7 @@ class DifferentialIncident
     # so that a report of cases distributed in 3 states won't result in
     # a count of triple that for the country.
     @rate = @count / @duration / @locations.length
-    @diseaseId = @originalIncidents[0].resolvedDisease.id
+    @diseaseId = @originalIncidents[0].resolvedDisease?.id
     return @
   truncated: (dateRange) ->
     newStartDate = new Date(@startDate)
@@ -81,11 +81,11 @@ class DifferentialIncident
 convertAllIncidentsToDifferentials = (incidents, replaceRegionsWithCountries=true) ->
   result = []
   diseases = _.chain(incidents)
-    .map (x) -> x.resolvedDisease.id
+    .map (x) -> x.resolvedDisease?.id
     .uniq()
     .value()
   diseases.forEach (disease) ->
-    diseaseMatch = (x) -> x.resolvedDisease.id == disease
+    diseaseMatch = (x) -> x.resolvedDisease?.id == disease
     result = result.concat(
       convertAllIncidentsToDifferentialsSingleDisease(
         incidents.filter(diseaseMatch),

--- a/imports/incidentResolution/incidentResolution.coffee
+++ b/imports/incidentResolution/incidentResolution.coffee
@@ -474,7 +474,7 @@ removeOutlierIncidentsSingleType = (incidents, constrainingIncidents) ->
   )
   # Iteratively remove incidents until the constraining incidents are not
   # exceeded by any counts.
-  loop
+  while incidents.length > 0
     outlierIncidentIds = new Set()
     subIntervals = differentialIncidentsToSubIntervals(incidents)
     # Compute CASIM for each sub-interval
@@ -552,7 +552,6 @@ removeOutlierIncidentsSingleType = (incidents, constrainingIncidents) ->
             break
     if excessCounts == 0
       break
-    #console.log "excessCounts:", excessCounts
     incidents = incidents.filter (x) -> not outlierIncidentIds.has(x.id)
   return incidents
 

--- a/imports/incidentResolution/resolver.test.coffee
+++ b/imports/incidentResolution/resolver.test.coffee
@@ -52,10 +52,7 @@ describe 'Incident Resolution', ->
 
   it 'converts incidents to the correct number of differential incident intervals', ->
     differentialIncidents = convertAllIncidentsToDifferentials(incidents)
-    # console.log JSON.stringify(differentialIncidents.map((x) ->
-    #   _.pick(x, "startDate", "endDate", "count", "cumulative")
-    # ), 0, 2)
-    chai.assert.equal(differentialIncidents.length, 286)
+    chai.assert.equal(differentialIncidents.length, 285)
 
   it 'handles outlier cumulative counts', ->
     differentialIncidents = convertAllIncidentsToDifferentials([
@@ -328,6 +325,8 @@ describe 'Incident Resolution', ->
         sofar + x.value
       , 0
     chai.assert.equal(Math.round(total), 30)
+    chai.assert.equal(subIntervals[0].start, Number(new Date("Jan 1 2008 UTC")))
+    chai.assert.equal(subIntervals.slice(-1)[0].end, Number(new Date("Jan 1 2010 UTC")))
 
   it 'can remove statistical outlier incidents', ->
     baseIncidents = [{
@@ -393,3 +392,51 @@ describe 'Incident Resolution', ->
     }]
     result = removeOutlierIncidents(baseIncidents, [])
     chai.assert.equal(result.length, 9)
+
+  it 'can use cumulative incidents to remove outliers', ->
+    baseIncidents = [{
+      cases: 9
+      dateRange:
+        start: new Date("Oct 3 2010 UTC")
+        end: new Date("Dec 10 2010 UTC")
+      locations: [lome]
+    }, {
+      cases: 6
+      dateRange:
+        start: new Date("Nov 3 2010 UTC")
+        end: new Date("Nov 19 2010 UTC")
+      locations: [lome]
+    }, {
+      cases: 1500000
+      dateRange:
+        start: new Date("Jan 3 2010 UTC")
+        end: new Date("Oct 10 2010 UTC")
+      locations: [lome]
+    }, {
+      cases: 11
+      dateRange:
+        start: new Date("Aug 3 2010 UTC")
+        end: new Date("Oct 10 2010 UTC")
+      locations: [lome]
+    }, {
+      cases: 2
+      dateRange:
+        start: new Date("Jan 20 2010 UTC")
+        end: new Date("Apr 10 2010 UTC")
+      locations: [lome]
+    }, {
+      cases: 5
+      dateRange:
+        end: new Date("Jan 1 2009 UTC")
+        cumulative: true
+      locations: [lome]
+    }, {
+      cases: 65
+      dateRange:
+        end: new Date("Jan 1 2011 UTC")
+        cumulative: true
+      locations: [lome]
+    }]
+    result = removeOutlierIncidents(baseIncidents, [])
+    console.log(result)
+    chai.assert.equal(result.length, 6)

--- a/imports/incidentResolution/resolver.test.coffee
+++ b/imports/incidentResolution/resolver.test.coffee
@@ -334,13 +334,13 @@ describe 'Incident Resolution', ->
       dateRange:
         start: new Date("Oct 3 2010 UTC")
         end: new Date("Dec 10 2010 UTC")
-      locations: [lome]
+      locations: [tongo]
     }, {
       cases: 6
       dateRange:
         start: new Date("Nov 3 2010 UTC")
         end: new Date("Nov 19 2010 UTC")
-      locations: [lome]
+      locations: [tongo]
     }, {
       cases: 1500000
       dateRange:
@@ -370,7 +370,7 @@ describe 'Incident Resolution', ->
       dateRange:
         start: new Date("Dec 31 2009 UTC")
         end: new Date("Jan 1 2011 UTC")
-      locations: [lome]
+      locations: [tongo]
     }, {
       cases: 50
       dateRange:
@@ -382,7 +382,7 @@ describe 'Incident Resolution', ->
       dateRange:
         start: new Date("Dec 31 2010 UTC")
         end: new Date("Jan 1 2012 UTC")
-      locations: [lome]
+      locations: [tongo]
     }, {
       cases: 45
       dateRange:

--- a/imports/schemas/geoname.coffee
+++ b/imports/schemas/geoname.coffee
@@ -45,3 +45,25 @@ module.exports = new SimpleSchema
   "population":
     type: Number
     optional: true
+  # TODO: Remove these properties.
+  "asciiName":
+    type: String
+    optional: true
+  "rawNames":
+    type: [String]
+    optional: true
+  "cc2":
+    type: String
+    optional: true
+  "elevation":
+    type: String
+    optional: true
+  "dem":
+    type: String
+    optional: true
+  "timezone":
+    type: String
+    optional: true
+  "modificationDate":
+    type: String
+    optional: true

--- a/server/router.coffee
+++ b/server/router.coffee
@@ -65,7 +65,7 @@ sum = (list) ->
 fs = Npm.require('fs')
 path = Npm.require('path')
 
-ENABLE_PROFILING = false
+ENABLE_PROFILING = process.env.ENABLE_PROFILING or false
 
 Router.configureBodyParsers = ->
   # The resolve-incidents endpoint may have files larger than the default limit
@@ -410,14 +410,18 @@ Router.route("/api/events-with-resolved-data", where: "server")
           constrainingIncidents.push incident
         else
           baseIncidents.push incident
+      console.time('remove outliers') if ENABLE_PROFILING
       incidentsWithoutOutliers = removeOutlierIncidents(
         baseIncidents,
         constrainingIncidents
       )
+      console.timeEnd('remove outliers') if ENABLE_PROFILING
+      console.time('create supplemental incidents') if ENABLE_PROFILING
       supplementalIncidents = createSupplementalIncidents(
         incidentsWithoutOutliers,
         constrainingIncidents
       )
+      console.timeEnd('create supplemental incidents') if ENABLE_PROFILING
       allDifferentials = convertAllIncidentsToDifferentials(
         incidentsWithoutOutliers
       ).concat(supplementalIncidents)

--- a/server/syncStructuredFeeds.coffee
+++ b/server/syncStructuredFeeds.coffee
@@ -14,6 +14,13 @@ module.exports = ->
             q: country
         nameToGeoname[country] = geonamesResult.data.hits[0]._source
         delete nameToGeoname[country].alternateNames
+        delete nameToGeoname[country].rawNames
+        delete nameToGeoname[country].asciiName
+        delete nameToGeoname[country].cc2
+        delete nameToGeoname[country].elevation
+        delete nameToGeoname[country].dem
+        delete nameToGeoname[country].timezone
+        delete nameToGeoname[country].modificationDate
 
   # Import WHO datasets:
   WHODataUrls = [

--- a/server/updateAutoEvents.coffee
+++ b/server/updateAutoEvents.coffee
@@ -17,6 +17,10 @@ module.exports = ->
     incident.species.id == 'tsn:180092'
   myIncidents.forEach (incident) ->
     disease = incident.resolvedDisease
+    if disease.id == 'http://purl.obolibrary.org/obo/DOID_0050117'
+      # Do not create event for disease by infectious agent because it will
+      # contain too many incidents.
+      return
     diseaseGroups[disease.id + ":" + incident.species.id] = {
       resolvedDisease: disease
       species: incident.species


### PR DESCRIPTION
 - When an event has multiple diseases each one is supplemented separately.
 - Supplemental incidents are created for time spans that have no base incidents.
 - Cumulative counts are used as constraining incidents to remove outliers.
 - When there is insufficient data to do statistical outlier removal on a location, data from parent locations is used.